### PR TITLE
Add template for metric-federation Thanos Ruler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ whitelisted_metrics: $(GOJSONTOYAML) $(GOJQ)
 manifests: format $(VENDOR_DIR)
 manifests: resources/services/telemeter-template.yaml resources/services/jaeger-template.yaml resources/services/conprof-template.yaml
 manifests: resources/services/observatorium-template.yaml resources/services/observatorium-metrics-template.yaml resources/services/observatorium-logs-template.yaml
+manifests: resources/services/metric-federation-rule-template.yaml
 	$(MAKE) clean
 
 resources/services/conprof-template.yaml: $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
@@ -111,6 +112,10 @@ resources/services/observatorium-metrics-template.yaml: $(wildcard services/obse
 resources/services/observatorium-logs-template.yaml: $(wildcard services/observatorium-logs-*) $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
 	@echo ">>>>> Running observatorium-logs templates"
 	$(JSONNET) -J vendor services/observatorium-logs-template.jsonnet | $(GOJSONTOYAML) > $@
+
+resources/services/metric-federation-rule-template.yaml: $(wildcard services/metric-federation-rule*) $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
+	@echo ">>>>> Running metric-federation-rule templates"
+	$(JSONNET) -J vendor services/metric-federation-rule-template.jsonnet | $(GOJSONTOYAML) > $@
 
 .PHONY: clean
 clean:

--- a/configuration/observatorium/metric-federation-rules.libsonnet
+++ b/configuration/observatorium/metric-federation-rules.libsonnet
@@ -1,0 +1,44 @@
+{
+  prometheus+:: {
+    recordingrules+: {
+      groups+: [
+        {
+          name: 'kafka.rules',
+          interval: '1m',
+          rules: [
+            {
+              record: 'rhosak:haproxy_server_bytes_out_total:kube_namespace_labels:sum_rate',
+              expr: |||
+                haproxy_server_bytes_out_total:kube_namespace_labels:sum_rate
+              |||,
+            },
+            {
+              record: 'rhosak:haproxy_server_bytes_in_total:kube_namespace_labels:sum_rate',
+              expr: |||
+                haproxy_server_bytes_in_total:kube_namespace_labels:sum_rate
+              |||,
+            },
+            {
+              record: 'rhosak:haproxy_server_bytes_in_total:kube_namespace_labels:sum_rate:haproxy_server_bytes_out_total:kube_namespace_labels:sum_rate',
+              expr: |||
+                haproxy_server_bytes_in_total:kube_namespace_labels:sum_rate:haproxy_server_bytes_out_total:kube_namespace_labels:sum_rate
+              |||,
+            },
+            {
+              record: 'rhosak:kafka_broker_quota_totalstorageusedbytes:kube_namespace_labels:sum_max_over_time',
+              expr: |||
+                kafka_broker_quota_totalstorageusedbytes:kube_namespace_labels:sum_max_over_time
+              |||,
+            },
+            {
+              record: 'rhosak:strimzi_resource_state:kube_namespace_labels:group',
+              expr: |||
+                strimzi_resource_state:kube_namespace_labels:group
+              |||,
+            },
+          ],
+        },
+      ],
+    },
+  },
+}

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -1,0 +1,323 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: metric-federation-rule
+objects:
+- apiVersion: v1
+  data:
+    observatorium.yaml: |-
+      "groups":
+      - "interval": "1m"
+        "name": "telemeter-kafka.rules"
+        "rules":
+        - "expr": |
+            haproxy_server_bytes_out_total:kube_namespace_labels:sum_rate
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "rhosak:haproxy_server_bytes_out_total:kube_namespace_labels:sum_rate"
+        - "expr": |
+            haproxy_server_bytes_in_total:kube_namespace_labels:sum_rate
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "rhosak:haproxy_server_bytes_in_total:kube_namespace_labels:sum_rate"
+        - "expr": |
+            haproxy_server_bytes_in_total:kube_namespace_labels:sum_rate:haproxy_server_bytes_out_total:kube_namespace_labels:sum_rate
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "rhosak:haproxy_server_bytes_in_total:kube_namespace_labels:sum_rate:haproxy_server_bytes_out_total:kube_namespace_labels:sum_rate"
+        - "expr": |
+            kafka_broker_quota_totalstorageusedbytes:kube_namespace_labels:sum_max_over_time
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "rhosak:kafka_broker_quota_totalstorageusedbytes:kube_namespace_labels:sum_max_over_time"
+        - "expr": |
+            strimzi_resource_state:kube_namespace_labels:group
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "rhosak:strimzi_resource_state:kube_namespace_labels:group"
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/part-of: observatorium
+    name: metric-federation-rules
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-metric-federation-rule
+  spec:
+    clusterIP: None
+    ports:
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+    - name: http
+      port: 10902
+      targetPort: 10902
+    selector:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-metric-federation-rule
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      prometheus: app-sre
+    name: observatorium-thanos-metric-federation-rule
+  spec:
+    endpoints:
+    - port: http
+      relabelings:
+      - separator: /
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: instance
+    namespaceSelector:
+      matchNames: ${{NAMESPACES}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: metric-federation
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-metric-federation-rule
+  spec:
+    replicas: ${{THANOS_RULER_REPLICAS}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: metric-federation
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+    serviceName: observatorium-thanos-metric-federation-rule
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: metric-federation
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+          app.kubernetes.io/tracing: jaeger-agent
+          app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      spec:
+        containers:
+        - args:
+          - rule
+          - --log.level=${THANOS_RULER_LOG_LEVEL}
+          - --log.format=logfmt
+          - --grpc-address=0.0.0.0:10901
+          - --http-address=0.0.0.0:10902
+          - --objstore.config=$(OBJSTORE_CONFIG)
+          - --data-dir=/var/thanos/rule
+          - --label=rule_replica="$(NAME)"
+          - --alert.label-drop=rule_replica
+          - --tsdb.retention=48h
+          - --tsdb.block-duration=2h
+          - --query=dnssrv+_http._tcp.observatorium-thanos-query.${THANOS_QUERIER_NAMESPACE}.svc.cluster.local
+          - --rule-file=/etc/thanos/rules/metric-federation-rules/observatorium.yaml
+          - |-
+            --tracing.config="config":
+              "sampler_param": 2
+              "sampler_type": "ratelimiting"
+              "service_name": "thanos-rule"
+            "type": "JAEGER"
+          env:
+          - name: NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OBJSTORE_CONFIG
+            valueFrom:
+              secretKeyRef:
+                key: thanos.yaml
+                name: ${THANOS_CONFIG_SECRET}
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: aws_access_key_id
+                name: ${THANOS_S3_SECRET}
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: aws_secret_access_key
+                name: ${THANOS_S3_SECRET}
+          image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 24
+            httpGet:
+              path: /-/healthy
+              port: 10902
+              scheme: HTTP
+            periodSeconds: 5
+          name: thanos-rule
+          ports:
+          - containerPort: 10901
+            name: grpc
+          - containerPort: 10902
+            name: http
+          readinessProbe:
+            failureThreshold: 18
+            httpGet:
+              path: /-/ready
+              port: 10902
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: ${THANOS_RULER_CPU_LIMIT}
+              memory: ${THANOS_RULER_MEMORY_LIMIT}
+            requests:
+              cpu: ${THANOS_RULER_CPU_REQUEST}
+              memory: ${THANOS_RULER_MEMORY_REQUEST}
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /var/thanos/rule
+            name: data
+            readOnly: false
+          - mountPath: /etc/thanos/rules/metric-federation-rules
+            name: metric-federation-rules
+        - args:
+          - -webhook-url=http://localhost:10902/-/reload
+          - -volume-dir=/etc/thanos/rules/metric-federation-rules
+          image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+          name: configmap-reloader
+          volumeMounts:
+          - mountPath: /etc/thanos/rules/metric-federation-rules
+            name: metric-federation-rules
+        - args:
+          - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+          - --reporter.type=grpc
+          - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+          env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14271
+              scheme: HTTP
+          name: jaeger-agent
+          ports:
+          - containerPort: 5778
+            name: configs
+          - containerPort: 6831
+            name: jaeger-thrift
+          - containerPort: 14271
+            name: metrics
+          resources:
+            limits:
+              cpu: 128m
+              memory: 128Mi
+            requests:
+              cpu: 32m
+              memory: 64Mi
+        nodeSelector:
+          beta.kubernetes.io/os: linux
+        securityContext: {}
+        serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+        volumes:
+        - configMap:
+            name: metric-federation-rules
+          name: metric-federation-rules
+    volumeClaimTemplates:
+    - metadata:
+        labels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: metric-federation
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+        name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: ${THANOS_RULER_PVC_REQUEST}
+        storageClassName: ${STORAGE_CLASS}
+parameters:
+- name: NAMESPACE
+  value: observatorium-metrics
+- name: CONFIGMAP_RELOADER_IMAGE
+  value: quay.io/openshift/origin-configmap-reloader
+- name: CONFIGMAP_RELOADER_IMAGE_TAG
+  value: 4.5.0
+- name: JAEGER_AGENT_IMAGE_TAG
+  value: 1.15.0
+- name: JAEGER_AGENT_IMAGE
+  value: quay.io/app-sre/jaegertracing-jaeger-agent
+- name: JAEGER_COLLECTOR_NAMESPACE
+  value: $(NAMESPACE)
+- name: SERVICE_ACCOUNT_NAME
+  value: prometheus-telemeter
+- name: STORAGE_CLASS
+  value: gp2
+- name: THANOS_CONFIG_SECRET
+  value: thanos-objectstorage
+- name: THANOS_IMAGE_TAG
+  value: master-2020-08-12-70f89d83
+- name: THANOS_IMAGE
+  value: quay.io/thanos/thanos
+- name: THANOS_QUERIER_NAMESPACE
+  value: observatorium-mst
+- name: THANOS_RULER_CPU_LIMIT
+  value: "1"
+- name: THANOS_RULER_CPU_REQUEST
+  value: 500m
+- name: THANOS_RULER_LOG_LEVEL
+  value: info
+- name: THANOS_RULER_MEMORY_LIMIT
+  value: 2Gi
+- name: THANOS_RULER_MEMORY_REQUEST
+  value: 2Gi
+- name: THANOS_RULER_PVC_REQUEST
+  value: 50Gi
+- name: THANOS_RULER_REPLICAS
+  value: "2"
+- name: THANOS_S3_SECRET
+  value: telemeter-thanos-stage-s3

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -292,6 +292,7 @@ objects:
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-1.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-2.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-receive-default.${NAMESPACE}.svc.cluster.local
+          - --store=dnssrv+_grpc._tcp.observatorium-thanos-metric-federation-rule.${NAMESPACE}.svc.cluster.local
           - --web.prefix-header=X-Forwarded-Prefix
           - --query.timeout=15m
           - --query.lookback-delta=15m

--- a/services/metric-federation-rule-template.jsonnet
+++ b/services/metric-federation-rule-template.jsonnet
@@ -1,0 +1,35 @@
+local obs = import 'observatorium.libsonnet';
+{
+  apiVersion: 'v1',
+  kind: 'Template',
+  metadata: { name: 'metric-federation-rule' },
+  objects: [
+    obs.thanos.manifests[name] {
+      metadata+: { namespace:: 'hidden' },
+    }
+    for name in std.objectFields(obs.thanos.manifests)
+    if obs.thanos.manifests[name] != null && std.startsWith(name, 'metric-federation-rule')
+  ],
+  parameters: [
+    { name: 'NAMESPACE', value: 'observatorium-metrics' },
+    { name: 'CONFIGMAP_RELOADER_IMAGE', value: 'quay.io/openshift/origin-configmap-reloader' },
+    { name: 'CONFIGMAP_RELOADER_IMAGE_TAG', value: '4.5.0' },
+    { name: 'JAEGER_AGENT_IMAGE_TAG', value: '1.15.0' },
+    { name: 'JAEGER_AGENT_IMAGE', value: 'quay.io/app-sre/jaegertracing-jaeger-agent' },
+    { name: 'JAEGER_COLLECTOR_NAMESPACE', value: '$(NAMESPACE)' },
+    { name: 'SERVICE_ACCOUNT_NAME', value: 'prometheus-telemeter' },
+    { name: 'STORAGE_CLASS', value: 'gp2' },
+    { name: 'THANOS_CONFIG_SECRET', value: 'thanos-objectstorage' },
+    { name: 'THANOS_IMAGE_TAG', value: 'master-2020-08-12-70f89d83' },
+    { name: 'THANOS_IMAGE', value: 'quay.io/thanos/thanos' },
+    { name: 'THANOS_QUERIER_NAMESPACE', value: 'observatorium-mst' },
+    { name: 'THANOS_RULER_CPU_LIMIT', value: '1' },
+    { name: 'THANOS_RULER_CPU_REQUEST', value: '500m' },
+    { name: 'THANOS_RULER_LOG_LEVEL', value: 'info' },
+    { name: 'THANOS_RULER_MEMORY_LIMIT', value: '2Gi' },
+    { name: 'THANOS_RULER_MEMORY_REQUEST', value: '2Gi' },
+    { name: 'THANOS_RULER_PVC_REQUEST', value: '50Gi' },
+    { name: 'THANOS_RULER_REPLICAS', value: '2' },
+    { name: 'THANOS_S3_SECRET', value: 'telemeter-thanos-stage-s3' },
+  ],
+}

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -112,6 +112,25 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       },
     },
 
+    metricFederationRule+:: {
+      statefulSet+: jaegerAgentSidecar.statefulSet {
+        spec+: {
+          replicas: '${{THANOS_RULER_REPLICAS}}',
+          template+: {
+            spec+: {
+              securityContext: {},
+              containers: [
+                if c.name == 'thanos-rule' then c {
+                  env+: s3EnvVars,
+                } else c
+                for c in super.containers
+              ],
+            },
+          },
+        },
+      },
+    },
+
     stores+:: {
       shards:
         std.mapWithKey(function(shard, obj) obj {  // loops over each [shard-n]:obj

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -8,7 +8,7 @@ local obs = import 'observatorium.libsonnet';
       metadata+: { namespace:: 'hidden' },
     }
     for name in std.objectFields(obs.thanos.manifests)
-    if obs.thanos.manifests[name] != null
+    if obs.thanos.manifests[name] != null && !std.startsWith(name, 'metric-federation-rule')
   ],
   parameters: [
     { name: 'NAMESPACE', value: 'observatorium-metrics' },

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -2,6 +2,7 @@ local t = (import 'github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/thanos.l
 local trc = (import 'github.com/observatorium/thanos-receive-controller/jsonnet/lib/thanos-receive-controller.libsonnet');
 local memcached = (import 'github.com/observatorium/observatorium/configuration/components/memcached.libsonnet');
 local telemeterRules = (import 'github.com/openshift/telemeter/jsonnet/telemeter/rules.libsonnet');
+local metricFederationRules = (import '../configuration/observatorium/metric-federation-rules.libsonnet');
 local tenants = (import '../configuration/observatorium/tenants.libsonnet');
 
 {
@@ -131,6 +132,78 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
                 },
               }, group.rules),
             }, telemeterRules.prometheus.recordingrules.groups),
