### PR TITLE
Override the default securityContext values of Kube-Thanos JSonnet variables

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -209,9 +209,7 @@ objects:
           - mountPath: /etc/proxy/secrets
             name: compact-proxy
             readOnly: false
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
         volumes:
@@ -248,6 +246,7 @@ objects:
     name: observatorium-thanos-query
   spec:
     replicas: ${{THANOS_QUERIER_REPLICAS}}
+    securityContext: {}
     selector:
       matchLabels:
         app.kubernetes.io/component: query-layer
@@ -407,9 +406,7 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
         volumes:
@@ -595,9 +592,7 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
         volumes:
@@ -834,10 +829,8 @@ objects:
             requests:
               cpu: 10m
               memory: 24Mi
-          securityContext:
-            runAsUser: 65534
-        securityContext:
-          fsGroup: 65534
+          securityContext: {}
+        securityContext: {}
         serviceAccount: observatorium-thanos-receive-controller
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -1170,9 +1163,7 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 900
         volumes:
@@ -1519,9 +1510,7 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         volumes:
         - configMap:
@@ -1657,9 +1646,7 @@ objects:
             requests:
               cpu: ${MEMCACHED_EXPORTER_CPU_REQUEST}
               memory: ${MEMCACHED_EXPORTER_MEMORY_REQUEST}
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: observatorium-thanos-store-bucket-cache-memcached
 - apiVersion: v1
   kind: Service
@@ -1776,9 +1763,7 @@ objects:
             requests:
               cpu: ${MEMCACHED_EXPORTER_CPU_REQUEST}
               memory: ${MEMCACHED_EXPORTER_MEMORY_REQUEST}
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: observatorium-thanos-store-index-cache-memcached
 - apiVersion: v1
   kind: ServiceAccount
@@ -2014,9 +1999,7 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
         volumes: []
@@ -2260,9 +2243,7 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
         volumes: []
@@ -2506,9 +2487,7 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
         volumes: []

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -75,6 +75,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
             else [],
           template+: {
             spec+: {
+              securityContext: {},
               containers: [
                 // Overwrite and extend the thanos-compact container only
                 if c.name == 'thanos-compact' then c {
@@ -98,6 +99,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
           replicas: '${{THANOS_RULER_REPLICAS}}',
           template+: {
             spec+: {
+              securityContext: {},
               containers: [
                 if c.name == 'thanos-rule' then c {
                   env+: s3EnvVars,
@@ -118,6 +120,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
               replicas: '${{THANOS_STORE_REPLICAS}}',
               template+: {
                 spec+: {
+                  securityContext: {},
                   containers: [
                     if c.name == 'thanos-store' then c {
                       env+: s3EnvVars,
@@ -131,9 +134,32 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         }, super.shards),
     },
 
+    receiveController+:: {
+      deployment+: {
+        spec+: {
+          template+: {
+            spec+: {
+              securityContext: {},
+              containers: [
+                if c.name == 'thanos-receive-controller' then c {
+                  securityContext: {},
+                } else c
+                for c in super.containers
+              ],
+            },
+          },
+        },
+      },
+    },
+
     storeIndexCache+:: {
       statefulSet+: {
         spec+: {
+          template+: {
+            spec+: {
+              securityContext: {},
+            },
+          },
           replicas: '${{THANOS_STORE_INDEX_CACHE_REPLICAS}}',
           volumeClaimTemplates:: null,
         },
@@ -143,6 +169,11 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
     storeBucketCache+:: {
       statefulSet+: {
         spec+: {
+          template+: {
+            spec+: {
+              securityContext: {},
+            },
+          },
           replicas: '${{THANOS_STORE_BUCKET_CACHE_REPLICAS}}',
           volumeClaimTemplates:: null,
         },
@@ -179,9 +210,16 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       deployment+: oauth.deployment + jaegerAgentSidecar.deployment {
         spec+: {
           replicas: '${{THANOS_QUERIER_REPLICAS}}',
+          securityContext: {},
+          template+: {
+            spec+: {
+              securityContext: {},
+            },
+          },
         },
       },
     },
+
 
     queryFrontend+:: {
       local queryFrontend = self,
@@ -215,6 +253,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
           replicas: '${{THANOS_QUERY_FRONTEND_REPLICAS}}',
           template+: {
             spec+: {
+              securityContext: {},
               containers: [
                 if c.name == 'thanos-query-frontend' then c {
                   args: std.filter(function(arg)
@@ -260,6 +299,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
               replicas: '${{THANOS_RECEIVE_REPLICAS}}',
               template+: {
                 spec+: {
+                  securityContext: {},
                   containers: [
                     if c.name == 'thanos-receive' then c {
                       args+: [


### PR DESCRIPTION
The default securityContext value-set of is a blocker for stage RHOBS deployments (maybe for production RHOBS as well). 

This PR overrides these securityContext default values for RHOBS deployments.