### PR TITLE
Add tracing endpoints to opa-ams config & regen templates

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -164,6 +164,7 @@ objects:
           - --ams.mappings=dptp=${DPTP_ORGANIZATION_ID}
           - --ams.mappings=managedkafka=${MANAGEDKAFKA_ORGANIZATION_ID}
           - --ams.mappings=osd=${OSD_ORGANIZATION_ID}
+          - --internal.tracing.endpoint=localhost:6831
           env:
           - name: ISSUER_URL
             valueFrom:

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -262,6 +262,11 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
           memory: '${OPA_AMS_MEMORY_LIMIT}',
         },
       },
+      internal: {
+        tracing: {
+          endpoint: 'localhost:6831',
+        },
+      },
     }),
 
     // proxySecret: oauth.proxySecret,

--- a/services/sidecars/opa-ams.libsonnet
+++ b/services/sidecars/opa-ams.libsonnet
@@ -77,6 +77,34 @@ function(params) {
                 for tenant in std.objectFields(opa.config.mappings)
               ]
             else []
+          ) + (
+            if std.objectHas(opa.config.internal, 'tracing') then
+              [] + (
+                if std.objectHas(opa.config.internal.tracing, 'endpoint') then
+                  [
+                    '--internal.tracing.endpoint=' + opa.config.internal.tracing.endpoint,
+                  ]
+                else []
+              ) + (
+                if std.objectHas(opa.config.internal.tracing, 'endpointType') then
+                  [
+                    '--internal.tracing.endpoint-type=' + opa.config.internal.tracing.endpointType,
+                  ]
+                else []
+              ) + (
+                if std.objectHas(opa.config.internal.tracing, 'samplingFraction') then
+                  [
+                    '--internal.tracing.sampling-fraction=' + opa.config.internal.tracing.samplingFraction,
+                  ]
+                else []
+              ) + (
+                if std.objectHas(opa.config.internal.tracing, 'serviceName') then
+                  [
+                    '--internal.tracing.service-name=' + opa.config.internal.tracing.serviceName,
+                  ]
+                else []
+              )
+            else []
           ),
           env: [
             {


### PR DESCRIPTION
This PR follows the example set [here](https://github.com/observatorium/api/pull/127/files) and adds tracing context to the opa-ams sidecar. 

Signed-off-by: Ian Billett <ibillett@redhat.com>