### PR TITLE
Add missing NAMESPACES parameter

### DIFF
--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -283,6 +283,8 @@ objects:
 parameters:
 - name: NAMESPACE
   value: observatorium-metrics
+- name: NAMESPACES
+  value: '["observatorium-metrics"]'
 - name: CONFIGMAP_RELOADER_IMAGE
   value: quay.io/openshift/origin-configmap-reloader
 - name: CONFIGMAP_RELOADER_IMAGE_TAG

--- a/services/metric-federation-rule-template.jsonnet
+++ b/services/metric-federation-rule-template.jsonnet
@@ -12,6 +12,7 @@ local obs = import 'observatorium.libsonnet';
   ],
   parameters: [
     { name: 'NAMESPACE', value: 'observatorium-metrics' },
+    { name: 'NAMESPACES', value: '["observatorium-metrics"]' },
     { name: 'CONFIGMAP_RELOADER_IMAGE', value: 'quay.io/openshift/origin-configmap-reloader' },
     { name: 'CONFIGMAP_RELOADER_IMAGE_TAG', value: '4.5.0' },
     { name: 'JAEGER_AGENT_IMAGE_TAG', value: '1.15.0' },


### PR DESCRIPTION
The `NAMESPACES` parameter was missing from the metric-federation ruler template, causing problems when deploying.