### PR TITLE
Add prefix header flag to Thanos Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To update a dependency:
 
 ```console
 # Updates `kube-thanos` to master and sets the new hash in `jsonnetfile.lock.json`.
-jb update https://github.com/thanos-io/kube-thanos
+jb update https://github.com/thanos-io/kube-thanos/jsonnet/kube-thanos@main
 
 # Update all dependancies to master and sets the new hashes in `jsonnetfile.lock.json`.
 jb update

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -109,7 +109,7 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "master"
+      "version": "main"
     },
     {
       "source": {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -162,8 +162,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "f53ad9856c6f765989ea76ba8eff8dd1e77186b7",
-      "sum": "1wMHM/+NvluUAxS5cBW2c6APEKQNQYLYnv1ZCE1R3/A="
+      "version": "e1a68590f56034ca1a43d59401f03e72fd01ac5f",
+      "sum": "9g4HwpZ8Vpi950O6x92HNM47Yqa0+Nfv+7YbwwKpt3o="
     },
     {
       "source": {

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -294,6 +294,7 @@ objects:
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-1.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-2.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-receive-default.${NAMESPACE}.svc.cluster.local
+          - --web.prefix-header=X-Forwarded-Prefix
           - --query.timeout=15m
           - --query.lookback-delta=15m
           - |-

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -209,6 +209,8 @@ objects:
           - mountPath: /etc/proxy/secrets
             name: compact-proxy
             readOnly: false
+        nodeSelector:
+          beta.kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -406,6 +408,8 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
+        nodeSelector:
+          beta.kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -592,6 +596,8 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
+        nodeSelector:
+          beta.kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -1163,6 +1169,8 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
+        nodeSelector:
+          beta.kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 900
@@ -1510,6 +1518,8 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
+        nodeSelector:
+          beta.kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         volumes:
@@ -1999,6 +2009,8 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
+        nodeSelector:
+          beta.kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -2243,6 +2255,8 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
+        nodeSelector:
+          beta.kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -2487,6 +2501,8 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
+        nodeSelector:
+          beta.kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -336,6 +336,7 @@ local telemeterRules = (import 'github.com/openshift/telemeter/jsonnet/telemeter
       logLevel: '${THANOS_QUERIER_LOG_LEVEL}',
       lookbackDelta: '15m',
       queryTimeout: '15m',
+      prefixHeader: 'X-Forwarded-Prefix',
       stores: [
         'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
         for service in


### PR DESCRIPTION
This PR

- Adds `--web.prefix-header` to the Thanos Query deployment. This is to make UI work properly for all tenants through Obs. API.
- This required updating `kube-thanos` to latest first.