### PR TITLE
Recycle Up when Configmap changes

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -671,6 +671,8 @@ objects:
         "query": "avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[100h])"
   kind: ConfigMap
   metadata:
+    annotations:
+      qontract.recycle: "true"
     labels:
       app.kubernetes.io/component: blackbox-prober
       app.kubernetes.io/instance: observatorium

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -359,6 +359,11 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
         },
       },
     },
+    configmap+: {
+      metadata+: {
+        annotations+: { 'qontract.recycle': 'true' },
+      },
+    },
   },
 
 


### PR DESCRIPTION
We're not currently running the SLI [queries](https://console-openshift-console.apps.app-sre-stage-0.k3s7.p1.openshiftapps.com/k8s/ns/observatorium-stage/pods/observatorium-observatorium-up-79d9c974d8-hmjmx/logs) because the Up binary does not get auto-restarted when the underlying configmap changes. This fixes that.

Signed-off-by: Ian Billett <ibillett@redhat.com>