### PR TITLE
Fix observatorium-logs SLO dashboard

### DIFF
--- a/observability/grafana-obs-logs.jsonnet
+++ b/observability/grafana-obs-logs.jsonnet
@@ -42,7 +42,7 @@ local dashboards = {
   ],
   parameters: [
     { name: 'OBSERVATORIUM_API_DATASOURCE', value: 'telemeter-prod-01-prometheus' },
-    { name: 'OBSERVATORIUM_API_NAMESPACE', value: 'telemeter-production' },
+    { name: 'OBSERVATORIUM_API_NAMESPACE', value: 'observatorium-production' },
     { name: 'OBSERVATORIUM_LOGS_NAMESPACE', value: 'observatorium-logs-production' },
   ],
 }

--- a/resources/observability/grafana/observatorium-logs/grafana-dashboards-template.yaml
+++ b/resources/observability/grafana/observatorium-logs/grafana-dashboards-template.yaml
@@ -16417,6 +16417,6 @@ parameters:
 - name: OBSERVATORIUM_API_DATASOURCE
   value: telemeter-prod-01-prometheus
 - name: OBSERVATORIUM_API_NAMESPACE
-  value: telemeter-production
+  value: observatorium-production
 - name: OBSERVATORIUM_LOGS_NAMESPACE
   value: observatorium-logs-production


### PR DESCRIPTION
This PR provides a small fix for the default namespace of the observatorium-api used by the observatorium-logs SLO dashboard.