### PR TITLE
MON-1390: Add avalanche deployment that writes data to the RHOBS tenant

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -541,7 +541,7 @@ objects:
           - --value-interval=60
           - --series-interval=86400
           - --metric-interval=86400
-          - --const-label=tenant_id="770c1124-6ae8-4324-a9d4-9ce08590094b"
+          - --const-label=tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
           image: quay.io/freshtracks.io/avalanche:master-2020-12-28-0c1c64c
           name: avalanache-remote-writer
 - apiVersion: v1

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -509,6 +509,41 @@ objects:
         app.kubernetes.io/instance: observatorium
         app.kubernetes.io/name: gubernator
         app.kubernetes.io/part-of: observatorium
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app.kubernetes.io/component: avalanche
+      app.kubernetes.io/name: avalanche-remote-writer
+      app.kubernetes.io/part-of: observatorium
+    name: avalanache-remote-writer
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: avalanche
+        app.kubernetes.io/name: avalanche-remote-writer
+        app.kubernetes.io/part-of: observatorium
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/component: avalanche
+          app.kubernetes.io/name: avalanche-remote-writer
+          app.kubernetes.io/part-of: observatorium
+      spec:
+        containers:
+          args:
+          - --metric-count=8333
+          - --series-count=1
+          - --remote-url="http://observatorium-thanos-receive.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291"
+          - --remote-write-interval=30s
+          - --remote-requests-count=1000000
+          - --value-interval=60
+          - --series-interval=86400
+          - --metric-interval=86400
+          - --const-label=tenant_id="770c1124-6ae8-4324-a9d4-9ce08590094b"
+          image: quay.io/freshtracks.io/avalanche:master-2020-12-28-0c1c64c
+          name: avalanache-remote-writer
 - apiVersion: v1
   kind: Service
   metadata:

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -533,8 +533,8 @@ objects:
       spec:
         containers:
           args:
-          - --metric-count=8333
-          - --series-count=1
+          - --metric-count=1
+          - --series-count=8333
           - --remote-url="http://observatorium-thanos-receive.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291"
           - --remote-write-interval=30s
           - --remote-requests-count=1000000

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -393,8 +393,8 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
               name: config.name,
               image: config.image,
               args: [
-                '--metric-count=8333',  // this is set so that we write 1M samples per hour to our test tenant
-                '--series-count=1',
+                '--metric-count=1',  // we only get one metric __name__
+                '--series-count=8333',  // this is set so that we write 1M samples per hour to our test tenant
                 '--remote-url="http://%s.%s.svc.cluster.local:%d"' % [
                   obs.thanos.receiversService.metadata.name,
                   obs.config.namespaces.metrics,

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -405,7 +405,7 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
                 '--value-interval=60',  // how often to update the metric values
                 '--series-interval=86400',  // how often to create new series names
                 '--metric-interval=86400',  // how often to create new metric names
-                '--const-label=tenant_id="770c1124-6ae8-4324-a9d4-9ce08590094b"',  // this is the id of our testing tenant
+                '--const-label=tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"',  // this is the id of our testing tenant
               ],
             },
           },


### PR DESCRIPTION
This PR adds a deployment of [open-fresh/avalanche](https://github.com/open-fresh/avalanche) that will run in both MST & Telemeter instances of RHOBS.

The purpose of this is to write a **known** & **static** amount of data to our tenant, so that we can make semi-precise measurements of query path performance for our SLI [implementation](https://issues.redhat.com/browse/MON-1390).

As the comments say, this deployment will write 1M samples per hour - 8.3k series at 30s intervals.

Tested this configuration _locally_, but not in a cluster yet. In fact - I'm not sure how we will even query this data quite yet.

Signed-off-by: Ian Billett <ibillett@redhat.com>