### PR TITLE
change as per the expected format of Thanos bool variables

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2600,7 +2600,7 @@ parameters:
 - name: THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR
   value: 1s
 - name: THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING
-  value: "--downsampling.disable"
+  value: --downsampling.disable
 - name: THANOS_COMPACTOR_MEMORY_LIMIT
   value: 5Gi
 - name: THANOS_COMPACTOR_MEMORY_REQUEST

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -123,7 +123,7 @@ objects:
           - --delete-delay=48h
           - --deduplication.replica-label=replica
           - --debug.max-compaction-level=3
-          - --downsampling.disable=${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}
+          - ${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2600,7 +2600,7 @@ parameters:
 - name: THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR
   value: 1s
 - name: THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING
-  value: "true"
+  value: "--downsampling.disable"
 - name: THANOS_COMPACTOR_MEMORY_LIMIT
   value: 5Gi
 - name: THANOS_COMPACTOR_MEMORY_REQUEST

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -71,7 +71,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
           replicas: '${{THANOS_COMPACTOR_REPLICAS}}',
           local disableDownsamplingFlag =
             if !compact.config.disableDownsampling then
-              ['--downsampling.disable=${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}']
+              ['${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}']
             else [],
           template+: {
             spec+: {

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -43,7 +43,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_COMPACTOR_RETENTION_RESOULTION_RAW', value: '14d' },
     { name: 'THANOS_COMPACTOR_RETENTION_RESOULTION_FIVE_MINUTES', value: '1s' },
     { name: 'THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR', value: '1s' },
-    { name: 'THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING', value: 'true' },
+    { name: 'THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING', value: '--downsampling.disable' },
     { name: 'THANOS_COMPACTOR_MEMORY_LIMIT', value: '5Gi' },
     { name: 'THANOS_COMPACTOR_MEMORY_REQUEST', value: '1Gi' },
     { name: 'THANOS_COMPACTOR_PVC_REQUEST', value: '50Gi' },


### PR DESCRIPTION
This PR updates the overwriting bool variable (for disable.downsampling) from the app-interface. This change is required as bool arguments Thanos cmd line does not accept the format of `--var=true/false`