### PR TITLE
increase timeout for memcached instances for index-cache and bucket-cache

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1882,7 +1882,7 @@ objects:
               "max_get_multi_concurrency": 1000
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
-              "timeout": "400ms"
+              "timeout": "2s"
             "type": "memcached"
           - |-
             --store.caching-bucket.config="blocks_iter_ttl": "5m"
@@ -1899,7 +1899,7 @@ objects:
               "max_get_multi_concurrency": 1000
               "max_idle_connections": 1100
               "max_item_size": "1MiB"
-              "timeout": "400ms"
+              "timeout": "2s"
             "max_chunks_get_range_requests": 3
             "metafile_content_ttl": "24h"
             "metafile_doesnt_exist_ttl": "15m"
@@ -2128,7 +2128,7 @@ objects:
               "max_get_multi_concurrency": 1000
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
-              "timeout": "400ms"
+              "timeout": "2s"
             "type": "memcached"
           - |-
             --store.caching-bucket.config="blocks_iter_ttl": "5m"
@@ -2145,7 +2145,7 @@ objects:
               "max_get_multi_concurrency": 1000
               "max_idle_connections": 1100
               "max_item_size": "1MiB"
-              "timeout": "400ms"
+              "timeout": "2s"
             "max_chunks_get_range_requests": 3
             "metafile_content_ttl": "24h"
             "metafile_doesnt_exist_ttl": "15m"
@@ -2374,7 +2374,7 @@ objects:
               "max_get_multi_concurrency": 1000
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
-              "timeout": "400ms"
+              "timeout": "2s"
             "type": "memcached"
           - |-
             --store.caching-bucket.config="blocks_iter_ttl": "5m"
@@ -2391,7 +2391,7 @@ objects:
               "max_get_multi_concurrency": 1000
               "max_idle_connections": 1100
               "max_item_size": "1MiB"
-              "timeout": "400ms"
+              "timeout": "2s"
             "max_chunks_get_range_requests": 3
             "metafile_content_ttl": "24h"
             "metafile_doesnt_exist_ttl": "15m"

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -166,7 +166,7 @@ local telemeterRules = (import 'github.com/openshift/telemeter/jsonnet/telemeter
           addresses: ['dnssrv+_client._tcp.%s.%s.svc' % [thanos.storeIndexCache.service.metadata.name, thanos.storeIndexCache.service.metadata.namespace]],
           // Default Memcached Max Connection Limit is '3072', this is related to concurrency.
           max_idle_connections: 1300,  // default: 100 - For better performances, this should be set to a number higher than your peak parallel requests.
-          timeout: '400ms',  // default: 500ms
+          timeout: '2s',  // default: 500ms
           max_async_buffer_size: 200000,  // default: 10_000
           max_async_concurrency: 200,  // default: 20
           max_get_multi_batch_size: 100,  // default: 0 - No batching.
@@ -180,7 +180,7 @@ local telemeterRules = (import 'github.com/openshift/telemeter/jsonnet/telemeter
           addresses: ['dnssrv+_client._tcp.%s.%s.svc' % [thanos.storeBucketCache.service.metadata.name, thanos.storeBucketCache.service.metadata.namespace]],
           // Default Memcached Max Connection Limit is '3072', this is related to concurrency.
           max_idle_connections: 1100,  // default: 100 - For better performances, this should be set to a number higher than your peak parallel requests.
-          timeout: '400ms',  // default: 500ms
+          timeout: '2s',  // default: 500ms
           max_async_buffer_size: 25000,  // default: 10_000
           max_async_concurrency: 50,  // default: 20
           max_get_multi_batch_size: 100,  // default: 0 - No batching.


### PR DESCRIPTION
Increase timeout (from 400ms to 2s) for memcached reads both at Thanos Index-cache and store-bucket.

Currently at telemeter-production Thanos Store,  index-cache look ups are failing with timeouts.