### PR TITLE
Make Avalanche append the correct tenant headers

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -553,11 +553,12 @@ objects:
           - --remote-url=http://observatorium-thanos-receive.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291/api/v1/receive
           - --remote-write-interval=30s
           - --remote-requests-count=1000000
-          - --value-interval=60
+          - --value-interval=3600
           - --series-interval=86400
           - --metric-interval=86400
-          - --const-label=tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
-          image: quay.io/observatorium/avalanche:master-2020-12-28-0c1c64c
+          - --remote-tenant-header=THANOS-TENANT
+          - --remote-tenant=0fc2b00e-201b-4c17-b9f2-19d91adc4fd2
+          image: quay.io/observatorium/avalanche:make-tenant-header-configurable-2021-10-07-0a2cbf5
           name: avalanche-remote-writer
 - apiVersion: v1
   kind: Service

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -371,7 +371,7 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
 
     local config = {
       name: 'avalanche-remote-writer',
-      image: 'quay.io/observatorium/avalanche:master-2020-12-28-0c1c64c',
+      image: 'quay.io/observatorium/avalanche:make-tenant-header-configurable-2021-10-07-0a2cbf5',
       commonLabels: {
         'app.kubernetes.io/component': 'avalanche',
         'app.kubernetes.io/name': 'avalanche-remote-writer',
@@ -407,10 +407,11 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
                 ],  // this is the internal cluster url of the thanos receive service
                 '--remote-write-interval=30s',  // how frequenetly to remote_write data
                 '--remote-requests-count=1000000',  // how many requests we make before exiting - make it a big number
-                '--value-interval=60',  // how often to update the metric values
+                '--value-interval=3600',  // how often to update the metric values
                 '--series-interval=86400',  // how often to create new series names
                 '--metric-interval=86400',  // how often to create new metric names
-                '--const-label=tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"',  // this is the id of our testing tenant
+                '--remote-tenant-header=THANOS-TENANT',  // this is tenant header to set in remote write requests
+                '--remote-tenant=0fc2b00e-201b-4c17-b9f2-19d91adc4fd2',  // this is tenant we will write data to
               ],
             }],
           },


### PR DESCRIPTION
Currently, our deployment of avalanche is not working as expected. This is because `Thanos Receive` does not respect `tenant_id`s supplied in metric label sets. Thought process [here](https://coreos.slack.com/archives/C026ZQSB468/p1633618569174300).

To fix this, we need to supply `THANOS-TENANT` in the `remote_write` request headers. I've made the changes and raised https://github.com/open-fresh/avalanche/pull/25 to make this configurable in the upstream.

However, since that repo was last updated last December, I've built the dockerfile locally and pushed it to the Observatorium quay [repo](https://quay.io/repository/observatorium/avalanche?tab=tags). We will switch the images if / when the upstream PR is merged.

Tested locally and things are working as expected.

Finally, I've updated the value interval from 60s to 1h. Random gauges changing every 60s is not representative of real-world users.

Signed-off-by: Ian Billett <ibillett@redhat.com>