### PR TITLE
services: add configmap-reloader image to template

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2740,3 +2740,7 @@ parameters:
   value: 1Gi
 - name: THANOS_STORE_REPLICAS
   value: "5"
+- name: CONFIGMAP_RELOADER_IMAGE
+  value: quay.io/openshift/origin-configmap-reloader
+- name: CONFIGMAP_RELOADER_IMAGE_TAG
+  value: 4.5.0

--- a/services/main.jsonnet
+++ b/services/main.jsonnet
@@ -535,8 +535,6 @@ local observatorium =
         { name: 'PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET', value: 'observatorium-thanos-receive' },
         { name: 'TELEMETER_SERVER_TOKEN_EXPIRE_SECONDS', value: '3600' },
         { name: 'TELEMETER_LOG_LEVEL', value: 'warn' },
-        { name: 'CONFIGMAP_RELOADER_IMAGE', value: 'quay.io/openshift/origin-configmap-reloader' },
-        { name: 'CONFIGMAP_RELOADER_IMAGE_TAG', value: '4.5.0' },
       ],
     },
 

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -103,5 +103,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_STORE_MEMORY_LIMIT', value: '8Gi' },
     { name: 'THANOS_STORE_MEMORY_REQUEST', value: '1Gi' },
     { name: 'THANOS_STORE_REPLICAS', value: '5' },
+    { name: 'CONFIGMAP_RELOADER_IMAGE', value: 'quay.io/openshift/origin-configmap-reloader' },
+    { name: 'CONFIGMAP_RELOADER_IMAGE_TAG', value: '4.5.0' },
   ],
 }


### PR DESCRIPTION
Right now, the CONFIGMAP_RELOADER_IMAGE parameters do not appear in the
OpenShift template for Observatorium metrics because they are declared
in the wrong file. This commit fixes this so that the template is valid.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @onprem @spaparaju 