### PR TITLE
Fix crashloop by unquoting remote-url 

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -535,7 +535,7 @@ objects:
         - args:
           - --metric-count=1
           - --series-count=8333
-          - --remote-url="http://observatorium-thanos-receive.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+          - --remote-url=http://observatorium-thanos-receive.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291/api/v1/receive
           - --remote-write-interval=30s
           - --remote-requests-count=1000000
           - --value-interval=60

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -516,7 +516,7 @@ objects:
       app.kubernetes.io/component: avalanche
       app.kubernetes.io/name: avalanche-remote-writer
       app.kubernetes.io/part-of: observatorium
-    name: avalanache-remote-writer
+    name: avalanche-remote-writer
   spec:
     replicas: 1
     selector:
@@ -543,7 +543,7 @@ objects:
           - --metric-interval=86400
           - --const-label=tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
           image: quay.io/observatorium/avalanche:master-2020-12-28-0c1c64c
-          name: avalanache-remote-writer
+          name: avalanche-remote-writer
 - apiVersion: v1
   kind: Service
   metadata:

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -395,7 +395,7 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
               args: [
                 '--metric-count=1',  // we only get one metric __name__
                 '--series-count=8333',  // this is set so that we write 1M samples per hour to our test tenant
-                '--remote-url="http://%s.%s.svc.cluster.local:%d/api/v1/receive"' % [
+                '--remote-url=http://%s.%s.svc.cluster.local:%d/api/v1/receive' % [
                   obs.thanos.receiversService.metadata.name,
                   obs.config.namespaces.metrics,
                   obs.thanos.receiversService.spec.ports[2].port,

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -365,7 +365,7 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
   avalanche:: {
 
     local config = {
-      name: 'avalanache-remote-writer',
+      name: 'avalanche-remote-writer',
       image: 'quay.io/observatorium/avalanche:master-2020-12-28-0c1c64c',
       commonLabels: {
         'app.kubernetes.io/component': 'avalanche',


### PR DESCRIPTION
The avalanche deployment is [crashlooping](https://console-openshift-console.apps.app-sre-stage-0.k3s7.p1.openshiftapps.com/k8s/ns/observatorium-stage/deployments/avalanache-remote-writer) due to a url parsing error:
```
error: invalid URL: parse "\"http://observatorium-thanos-receive.observatorium-metrics-stage.svc.cluster.local:19291/api/v1/receive\"": first path segment in URL cannot contain colon
```
See [this](https://play.golang.org/p/MIYJEdAEM6G) Go playground for an example.

This PR fixes this problem, by removing the inner quotes on the URL. 

Signed-off-by: Ian Billett <ibillett@redhat.com>