### PR TITLE
Monitor api memcached

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -550,6 +550,10 @@ objects:
   spec:
     endpoints:
     - port: metrics
+    namespaceSelector:
+      matchNames:
+      - ${NAMESPACE}
+      - ${MST_NAMESPACE}
     selector:
       matchLabels:
         app.kubernetes.io/component: api-cache

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -120,7 +120,18 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
         },
       },
     },
-  }),
+  }) {
+    serviceMonitor+: {
+      spec+: {
+        namespaceSelector+: {
+          matchNames+: [
+            '${NAMESPACE}',
+            '${MST_NAMESPACE}',  // TODO(kakkoyun): Remove when we find more permenant solution.
+          ],
+        },
+      },
+    },
+  },
 
   api:: api({
     local cfg = self,


### PR DESCRIPTION
Right now, the API memcached is not monitored because the service monitor does not have the correct namespace selector. This commit fixes this bug.

cc @kakkoyun @spaparaju 