### PR TITLE
Fix prometheus rules annotations

### DIFF
--- a/observability/observatorium-logs/loki-tenant-alerts.libsonnet
+++ b/observability/observatorium-logs/loki-tenant-alerts.libsonnet
@@ -7,7 +7,7 @@ function(namespace) {
           {
             alert: 'LokiTenantRateLimitWarning',
             expr: |||
-              sum by (tenant, reason) (sum_over_time(rate(loki_discarded_samples_total{namespace="%s"}[1m])[30m:1m]))
+              sum by (namespace, tenant, reason) (sum_over_time(rate(loki_discarded_samples_total{namespace="%s"}[1m])[30m:1m]))
               > 100
             ||| % namespace,
             'for': '15m',
@@ -16,7 +16,7 @@ function(namespace) {
             },
             annotations: {
               message: |||
-                {{ $labels.tenant }} is experiencing rate limiting for reason '{{ $labels.reason }}': {{ printf "%.2f" $value }}%.
+                {{ $labels.tenant }} is experiencing rate limiting for reason '{{ $labels.reason }}': {{ printf "%.0f" $value }}
               |||,
             },
           },

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -76,6 +76,8 @@ local appSREOverwrites(environment) = {
       else if
         std.startsWith(name, 'telemeter') then 'Tg-mH0rizaSJDKSADJ'
       else if
+        std.startsWith(name, 'loki_tenant') then 'f6fe30815b172c9da7e813c15ddfe607'
+      else if
         std.startsWith(name, 'loki') then 'Lg-mH0rizaSJDKSADX'
       else if
         std.startsWith(name, 'gubernator') then 'no-dashboard'
@@ -102,7 +104,7 @@ local appSREOverwrites(environment) = {
   local setServiceLabel = function(alertName) {
     label:
       if std.length(std.findSubstr('Logs', alertName)) > 0 || std.length(std.findSubstr('Loki', alertName)) > 0
-      then 'obervatorium-logs'
+      then 'observatorium-logs'
       else 'telemeter',
   },
 
@@ -126,7 +128,7 @@ local appSREOverwrites(environment) = {
               if std.length(std.findSubstr('Logs', r.alert)) > 0 then
                 {
                   runbook: 'https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#%s' % std.asciiLower(r.alert),
-                  dashboard: 'https://grafana.app-sre.devshift.net/d/%s/api-logs?orgId=1&refresh=1m&var-datasource=%s' % [
+                  dashboard: 'https://grafana.app-sre.devshift.net/d/%s/api-logs?orgId=1&refresh=1m&var-datasource=%s&var-namespace={{$labels.namespace}}' % [
                     dashboardID('loki').id,
                     dashboardDatasource(environment).datasource,
                   ],
@@ -136,6 +138,15 @@ local appSREOverwrites(environment) = {
                   runbook: 'https://github.com/rhobs/configuration/blob/main/docs/sop/telemeter.md#%s' % std.asciiLower(r.alert),
                   dashboard: 'https://grafana.app-sre.devshift.net/d/%s/telemeter?orgId=1&refresh=1m&var-datasource=%s' % [
                     dashboardID(g.name).id,
+                    dashboardDatasource(environment).datasource,
+                  ],
+                }
+              else if std.startsWith(g.name, 'loki_tenant') then
+                {
+                  runbook: 'https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#%s' % std.asciiLower(r.alert),
+                  dashboard: 'https://grafana.app-sre.devshift.net/d/%s/%s?orgId=1&refresh=10s&var-metrics=%s&var-namespace={{$labels.namespace}}' % [
+                    dashboardID(g.name).id,
+                    g.name,
                     dashboardDatasource(environment).datasource,
                   ],
                 }
@@ -468,7 +479,7 @@ local renderAlerts(name, environment, mixin) = {
   'observatorium-logs-stage.prometheusrules': renderAlerts(obsLogsStageEnv, 'stage', obsLogsStage),
 
   local obsLogsProdEnv = 'observatorium-logs-production',
-  local obsLogsProd = loki + lokiTenants(obsLogsStageEnv),
+  local obsLogsProd = loki + lokiTenants(obsLogsProdEnv),
   'observatorium-logs-production.prometheusrules': renderAlerts(obsLogsProdEnv, 'production', obsLogsProd),
 }
 

--- a/resources/observability/prometheusrules/observatorium-api-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-api-production.prometheusrules.yaml
@@ -423,7 +423,7 @@ spec:
       record: http_requests_total:burnrate6h
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=push,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -434,11 +434,11 @@ spec:
       labels:
         handler: push
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: critical
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=push,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -449,11 +449,11 @@ spec:
       labels:
         handler: push
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: critical
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=push,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -464,11 +464,11 @@ spec:
       labels:
         handler: push
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=push,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -479,7 +479,7 @@ spec:
       labels:
         handler: push
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
   - name: observatorium-api-query-logs-errors.slo
     rules:
@@ -541,7 +541,7 @@ spec:
       record: http_requests_total:burnrate6h
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=~query|label|labels|label_values,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -552,11 +552,11 @@ spec:
       labels:
         handler: query|label|labels|label_values
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: critical
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=~query|label|labels|label_values,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -567,11 +567,11 @@ spec:
       labels:
         handler: query|label|labels|label_values
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: critical
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=~query|label|labels|label_values,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -582,11 +582,11 @@ spec:
       labels:
         handler: query|label|labels|label_values
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=~query|label|labels|label_values,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -597,7 +597,7 @@ spec:
       labels:
         handler: query|label|labels|label_values
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
   - name: observatorium-api-query-range-logs-errors.slo
     rules:
@@ -659,7 +659,7 @@ spec:
       record: http_requests_total:burnrate6h
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=query_range,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -670,11 +670,11 @@ spec:
       labels:
         handler: query_range
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: critical
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=query_range,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -685,11 +685,11 @@ spec:
       labels:
         handler: query_range
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: critical
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=query_range,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -700,11 +700,11 @@ spec:
       labels:
         handler: query_range
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=query_range,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -715,7 +715,7 @@ spec:
       labels:
         handler: query_range
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
   - name: observatorium-api-tail-logs-errors.slo
     rules:
@@ -777,7 +777,7 @@ spec:
       record: http_requests_total:burnrate6h
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=tail|prom_tail,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -788,11 +788,11 @@ spec:
       labels:
         handler: tail|prom_tail
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: critical
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=tail|prom_tail,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -803,11 +803,11 @@ spec:
       labels:
         handler: tail|prom_tail
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: critical
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=tail|prom_tail,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -818,11 +818,11 @@ spec:
       labels:
         handler: tail|prom_tail
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=tail|prom_tail,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -833,5 +833,5 @@ spec:
       labels:
         handler: tail|prom_tail
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium

--- a/resources/observability/prometheusrules/observatorium-api-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-api-stage.prometheusrules.yaml
@@ -423,7 +423,7 @@ spec:
       record: http_requests_total:burnrate6h
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=push,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -434,11 +434,11 @@ spec:
       labels:
         handler: push
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: high
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=push,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -449,11 +449,11 @@ spec:
       labels:
         handler: push
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: high
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=push,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -464,11 +464,11 @@ spec:
       labels:
         handler: push
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=push,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -479,7 +479,7 @@ spec:
       labels:
         handler: push
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
   - name: observatorium-api-query-logs-errors.slo
     rules:
@@ -541,7 +541,7 @@ spec:
       record: http_requests_total:burnrate6h
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=~query|label|labels|label_values,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -552,11 +552,11 @@ spec:
       labels:
         handler: query|label|labels|label_values
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: high
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=~query|label|labels|label_values,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -567,11 +567,11 @@ spec:
       labels:
         handler: query|label|labels|label_values
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: high
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=~query|label|labels|label_values,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -582,11 +582,11 @@ spec:
       labels:
         handler: query|label|labels|label_values
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=~query|label|labels|label_values,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -597,7 +597,7 @@ spec:
       labels:
         handler: query|label|labels|label_values
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
   - name: observatorium-api-query-range-logs-errors.slo
     rules:
@@ -659,7 +659,7 @@ spec:
       record: http_requests_total:burnrate6h
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=query_range,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -670,11 +670,11 @@ spec:
       labels:
         handler: query_range
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: high
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=query_range,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -685,11 +685,11 @@ spec:
       labels:
         handler: query_range
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: high
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=query_range,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -700,11 +700,11 @@ spec:
       labels:
         handler: query_range
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=query_range,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -715,7 +715,7 @@ spec:
       labels:
         handler: query_range
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
   - name: observatorium-api-tail-logs-errors.slo
     rules:
@@ -777,7 +777,7 @@ spec:
       record: http_requests_total:burnrate6h
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=tail|prom_tail,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -788,11 +788,11 @@ spec:
       labels:
         handler: tail|prom_tail
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: high
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=tail|prom_tail,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -803,11 +803,11 @@ spec:
       labels:
         handler: tail|prom_tail
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: high
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=tail|prom_tail,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -818,11 +818,11 @@ spec:
       labels:
         handler: tail|prom_tail
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium
     - alert: ObservatoriumAPILogsErrorsSLOBudgetBurn
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus
+        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/api-logs?orgId=1&refresh=1m&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: 'High error budget burn for group=logsv1,handler=tail|prom_tail,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapilogserrorsslobudgetburn
       expr: |
@@ -833,5 +833,5 @@ spec:
       labels:
         handler: tail|prom_tail
         job: observatorium-observatorium-api
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: medium

--- a/resources/observability/prometheusrules/observatorium-logs-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-logs-production.prometheusrules.yaml
@@ -24,7 +24,7 @@ spec:
           > 10
       for: 15m
       labels:
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: info
     - alert: LokiRequestPanics
       annotations:
@@ -35,7 +35,7 @@ spec:
       expr: |
         sum(increase(loki_panic_total[10m])) by (namespace, job) > 0
       labels:
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: info
     - alert: LokiRequestLatency
       annotations:
@@ -47,20 +47,20 @@ spec:
         namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*"} > 1
       for: 15m
       labels:
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: info
   - name: loki_tenant_alerts
     rules:
     - alert: LokiTenantRateLimitWarning
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/loki_tenant_alerts?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        dashboard: https://grafana.app-sre.devshift.net/d/f6fe30815b172c9da7e813c15ddfe607/loki_tenant_alerts?orgId=1&refresh=10s&var-metrics=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}
         message: |
-          {{ $labels.tenant }} is experiencing rate limiting for reason '{{ $labels.reason }}': {{ printf "%.2f" $value }}%.
+          {{ $labels.tenant }} is experiencing rate limiting for reason '{{ $labels.reason }}': {{ printf "%.0f" $value }}
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#lokitenantratelimitwarning
       expr: |
-        sum by (tenant, reason) (sum_over_time(rate(loki_discarded_samples_total{namespace="observatorium-logs-stage"}[1m])[30m:1m]))
+        sum by (namespace, tenant, reason) (sum_over_time(rate(loki_discarded_samples_total{namespace="observatorium-logs-production"}[1m])[30m:1m]))
         > 100
       for: 15m
       labels:
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: info

--- a/resources/observability/prometheusrules/observatorium-logs-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-logs-stage.prometheusrules.yaml
@@ -24,7 +24,7 @@ spec:
           > 10
       for: 15m
       labels:
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: info
     - alert: LokiRequestPanics
       annotations:
@@ -35,7 +35,7 @@ spec:
       expr: |
         sum(increase(loki_panic_total[10m])) by (namespace, job) > 0
       labels:
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: info
     - alert: LokiRequestLatency
       annotations:
@@ -47,20 +47,20 @@ spec:
         namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*"} > 1
       for: 15m
       labels:
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: info
   - name: loki_tenant_alerts
     rules:
     - alert: LokiTenantRateLimitWarning
       annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/Lg-mH0rizaSJDKSADX/loki_tenant_alerts?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        dashboard: https://grafana.app-sre.devshift.net/d/f6fe30815b172c9da7e813c15ddfe607/loki_tenant_alerts?orgId=1&refresh=10s&var-metrics=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}
         message: |
-          {{ $labels.tenant }} is experiencing rate limiting for reason '{{ $labels.reason }}': {{ printf "%.2f" $value }}%.
+          {{ $labels.tenant }} is experiencing rate limiting for reason '{{ $labels.reason }}': {{ printf "%.0f" $value }}
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#lokitenantratelimitwarning
       expr: |
-        sum by (tenant, reason) (sum_over_time(rate(loki_discarded_samples_total{namespace="observatorium-logs-stage"}[1m])[30m:1m]))
+        sum by (namespace, tenant, reason) (sum_over_time(rate(loki_discarded_samples_total{namespace="observatorium-logs-stage"}[1m])[30m:1m]))
         > 100
       for: 15m
       labels:
-        service: obervatorium-logs
+        service: observatorium-logs
         severity: info


### PR DESCRIPTION
The following change set provides minor fixes for our prometheus rules' annotations:
- Dashboard links get a proper value for `var-namespace` based on alert group and environment.
- Add missing dashboard ID for loki tenant alerts
- Fix namespace selector for loki tenant alerts