### PR TITLE
Fix Up Binary 404s

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -729,7 +729,7 @@ objects:
           - --log.level=debug
           - --endpoint-type=metrics
           - --queries-file=/etc/up/queries.yaml
-          - --endpoint-read=http://observatorium-thanos-query-frontend.${OBSERVATORIUM_METRICS_NAMESPACE}.svc:9090/api/v1/query
+          - --endpoint-read=http://observatorium-thanos-query-frontend.${OBSERVATORIUM_METRICS_NAMESPACE}.svc:9090
           image: quay.io/observatorium/up:master-2021-10-18-8943d73
           name: observatorium-up
           ports:

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -327,7 +327,7 @@ local memcached = (import 'github.com/observatorium/observatorium/configuration/
     image: 'quay.io/observatorium/up:' + cfg.version,
     replicas: 1,
     endpointType: 'metrics',
-    readEndpoint: 'http://%s.%s.svc:9090/api/v1/query' % [obs.thanos.queryFrontend.service.metadata.name, obs.config.namespaces.metrics],
+    readEndpoint: 'http://%s.%s.svc:9090' % [obs.thanos.queryFrontend.service.metadata.name, obs.config.namespaces.metrics],
     queryConfig: (import '../configuration/observatorium/queries.libsonnet'),
     serviceMonitor: true,
     resources: {


### PR DESCRIPTION
After we rolled out [this](https://github.com/rhobs/configuration/pull/88) PR today - the `up` binary logs are full of...

```
caller=level.go:63 ts=2021-11-01T19:02:58.732081262Z name=up level=info caller=main.go:249 component=query-reader msg="failed to execute specified query" type=query name=query-path-sli-1M-samples duration=0.00187121 warnings=v1.Warnings(nil) err="querying: client_error: client error: 404"
caller=level.go:63 ts=2021-11-01T19:02:58.832226318Z name=up level=debug caller=query.go:36 component=query-reader msg="running specified query" name=query-path-sli-10M-samples query="avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[10h])"
caller=level.go:63 ts=2021-11-01T19:02:58.834105535Z name=up level=info caller=main.go:249 component=query-reader msg="failed to execute specified query" type=query name=query-path-sli-10M-samples duration=0.001887927 warnings=v1.Warnings(nil) err="querying: client_error: client error: 404"
caller=level.go:63 ts=2021-11-01T19:02:58.934237652Z name=up level=debug caller=query.go:36 component=query-reader msg="running specified query" name=query-path-sli-100M-samples query="avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[100h])"
caller=level.go:63 ts=2021-11-01T19:02:58.936047222Z name=up level=info caller=main.go:249 component=query-reader msg="failed to execute specified query" type=query name=query-path-sli-100M-samples duration=0.00181404 warnings=v1.Warnings(nil) err="querying: client_error: client error: 404"
caller=level.go:63 ts=2021-11-01T19:02:59.136284482Z name=up level=debug caller=query.go:36 component=query-reader msg="running specified query" name=query-path-sli-1M-samples query="avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[1h])"
```

The isssue was that [this](https://github.com/observatorium/up/commit/6955e93d6a3b96cc9e152c5f283946db5cb57588#diff-67a6e36014be865053c43d38b2091bd2d3f17a91b117d97c0f5244cd7d71127dR224) PR appended `api/v1/query` to the `--read-endpoint` to give the same behaviour as the other endpoints,  since this path was already in the URLs it caused a flood of `404`s.

This PR removes `api/v1/query` from the specified endpoint to make the queries succeed.

Signed-off-by: Ian Billett <ibillett@redhat.com>