### PR TITLE
Add missing 'app-sre' label to cache ServiceMonitor

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -544,6 +544,8 @@ objects:
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
+    labels:
+      prometheus: app-sre
     name: observatorium-api-cache-memcached
   spec:
     endpoints:

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -125,6 +125,12 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
     },
   }) {
     serviceMonitor+: {
+      metadata+: {
+        labels+: {
+          prometheus: 'app-sre',
+          'app.kubernetes.io/version':: 'hidden',
+        },
+      },
       spec+: {
         namespaceSelector: {
           // NOTICE:


### PR DESCRIPTION
TL;DR - `observatorium-api-cache-memcached` ServiceMonitor is not showing up in Prometheus because of this missing `prometheus: app-sre` label.

See [ASIC-56](https://issues.redhat.com/browse/ASIC-56) for context.