### PR TITLE
chore: Update federation rule kafka metric names to include gibibytes

### DIFF
--- a/configuration/observatorium/metric-federation-rules.libsonnet
+++ b/configuration/observatorium/metric-federation-rules.libsonnet
@@ -13,27 +13,27 @@
               |||,
             },
             {
-              record: 'kafka_id:haproxy_server_bytes_in_total:rate1h',
+              record: 'kafka_id:haproxy_server_bytes_in_total:rate1h_gibibytes',
               expr: |||
-                kafka_id:haproxy_server_bytes_in_total:rate1h
+                kafka_id:haproxy_server_bytes_in_total:rate1h_gibibytes
               |||,
             },
             {
-              record: 'kafka_id:haproxy_server_bytes_out_total:rate1h',
+              record: 'kafka_id:haproxy_server_bytes_out_total:rate1h_gibibytes',
               expr: |||
-                kafka_id:haproxy_server_bytes_out_total:rate1h
+                kafka_id:haproxy_server_bytes_out_total:rate1h_gibibytes
               |||,
             },
             {
-              record: 'kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h',
+              record: 'kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes',
               expr: |||
-                kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h
+                kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
               |||,
             },
             {
-              record: 'kafka_id:haproxy_server_bytes_in_out_total:rate1h',
+              record: 'kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes',
               expr: |||
-                kafka_id:haproxy_server_bytes_in_out_total:rate1h
+                kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
               |||,
             },
           ],

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -16,25 +16,25 @@ objects:
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
           "record": "kafka_id:strimzi_resource_state:group"
         - "expr": |
-            kafka_id:haproxy_server_bytes_in_total:rate1h
+            kafka_id:haproxy_server_bytes_in_total:rate1h_gibibytes
           "labels":
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "kafka_id:haproxy_server_bytes_in_total:rate1h"
+          "record": "kafka_id:haproxy_server_bytes_in_total:rate1h_gibibytes"
         - "expr": |
-            kafka_id:haproxy_server_bytes_out_total:rate1h
+            kafka_id:haproxy_server_bytes_out_total:rate1h_gibibytes
           "labels":
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "kafka_id:haproxy_server_bytes_out_total:rate1h"
+          "record": "kafka_id:haproxy_server_bytes_out_total:rate1h_gibibytes"
         - "expr": |
-            kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h
+            kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
           "labels":
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h"
+          "record": "kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes"
         - "expr": |
-            kafka_id:haproxy_server_bytes_in_out_total:rate1h
+            kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
           "labels":
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "kafka_id:haproxy_server_bytes_in_out_total:rate1h"
+          "record": "kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes"
   kind: ConfigMap
   metadata:
     annotations:


### PR DESCRIPTION
Updated kafka federation metric names to include gibibytes