+          }),
+        },
+      },
+    },
+
+    local metricFederationRulesName = 'metric-federation-rules',
+    metricFederationRule:: t.rule(thanosSharedConfig {
+      name: 'observatorium-thanos-metric-federation-rule',
+      commonLabels+:: {
+        'app.kubernetes.io/part-of': 'observatorium',
+        'app.kubernetes.io/instance': 'metric-federation',
+      },
+      replicas: 1,  // overwritten in observatorium-metrics-template.libsonnet
+      logLevel: '${THANOS_RULER_LOG_LEVEL}',
+      serviceMonitor: true,
+      queriers: [
+        'dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, '${THANOS_QUERIER_NAMESPACE}'],
+      ],
+      reloaderImage: '${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}',
+      rulesConfig: [
+        {
+          name: metricFederationRulesName,
+          key: observatoriumRulesKey,
+        },
+      ],
+      resources: {
+        limits: {
+          cpu: '${THANOS_RULER_CPU_LIMIT}',
+          memory: '${THANOS_RULER_MEMORY_LIMIT}',
+        },
+        requests: {
+          cpu: '${THANOS_RULER_CPU_REQUEST}',
+          memory: '${THANOS_RULER_MEMORY_REQUEST}',
+        },
+      },
+      volumeClaimTemplate: {
+        spec: {
+          accessModes: ['ReadWriteOnce'],
+          storageClassName: '${STORAGE_CLASS}',
+          resources: {
+            requests: {
+              storage: '${THANOS_RULER_PVC_REQUEST}',
+            },
+          },
+        },
+      },
+    }) + {
+      // TODO: Move configmap either to upstream (best) or as overwrite.
+      configmap: {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: {
+          name: metricFederationRulesName,
+          annotations: {
+            'qontract.recycle': 'true',
+          },
+          labels: {
+            'app.kubernetes.io/instance': 'observatorium',
+            'app.kubernetes.io/part-of': 'observatorium',
+          },
+        },
+        data: {
+          [observatoriumRulesKey]: std.manifestYamlDoc({
+            groups: std.map(function(group) {
+              name: 'telemeter-' + group.name,
+              interval: group.interval,
+              rules: std.map(function(rule) rule {
+                labels+: {
+                  tenant_id: tenants.map.telemeter.id,
+                },
+              }, group.rules),
+            }, metricFederationRules.prometheus.recordingrules.groups),
           }),
         },
       },
@@ -347,7 +420,8 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
         for service in
           [thanos.rule.service] +
           [thanos.stores.shards[shard].service for shard in std.objectFields(thanos.stores.shards)] +
-          [thanos.receivers.hashrings[hashring].service for hashring in std.objectFields(thanos.receivers.hashrings)]
+          [thanos.receivers.hashrings[hashring].service for hashring in std.objectFields(thanos.receivers.hashrings)] +
+          [thanos.metricFederationRule.service]
       ],
       serviceMonitor: true,
       resources: {
@@ -516,6 +590,9 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
     } + {
       ['store-bucket-cache-' + name]: thanos.storeBucketCache[name]
       for name in std.objectFields(thanos.storeBucketCache)
+    } + {
+      ['metric-federation-rule-' + name]: thanos.metricFederationRule[name]
+      for name in std.objectFields(thanos.metricFederationRule)
     },
   },
 }

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -421,6 +421,9 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           [thanos.rule.service] +
           [thanos.stores.shards[shard].service for shard in std.objectFields(thanos.stores.shards)] +
           [thanos.receivers.hashrings[hashring].service for hashring in std.objectFields(thanos.receivers.hashrings)] +
+          // This service will not exist in a namespace where the metric-federation Ruler is not
+          // deployed (the MST namespace). This will cause the Querier to spam a warning saying
+          // it was not able to resolve the address.
           [thanos.metricFederationRule.service]
       ],
       serviceMonitor: true,


### PR DESCRIPTION
This MR adds a new template that deploys another instance of Thanos Rule. This Rule instance will be used to federate certain metrics from the MST instance to the Telemeter instance.