### PR TITLE
Bump loki image tag 2.1.0 to 2.2.1

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -1499,7 +1499,7 @@ parameters:
 - name: STORAGE_CLASS
   value: gp2
 - name: LOKI_IMAGE_TAG
-  value: 2.1.0
+  value: 2.2.1
 - name: LOKI_IMAGE
   value: docker.io/grafana/loki
 - name: LOKI_S3_SECRET

--- a/services/observatorium-logs-template.jsonnet
+++ b/services/observatorium-logs-template.jsonnet
@@ -23,7 +23,7 @@ local obs = import 'observatorium.libsonnet';
   parameters: [
     { name: 'NAMESPACE', value: 'observatorium-logs' },
     { name: 'STORAGE_CLASS', value: 'gp2' },
-    { name: 'LOKI_IMAGE_TAG', value: '2.1.0' },
+    { name: 'LOKI_IMAGE_TAG', value: '2.2.1' },
     { name: 'LOKI_IMAGE', value: 'docker.io/grafana/loki' },
     { name: 'LOKI_S3_SECRET', value: 'observatorium-logs-stage-s3' },
     { name: 'LOKI_COMPACTOR_CPU_REQUESTS', value: '500m' },


### PR DESCRIPTION
Bumping the image tag for OSS folks who want to use our configuration out of the box. Since we use 2.2.1 in production we should stay aligned here, too