### PR TITLE
Bump telemeter reference to deploy new recording rules

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -162,8 +162,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "d6ceb8a4e94f775510591974b2cdeb19819abda0",
-      "sum": "lszFfJCYihFfNtBpMNHlM4iFackZQ7yxzo114U2c0gk="
+      "version": "0bea9a2c9711b8877f9c7b4b7aa5c0a55793d19d",
+      "sum": "ekAubr/SuvsRaZxctnTtmpSuWIHohYgYkfwdXE5qW2g="
     },
     {
       "source": {

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1293,7 +1293,27 @@ objects:
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
           "record": "id_version"
         - "expr": |
-            0 * (count by (_id, install_type) (label_replace(label_replace(label_replace(label_replace(topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"), "install_type", "ipi", "type", "openshift-install"), "install_type", "hive", "invoker", "hive"), "install_type", "assisted-installer", "invoker", "assisted-installer")) or on(_id) (label_replace(count by (_id) (cluster:virt_platform_nodes:sum), "install_type", "hypershift-unknown", "install_type", ""))*0)
+            (
+              count by (_id, install_type) (
+                label_replace(
+                  label_replace(
+                    label_replace(
+                      label_replace(
+                        label_replace(
+                          topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"
+                        ), "install_type", "ipi", "type", "openshift-install"
+                      ), "install_type", "hive", "invoker", "hive"
+                    ), "install_type", "assisted-installer", "invoker", "assisted-installer"
+                  ), "install_type", "infrastructure-operator", "invoker", "assisted-installer-operator"
+                )
+              ) or on(_id) (
+                label_replace(
+                  count by (_id) (
+                    cluster:virt_platform_nodes:sum
+                  ), "install_type", "hypershift-unknown", "install_type", ""
+                )
+              ) * 0
+            ) * 0
           "labels":
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
           "record": "id_install_type"


### PR DESCRIPTION
This PR is raised to ship [this](https://github.com/openshift/telemeter/commit/2e0039cc9e0735d74b4c8e1a471cd189965ff74e) recording rule changes.