### PR TITLE
Fix observatorium repo transition

### DIFF
--- a/docs/observatorium.md
+++ b/docs/observatorium.md
@@ -28,7 +28,7 @@ Observatorium logs implements a logging solution to allow multiple instances of 
 | API | https://github.com/observatorium/api |
 | API OPA-AMS | https://github.com/observatorium/opa-ams |
 | Config | https://github.com/observatorium/configuration |
-| Upstream config | https://github.com/observatorium/deployments |
+| Upstream config | https://github.com/observatorium/observatorium |
 
 
 ## Dependencies

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -58,11 +58,11 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/observatorium/deployments.git",
-          "subdir": ""
+          "remote": "https://github.com/observatorium/observatorium.git",
+          "subdir": "configuration"
         }
       },
-      "version": "master"
+      "version": "main"
     },
     {
       "source": {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -106,23 +106,12 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/observatorium/deployments.git",
-          "subdir": ""
-        }
-      },
-      "version": "d60a4ab46b795cabe99d3ea88df5e3ba68911551",
-      "sum": "zS8CdDvM/JZ7u6IMaLIZnQN3CcdrZqfiZECSPyFe5ho="
-    },
-    {
-      "source": {
-        "git": {
           "remote": "https://github.com/observatorium/observatorium.git",
-          "subdir": "jsonnet/lib"
+          "subdir": "configuration"
         }
       },
-      "version": "0164651421f2d1b77db703bbeea501cb5b7a10cc",
-      "sum": "Z86CgnoTybhpdQKWc2ptURmps1d9Qxhec0/IK6v71kY=",
-      "name": "observatorium"
+      "version": "0c524f875198cb46ed5596e4b6af3203c4b144d9",
+      "sum": "IJiVLQdaFs+UsJxbW0+DmID9ZqbCxoPaIDeFpSDEZJ8="
     },
     {
       "source": {

--- a/observability/config.libsonnet
+++ b/observability/config.libsonnet
@@ -1,5 +1,5 @@
 local utils = (import 'github.com/grafana/jsonnet-libs/mixin-utils/utils.libsonnet');
-local thanos = (import '../services/observatorium.libsonnet').thanos;
+local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
 
 {
   thanos: (import 'github.com/thanos-io/thanos/mixin/config.libsonnet') {

--- a/services/components/loki-caches.libsonnet
+++ b/services/components/loki-caches.libsonnet
@@ -1,4 +1,4 @@
-local memcached = (import 'github.com/observatorium/deployments/components/memcached.libsonnet');
+local memcached = (import 'github.com/observatorium/observatorium/configuration/components/memcached.libsonnet');
 
 // These are the defaults for this components configuration.
 // When calling the function to generate the component's manifest,

--- a/services/main.jsonnet
+++ b/services/main.jsonnet
@@ -1,10 +1,10 @@
 // TODO(kakkoyun): Remove after CI/CD job migration.
 local api = (import 'github.com/observatorium/api/jsonnet/lib/observatorium-api.libsonnet');
 local up = (import 'github.com/observatorium/up/jsonnet/up.libsonnet');
-local gubernator = (import 'github.com/observatorium/deployments/components/gubernator.libsonnet');
+local gubernator = (import 'github.com/observatorium/observatorium/configuration/components/gubernator.libsonnet');
 
 local observatorium =
-  (import 'github.com/observatorium/deployments/components/observatorium.libsonnet') +
+  (import 'github.com/observatorium/observatorium/configuration/components/observatorium.libsonnet') +
   (import 'observatorium-metrics.libsonnet') +
   (import 'observatorium-metrics-template-overwrites.libsonnet') +
   (import 'observatorium-logs.libsonnet') +

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -1,4 +1,4 @@
-local loki = (import 'github.com/observatorium/deployments/components/loki.libsonnet');
+local loki = (import 'github.com/observatorium/observatorium/configuration/components/loki.libsonnet');
 local lokiCaches = (import 'components/loki-caches.libsonnet');
 
 {

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -1,6 +1,6 @@
 local t = (import 'github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/thanos.libsonnet');
 local trc = (import 'github.com/observatorium/thanos-receive-controller/jsonnet/lib/thanos-receive-controller.libsonnet');
-local memcached = (import 'github.com/observatorium/deployments/components/memcached.libsonnet');
+local memcached = (import 'github.com/observatorium/observatorium/configuration/components/memcached.libsonnet');
 local telemeterRules = (import 'github.com/openshift/telemeter/jsonnet/telemeter/rules.libsonnet');
 
 {
@@ -416,7 +416,7 @@ local telemeterRules = (import 'github.com/openshift/telemeter/jsonnet/telemeter
       replicas: 1,  // overwritten in observatorium-metrics-template.libsonnet
       replicationFactor: 3,
       retention: '4d',
-      replicaLabels: thanos.config.replicaLabels,
+      replicaLabels: thanosSharedConfig.replicaLabels,
       debug: '${THANOS_RECEIVE_DEBUG_ENV}',
       resources: {
         requests: {

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -1,9 +1,9 @@
 local api = (import 'github.com/observatorium/api/jsonnet/lib/observatorium-api.libsonnet');
 local up = (import 'github.com/observatorium/up/jsonnet/up.libsonnet');
-local gubernator = (import 'github.com/observatorium/deployments/components/gubernator.libsonnet');
-local memcached = (import 'github.com/observatorium/deployments/components/memcached.libsonnet');
+local gubernator = (import 'github.com/observatorium/observatorium/configuration/components/gubernator.libsonnet');
+local memcached = (import 'github.com/observatorium/observatorium/configuration/components/memcached.libsonnet');
 
-(import 'github.com/observatorium/deployments/components/observatorium.libsonnet') +
+(import 'github.com/observatorium/observatorium/configuration/components/observatorium.libsonnet') +
 (import 'observatorium-metrics.libsonnet') +
 (import 'observatorium-metrics-template-overwrites.libsonnet') +
 (import 'observatorium-logs.libsonnet') +


### PR DESCRIPTION
The following PR provides missing fixes to build the manifests and observability resources post upstream repo transition from `observatorium/deployments` to `observatorium/observatorium`, i.e.:
1. Replace reference in `jsonnetfile.json` from `observatorium/deployments` to `observatorium/observatorium` and branch `master` to `main`.
2. Replace import references from `observatorium/deployments` to `observatorium/observatorium/configuration`
3. Minor fixes in `observatorium-metrics.libsonnet` when referenced from `observability/config.jsonnet`