### PR TITLE
Customize disabling down sampling for Thanos Compact component

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -121,9 +121,9 @@ objects:
           - --retention.resolution-5m=${THANOS_COMPACTOR_RETENTION_RESOULTION_FIVE_MINUTES}
           - --retention.resolution-1h=${THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR}
           - --delete-delay=48h
-          - --downsampling.disable
           - --deduplication.replica-label=replica
           - --debug.max-compaction-level=3
+          - --downsampling.disable=${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -2620,6 +2620,8 @@ parameters:
   value: 1s
 - name: THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR
   value: 1s
+- name: THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING
+  value: false
 - name: THANOS_COMPACTOR_MEMORY_LIMIT
   value: 5Gi
 - name: THANOS_COMPACTOR_MEMORY_REQUEST

--- a/services/main.jsonnet
+++ b/services/main.jsonnet
@@ -418,6 +418,7 @@ local observatorium =
         { name: 'THANOS_COMPACTOR_RETENTION_RESOULTION_RAW', value: '14d' },
         { name: 'THANOS_COMPACTOR_RETENTION_RESOULTION_FIVE_MINUTES', value: '1s' },
         { name: 'THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR', value: '1s' },
+        { name: 'THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING', value: false },
         { name: 'THANOS_COMPACTOR_REPLICAS', value: '1' },
         { name: 'THANOS_RECEIVE_REPLICAS', value: '5' },
         { name: 'THANOS_CONFIG_SECRET', value: 'thanos-objectstorage' },

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -82,8 +82,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
                   // Temporary workaround on high cardinality blocks for 2w.
                   // Since we have only 2w retention, there is no point in having 2w blocks.
                   // See: https://issues.redhat.com/browse/OBS-437
-                  args+: ['--debug.max-compaction-level=3'] +
-                         if disableDownsamplingFlag != null then disableDownsamplingFlag,
+                  args+: ['--debug.max-compaction-level=3'] + disableDownsamplingFlag,
                 } else c
                 for c in super.containers
               ],

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -78,7 +78,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
                   // Temporary workaround on high cardinality blocks for 2w.
                   // Since we have only 2w retention, there is no point in having 2w blocks.
                   // See: https://issues.redhat.com/browse/OBS-437
-                  args+: ['--debug.max-compaction-level=3'],
+                  args+: ['--debug.max-compaction-level=3', '--downsampling.disable=${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}'],
                 } else c
                 for c in super.containers
               ],

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -69,6 +69,10 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       statefulSet+: {
         spec+: {
           replicas: '${{THANOS_COMPACTOR_REPLICAS}}',
+          local disableDownsamplingFlag = if compact.config.disableDownsampling then
+            ['--debug.max-compaction-level=3']
+          else
+            ['--debug.max-compaction-level=3', '--downsampling.disable=${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}'],
           template+: {
             spec+: {
               containers: [
@@ -78,7 +82,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
                   // Temporary workaround on high cardinality blocks for 2w.
                   // Since we have only 2w retention, there is no point in having 2w blocks.
                   // See: https://issues.redhat.com/browse/OBS-437
-                  args+: ['--debug.max-compaction-level=3', '--downsampling.disable=${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}'],
+                  args+: disableDownsamplingFlag,
                 } else c
                 for c in super.containers
               ],

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -69,13 +69,10 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       statefulSet+: {
         spec+: {
           replicas: '${{THANOS_COMPACTOR_REPLICAS}}',
-          local debugArgs = ['--debug.max-compaction-level=3'],
           local disableDownsamplingFlag =
             if !compact.config.disableDownsampling then
               ['--downsampling.disable=${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}']
-            else
-              [''],
-          local compactArgs = debugArgs + disableDownsamplingFlag,
+            else [],
           template+: {
             spec+: {
               containers: [
@@ -85,7 +82,8 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
                   // Temporary workaround on high cardinality blocks for 2w.
                   // Since we have only 2w retention, there is no point in having 2w blocks.
                   // See: https://issues.redhat.com/browse/OBS-437
-                  args+: compactArgs,
+                  args+: ['--debug.max-compaction-level=3'] +
+                         if disableDownsamplingFlag != null then disableDownsamplingFlag,
                 } else c
                 for c in super.containers
               ],

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -69,10 +69,13 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       statefulSet+: {
         spec+: {
           replicas: '${{THANOS_COMPACTOR_REPLICAS}}',
-          local disableDownsamplingFlag = if compact.config.disableDownsampling then
-            ['--debug.max-compaction-level=3']
-          else
-            ['--debug.max-compaction-level=3', '--downsampling.disable=${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}'],
+          local debugArgs = ['--debug.max-compaction-level=3'],
+          local disableDownsamplingFlag =
+            if !compact.config.disableDownsampling then
+              ['--downsampling.disable=${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}']
+            else
+              [''],
+          local compactArgs = debugArgs + disableDownsamplingFlag,
           template+: {
             spec+: {
               containers: [
@@ -82,7 +85,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
                   // Temporary workaround on high cardinality blocks for 2w.
                   // Since we have only 2w retention, there is no point in having 2w blocks.
                   // See: https://issues.redhat.com/browse/OBS-437
-                  args+: disableDownsamplingFlag,
+                  args+: compactArgs,
                 } else c
                 for c in super.containers
               ],

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -43,6 +43,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_COMPACTOR_RETENTION_RESOULTION_RAW', value: '14d' },
     { name: 'THANOS_COMPACTOR_RETENTION_RESOULTION_FIVE_MINUTES', value: '1s' },
     { name: 'THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR', value: '1s' },
+    { name: 'THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING', value: false },
     { name: 'THANOS_COMPACTOR_MEMORY_LIMIT', value: '5Gi' },
     { name: 'THANOS_COMPACTOR_MEMORY_REQUEST', value: '1Gi' },
     { name: 'THANOS_COMPACTOR_PVC_REQUEST', value: '50Gi' },

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -37,7 +37,6 @@ local telemeterRules = (import 'github.com/openshift/telemeter/jsonnet/telemeter
       retentionResolutionRaw: '${THANOS_COMPACTOR_RETENTION_RESOULTION_RAW}',
       retentionResolution5m: '${THANOS_COMPACTOR_RETENTION_RESOULTION_FIVE_MINUTES}',
       retentionResolution1h: '${THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR}',
-      disableDownsampling: true,
       deduplicationReplicaLabels: ['replica'],
       resources: {
         limits: {


### PR DESCRIPTION
Customize disabling down sampling for Thanos Compact component. 
AFAIK as applying conditional logic at OpenShift templates is not possible, this PR directly applies the cmd line argument '--downsampling.disable' at Thanos Compact and bypass (not use) the corresponding JSonnet variable 'disableDownsampling' at Kube-Thanos.