### PR TITLE
Fix RBAC roles for rhobs

### DIFF
--- a/configuration/observatorium/rbac.libsonnet
+++ b/configuration/observatorium/rbac.libsonnet
@@ -55,7 +55,8 @@
     {
       name: 'rhobs',
       roles: [
-        'rhobs',
+        'rhobs-write',
+        'rhobs-read',
       ],
       subjects: [
         {

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -9,7 +9,8 @@ objects:
       "roleBindings":
       - "name": "rhobs"
         "roles":
-        - "rhobs"
+        - "rhobs-write"
+        - "rhobs-read"
         "subjects":
         - "kind": "user"
           "name": "service-account-observatorium-rhobs-staging"


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

After recent change, 'rhobs' tenant has non-existing role 'rhobs' which has been split into read/write. This commit fixes it.