### PR TITLE
remove securityContext for memcached and Loki deployments

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -101,9 +101,7 @@ objects:
           - containerPort: 9150
             name: metrics
           resources: {}
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: observatorium-loki-chunk-cache
 - apiVersion: v1
   kind: Service
@@ -203,9 +201,7 @@ objects:
           - containerPort: 9150
             name: metrics
           resources: {}
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: observatorium-loki-index-query-cache
 - apiVersion: v1
   kind: Service
@@ -305,9 +301,7 @@ objects:
           - containerPort: 9150
             name: metrics
           resources: {}
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: observatorium-loki-results-cache
 - apiVersion: v1
   kind: Service

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -618,9 +618,7 @@ objects:
             requests:
               cpu: ${MEMCACHED_EXPORTER_CPU_REQUEST}
               memory: ${MEMCACHED_EXPORTER_MEMORY_REQUEST}
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
+        securityContext: {}
         serviceAccountName: observatorium-api-cache-memcached
 - apiVersion: v1
   data:

--- a/services/observatorium-logs-template-overwrites.libsonnet
+++ b/services/observatorium-logs-template-overwrites.libsonnet
@@ -30,6 +30,11 @@ local jaegerAgentSidecar = (import 'sidecars/jaeger-agent.libsonnet')({
       [name]+: {
         spec+: {
           replicas: replicas[name],
+          template+: {
+            spec+: {
+              securityContext: {},
+            },
+          },
         },
       }
       for name in std.objectFields(super.manifests)

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -96,6 +96,7 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
     memoryLimitMb: '${MEMCACHED_MEMORY_LIMIT_MB}',
     maxItemSize: '5m',
     replicas: 1,  // overwritten in observatorium-metrics-template.libsonnet
+    securityContext: {},
     resources: {
       memcached: {
         requests: {


### PR DESCRIPTION
This PR removes securityContext for memcached and Loki deployments