### PR TITLE
 Upgrade Obs API to include rate limiting related changes

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -110,6 +110,7 @@ objects:
           - --tenants.config=/etc/observatorium/tenants.yaml
           - --middleware.rate-limiter.grpc-address=observatorium-gubernator.${NAMESPACE}.svc.cluster.local:8081
           - --internal.tracing.endpoint=localhost:6831
+          - --middleware.concurrent-request-limit=${OBSERVATORIUM_API_PER_POD_CONCURRENT_REQUETST_LIMIT}
           image: ${OBSERVATORIUM_API_IMAGE}:${OBSERVATORIUM_API_IMAGE_TAG}
           livenessProbe:
             failureThreshold: 10
@@ -853,6 +854,8 @@ parameters:
   value: 256Mi
 - name: OBSERVATORIUM_API_REPLICAS
   value: "3"
+- name: OBSERVATORIUM_API_PER_POD_CONCURRENT_REQUETST_LIMIT
+  value: "50"
 - name: OPA_AMS_CPU_LIMIT
   value: 200m
 - name: OPA_AMS_CPU_REQUEST

--- a/services/main.jsonnet
+++ b/services/main.jsonnet
@@ -484,6 +484,8 @@ local observatorium =
         { name: 'OBSERVATORIUM_API_CPU_LIMIT', value: '1' },
         { name: 'OBSERVATORIUM_API_MEMORY_REQUEST', value: '256Mi' },
         { name: 'OBSERVATORIUM_API_MEMORY_LIMIT', value: '1Gi' },
+        { name: 'OBSERVATORIUM_API_IMAGE_TAG', value: 'master-2021-03-29-v0.1.1-201-gd40a037' },
+        { name: 'OBSERVATORIUM_API_PER_POD_CONCURRENT_REQUETST_LIMIT', value: '50' },
         { name: 'AMS_URL', value: '' },
         { name: 'OPA_AMS_IMAGE', value: 'quay.io/observatorium/opa-ams' },
         { name: 'OPA_AMS_IMAGE_TAG', value: 'master-2021-02-17-ed50046' },

--- a/services/observatorium-template.jsonnet
+++ b/services/observatorium-template.jsonnet
@@ -59,6 +59,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'OBSERVATORIUM_API_MEMORY_LIMIT', value: '1Gi' },
     { name: 'OBSERVATORIUM_API_MEMORY_REQUEST', value: '256Mi' },
     { name: 'OBSERVATORIUM_API_REPLICAS', value: '3' },
+    { name: 'OBSERVATORIUM_API_PER_POD_CONCURRENT_REQUETST_LIMIT', value: '50' },
     { name: 'OPA_AMS_CPU_LIMIT', value: '200m' },
     { name: 'OPA_AMS_CPU_REQUEST', value: '100m' },
     { name: 'OPA_AMS_IMAGE_TAG', value: 'master-2021-02-17-ed50046' },


### PR DESCRIPTION
This PR:

- Upgrades Obs API. image to master-2021-03-29-v0.1.1-201-gd40a037
- configure per-pod level limits for Obs. API traffic