### PR TITLE
Use mirrored image

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -542,7 +542,7 @@ objects:
           - --series-interval=86400
           - --metric-interval=86400
           - --const-label=tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
-          image: quay.io/freshtracks.io/avalanche:master-2020-12-28-0c1c64c
+          image: quay.io/observatorium/avalanche:master-2020-12-28-0c1c64c
           name: avalanache-remote-writer
 - apiVersion: v1
   kind: Service

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -366,7 +366,7 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
 
     local config = {
       name: 'avalanache-remote-writer',
-      image: 'quay.io/freshtracks.io/avalanche:master-2020-12-28-0c1c64c',
+      image: 'quay.io/observatorium/avalanche:master-2020-12-28-0c1c64c',
       commonLabels: {
         'app.kubernetes.io/component': 'avalanche',
         'app.kubernetes.io/name': 'avalanche-remote-writer',


### PR DESCRIPTION
We can't roll [this](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/26542) out, because the AppSRE bot is trying to validate the `freshtracks.io` part of  `quay.io/freshtracks.io/avalanche` which has a bad cert :facepalm: 

To fix this, I've mirrored the image into `quay.io/observatorium/avalanche`.

Verify with `docker pull quay.io/observatorium/avalanche:master-2020-12-28-0c1c64c`

Signed-off-by: Ian Billett <ibillett@redhat.com>