### PR TITLE
Add loki tenant alert to notify on rate limiting events

### DIFF
--- a/docs/sop/observatorium.md
+++ b/docs/sop/observatorium.md
@@ -8,6 +8,7 @@
     - [LokiRequestErrors](#lokirequesterrors)
     - [LokiRequestPanics](#lokirequestpanics)
     - [LokiRequestLatency](#lokirequestlatency)
+    - [LokiTenantRateLimitWarning](#lokitenantratelimitwarning)
     - [ObservatoriumAPILogsErrorsSLOBudgetBurn](#observatoriumapilogserrorsslobudgetburn)
 - Observatorium Metrics
     - [ThanosCompactMultipleRunning](#thanoscompactmultiplerunning)
@@ -165,6 +166,25 @@ Loki components are slower than expected to conduct queries or process ingested 
 - Inspect the metrics for the api [dashboards](https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/api?orgId=1&refresh=1m)
 - Inspect the metrics for the Loki query-frontend/querier
 - Inspect the metrics for the Loki distributor/ingester
+
+## LokiTenantRateLimitWarning
+
+### Impact
+
+For users this means the service as applying back-pressure on the log ingestion clients by returning 429 status codes.
+
+### Summary
+
+Loki components are behaving normal and as expected.
+
+### Severity
+
+`medium`
+
+### Steps
+
+- Inspect the tenant ID for the ingester [limits](https://grafana.app-sre.devshift.net/d/f6fe30815b172c9da7e813c15ddfe607/loki-operational?orgId=1&refresh=30s&var-logs=&var-metrics=telemeter-prod-01-prometheus&var-namespace=observatorium-logs-production&from=now-1h&to=now) panel.
+- Contact the tenant administrator to adapt the client configuration.
 
 ## ObservatoriumAPILogsErrorsSLOBudgetBurn
 

--- a/observability/observatorium-logs/loki-tenant-alerts.libsonnet
+++ b/observability/observatorium-logs/loki-tenant-alerts.libsonnet
@@ -1,0 +1,27 @@
+function(namespace) {
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'loki_tenant_alerts',
+        rules: [
+          {
+            alert: 'LokiTenantRateLimitWarning',
+            expr: |||
+              sum by (tenant, reason) (sum_over_time(rate(loki_discarded_samples_total{namespace="%s"}[1m])[30m:1m]))
+              > 100
+            ||| % namespace,
+            'for': '15m',
+            labels: {
+              severity: 'medium',
+            },
+            annotations: {
+              message: |||
+                {{ $labels.tenant }} is experiencing rate limiting for reason '{{ $labels.reason }}': {{ printf "%.2f" $value }}%.
+              |||,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -1,5 +1,6 @@
 local loki = (import 'github.com/grafana/loki/production/loki-mixin/mixin.libsonnet');
 local slo = import 'github.com/metalmatze/slo-libsonnet/slo-libsonnet/slo.libsonnet';
+local lokiTenants = import './observatorium-logs/loki-tenant-alerts.libsonnet';
 local obs = import '../services/observatorium.libsonnet';
 
 local config = (import 'config.libsonnet') {
@@ -462,8 +463,13 @@ local renderAlerts(name, environment, mixin) = {
 {
   'observatorium-logs-recording-rules.prometheusrules': renderRules('observatorium-logs-recording-rules', loki),
 
-  'observatorium-logs-stage.prometheusrules': renderAlerts('observatorium-logs-stage', 'stage', loki),
-  'observatorium-logs-production.prometheusrules': renderAlerts('observatorium-logs-production', 'production', loki),
+  local obsLogsStageEnv = 'observatorium-logs-stage',
+  local obsLogsStage = loki + lokiTenants(obsLogsStageEnv),
+  'observatorium-logs-stage.prometheusrules': renderAlerts(obsLogsStageEnv, 'stage', obsLogsStage),
+
+  local obsLogsProdEnv = 'observatorium-logs-production',
+  local obsLogsProd = loki + lokiTenants(obsLogsStageEnv),
+  'observatorium-logs-production.prometheusrules': renderAlerts(obsLogsProdEnv, 'production', obsLogsProd),
 }
 
 {

--- a/resources/observability/prometheusrules/observatorium-logs-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-logs-production.prometheusrules.yaml
@@ -49,3 +49,18 @@ spec:
       labels:
         service: obervatorium-logs
         severity: info
+  - name: loki_tenant_alerts
+    rules:
+    - alert: LokiTenantRateLimitWarning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/loki_tenant_alerts?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: |
+          {{ $labels.tenant }} is experiencing rate limiting for reason '{{ $labels.reason }}': {{ printf "%.2f" $value }}%.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#lokitenantratelimitwarning
+      expr: |
+        sum by (tenant, reason) (sum_over_time(rate(loki_discarded_samples_total{namespace="observatorium-logs-stage"}[1m])[30m:1m]))
+        > 100
+      for: 15m
+      labels:
+        service: obervatorium-logs
+        severity: info

--- a/resources/observability/prometheusrules/observatorium-logs-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-logs-stage.prometheusrules.yaml
@@ -49,3 +49,18 @@ spec:
       labels:
         service: obervatorium-logs
         severity: info
+  - name: loki_tenant_alerts
+    rules:
+    - alert: LokiTenantRateLimitWarning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/loki_tenant_alerts?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: |
+          {{ $labels.tenant }} is experiencing rate limiting for reason '{{ $labels.reason }}': {{ printf "%.2f" $value }}%.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#lokitenantratelimitwarning
+      expr: |
+        sum by (tenant, reason) (sum_over_time(rate(loki_discarded_samples_total{namespace="observatorium-logs-stage"}[1m])[30m:1m]))
+        > 100
+      for: 15m
+      labels:
+        service: obervatorium-logs
+        severity: info


### PR DESCRIPTION
This PR adds another non-oncall-paging alert for Loki when tenants exceed their pre-configured limits. The tenet is to address rate limiting events pro-actively and inform tenants about possible client misconfiguration.