### PR TITLE
Make target namespace configurable for ams remote write proxy

### DIFF
--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -532,7 +532,7 @@ objects:
 
           location / {
             proxy_set_header THANOS-TENANT FB870BF3-9F3A-44FF-9BF7-D7A047A52F43;
-            proxy_pass http://${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET}.${NAMESPACE}.svc.cluster.local:19291;
+            proxy_pass http://${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET}.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291;
           }
         }
       }
@@ -816,6 +816,8 @@ parameters:
   value: 200Mi
 - name: OBSERVATORIUM_NAMESPACE
   value: observatorium
+- name: OBSERVATORIUM_METRICS_NAMESPACE
+  value: observatorium-metrics
 - name: PROMETHEUS_AMS_REMOTE_WRITE_PROXY_IMAGE
   value: quay.io/app-sre/observatorium-receive-proxy
 - name: PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET

--- a/services/prometheus/remote-write-proxy.libsonnet
+++ b/services/prometheus/remote-write-proxy.libsonnet
@@ -9,6 +9,7 @@ local defaults = {
   version: error 'must provide version',
   image: error 'must set image for proxy',
   target: error 'must provide target',
+  targetNamespace: error 'must provide target namespace',
   tenantID: error 'must provide tenant ID',
   ports: {
     proxy: 8080,
@@ -110,7 +111,7 @@ function(params) {
         listen_port: rwp.config.ports.proxy,
         forward_host: 'http://%s.%s.svc.cluster.local:%d' % [
           rwp.config.target,
-          rwp.config.namespace,
+          rwp.config.targetNamespace,
           rwp.config.ports.target,
         ],
         thanos_tenant: rwp.config.tenantID,

--- a/services/telemeter-template.jsonnet
+++ b/services/telemeter-template.jsonnet
@@ -62,6 +62,7 @@ local prometheusAms = (import 'prometheus/remote-write-proxy.libsonnet')({
   version: '${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_VERSION}',
   image: '${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_IMAGE}:${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_VERSION}',
   target: '${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET}',
+  targetNamespace: '${OBSERVATORIUM_METRICS_NAMESPACE}',
   tenantID: 'FB870BF3-9F3A-44FF-9BF7-D7A047A52F43',
 });
 
@@ -167,6 +168,7 @@ local tr = (import 'github.com/observatorium/token-refresher/jsonnet/lib/token-r
     { name: 'OAUTH_PROXY_CPU_LIMITS', value: '200m' },
     { name: 'OAUTH_PROXY_MEMORY_LIMITS', value: '200Mi' },
     { name: 'OBSERVATORIUM_NAMESPACE', value: 'observatorium' },
+    { name: 'OBSERVATORIUM_METRICS_NAMESPACE', value: 'observatorium-metrics' },
     { name: 'PROMETHEUS_AMS_REMOTE_WRITE_PROXY_IMAGE', value: 'quay.io/app-sre/observatorium-receive-proxy' },
     { name: 'PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET', value: 'observatorium-thanos-receive' },
     { name: 'PROMETHEUS_AMS_REMOTE_WRITE_PROXY_VERSION', value: '14e844d' },


### PR DESCRIPTION
The AMS remote write proxy writes directly to Thanos Receive, which will move to a different namespace after migration. This PR changes the target namespace to `${OBSERVATORIUM_METRICS_NAMESPACE}` so that it continues to work after migration.