### PR TITLE
Adjust severity for OIDC failure alert

### DIFF
--- a/docs/sop/observatorium.md
+++ b/docs/sop/observatorium.md
@@ -96,7 +96,7 @@ There is either outage on the side of the OIDC provider or the tenant authorizat
 
 ### Severity
 
-`high`
+`medium`
 
 ### Access Required
 

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -542,7 +542,7 @@ local renderAlerts(name, environment, mixin) = {
                 sum(increase(observatorium_api_tenants_failed_registrations{tenant!="rhobs"}[5m])) by (tenant) > 0
               |||,
               labels: {
-                severity: 'high',
+                severity: 'warning',
               },
             },
           ],

--- a/resources/observability/prometheusrules/observatorium-tenants-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-tenants-production.prometheusrules.yaml
@@ -20,4 +20,4 @@ spec:
         sum(increase(observatorium_api_tenants_failed_registrations{tenant!="rhobs"}[5m])) by (tenant) > 0
       labels:
         service: telemeter
-        severity: high
+        severity: medium

--- a/resources/observability/prometheusrules/observatorium-tenants-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-tenants-stage.prometheusrules.yaml
@@ -20,4 +20,4 @@ spec:
         sum(increase(observatorium_api_tenants_failed_registrations{tenant!="rhobs"}[5m])) by (tenant) > 0
       labels:
         service: telemeter
-        severity: high
+        severity: medium


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

After agreement with AppSRE, changing severity to `medium`, as this alert should be addressed primarily by Observatorium team, see https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/25214#note_2838339