### PR TITLE
[observatorium-logs] Provide minor template fixes for OSS users

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -1593,7 +1593,7 @@ parameters:
 - name: JAEGER_AGENT_IMAGE
   value: jaegertracing/jaeger-agent
 - name: JAEGER_AGENT_IMAGE_TAG
-  value: 1.14.0
+  value: 1.22.0
 - name: JAEGER_PROXY_CPU_REQUEST
   value: 100m
 - name: JAEGER_PROXY_MEMORY_REQUEST
@@ -1626,3 +1626,5 @@ parameters:
   value: 50Mi
 - name: MEMCACHED_EXPORTER_MEMORY_LIMIT
   value: 200Mi
+- name: SERVICE_ACCOUNT_NAME
+  value: default

--- a/services/observatorium-logs-template.jsonnet
+++ b/services/observatorium-logs-template.jsonnet
@@ -80,7 +80,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'LOKI_PVC_REQUEST', value: '50Gi' },
     { name: 'JAEGER_COLLECTOR_NAMESPACE', value: 'observatorium' },
     { name: 'JAEGER_AGENT_IMAGE', value: 'jaegertracing/jaeger-agent' },
-    { name: 'JAEGER_AGENT_IMAGE_TAG', value: '1.14.0' },
+    { name: 'JAEGER_AGENT_IMAGE_TAG', value: '1.22.0' },
     { name: 'JAEGER_PROXY_CPU_REQUEST', value: '100m' },
     { name: 'JAEGER_PROXY_MEMORY_REQUEST', value: '100Mi' },
     { name: 'JAEGER_PROXY_CPU_LIMITS', value: '200m' },
@@ -97,5 +97,6 @@ local obs = import 'observatorium.libsonnet';
     { name: 'MEMCACHED_EXPORTER_CPU_LIMIT', value: '200m' },
     { name: 'MEMCACHED_EXPORTER_MEMORY_REQUEST', value: '50Mi' },
     { name: 'MEMCACHED_EXPORTER_MEMORY_LIMIT', value: '200Mi' },
+    { name: 'SERVICE_ACCOUNT_NAME', value: 'default' },
   ],
 }


### PR DESCRIPTION
Provides some minor fixes for OSS users of the `obsevatorium-logs-template.yaml`:
1. Use jaeger image tag `1.22` to fix `Error: unknown flag: --agent.tags`
2. Use `default` as `SERVICE_ACCOUNT_NAME` to fix `oc process -f obsevatorium-logs-template.yaml | oc apply -f` usage.