### PR TITLE
update kafka hours federation rule

### DIFF
--- a/configuration/observatorium/metric-federation-rules.libsonnet
+++ b/configuration/observatorium/metric-federation-rules.libsonnet
@@ -7,9 +7,9 @@
           interval: '1m',
           rules: [
             {
-              record: 'kafka_id:strimzi_resource_state:group',
+              record: 'kafka_id:strimzi_resource_state:max_over_time1h',
               expr: |||
-                kafka_id:strimzi_resource_state:group
+                kafka_id:strimzi_resource_state:max_over_time1h
               |||,
             },
             {

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -11,10 +11,10 @@ objects:
         "name": "telemeter-kafka.rules"
         "rules":
         - "expr": |
-            kafka_id:strimzi_resource_state:group
+            kafka_id:strimzi_resource_state:max_over_time1h
           "labels":
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "kafka_id:strimzi_resource_state:group"
+          "record": "kafka_id:strimzi_resource_state:max_over_time1h"
         - "expr": |
             kafka_id:haproxy_server_bytes_in_total:rate1h_gibibytes
           "labels":


### PR DESCRIPTION
The `kafka_id:strimzi_resource_state:group` rule has been changed in our config to `kafka_id:strimzi_resource_state:max_over_time1h`. That change is [here](https://github.com/bf2fc6cc711aee1a0c2a/observability-resources-mk/pull/96). 

As a result of this [request](https://issues.redhat.com/browse/MGDSTRM-5707).