### PR TITLE
Add RHODS metrics to telemetry allowlist

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -70,6 +70,8 @@
   "{__name__=\"openshift:prometheus_tsdb_head_samples_appended_total:sum\"}",
   "{__name__=\"openshift:prometheus_tsdb_head_series:sum\"}",
   "{__name__=\"rhmi_status\"}",
+  "{__name__=\"rhods_aggregate_availability\"}",
+  "{__name__=\"rhods_total_users\"}",
   "{__name__=\"subscription_sync_total\"}",
   "{__name__=\"up\"}",
   "{__name__=\"visual_web_terminal_sessions_total\"}",

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -164,6 +164,8 @@ objects:
           - --whitelist={__name__="openshift:prometheus_tsdb_head_samples_appended_total:sum"}
           - --whitelist={__name__="openshift:prometheus_tsdb_head_series:sum"}
           - --whitelist={__name__="rhmi_status"}
+          - --whitelist={__name__="rhods_aggregate_availability"}
+          - --whitelist={__name__="rhods_total_users"}
           - --whitelist={__name__="subscription_sync_total"}
           - --whitelist={__name__="up"}
           - --whitelist={__name__="visual_web_terminal_sessions_total"}
@@ -338,6 +340,8 @@ objects:
           - --whitelist={__name__="openshift:prometheus_tsdb_head_samples_appended_total:sum"}
           - --whitelist={__name__="openshift:prometheus_tsdb_head_series:sum"}
           - --whitelist={__name__="rhmi_status"}
+          - --whitelist={__name__="rhods_aggregate_availability"}
+          - --whitelist={__name__="rhods_total_users"}
           - --whitelist={__name__="subscription_sync_total"}
           - --whitelist={__name__="up"}
           - --whitelist={__name__="visual_web_terminal_sessions_total"}


### PR DESCRIPTION
Metrics were added to the cluster monitoring allowlist at https://github.com/openshift/cluster-monitoring-operator/pull/1232.

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>