### PR TITLE
Name dashboard configmaps correctly

### DIFF
--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -471,7 +471,7 @@ function(instanceName, environment, dashboardName) {
   apiVersion: 'v1',
   kind: 'ConfigMap',
   metadata: {
-    name: 'grafana-dashboard-slo' + instanceName + '-' + environment,
+    name: 'grafana-dashboard-slo-' + instanceName + '-' + environment,
   },
   data: {
     'slo.json': std.manifestJson({

--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -471,7 +471,7 @@ function(instanceName, environment, dashboardName) {
   apiVersion: 'v1',
   kind: 'ConfigMap',
   metadata: {
-    name: 'grafana-dashboard-slo' + instance + '-' + environment,
+    name: 'grafana-dashboard-slo' + instanceName + '-' + environment,
   },
   data: {
     'slo.json': std.manifestJson({

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
@@ -1192,4 +1192,4 @@ metadata:
     grafana-folder: /grafana-dashboard-definitions/Observatorium
   labels:
     grafana_dashboard: "true"
-  name: grafana-dashboard-slomst-production
+  name: grafana-dashboard-slo-mst-production

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
@@ -1192,4 +1192,4 @@ metadata:
     grafana-folder: /grafana-dashboard-definitions/Observatorium
   labels:
     grafana_dashboard: "true"
-  name: 'grafana-dashboard-slo{"apiJob": "observatorium-observatorium-mst-api", "datasource": "telemeter-prod-01-prometheus", "upNamespace": "observatorium-mst-production"}-production'
+  name: grafana-dashboard-slomst-production

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
@@ -1192,4 +1192,4 @@ metadata:
     grafana-folder: /grafana-dashboard-definitions/Observatorium
   labels:
     grafana_dashboard: "true"
-  name: grafana-dashboard-slomst-stage
+  name: grafana-dashboard-slo-mst-stage

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
@@ -1192,4 +1192,4 @@ metadata:
     grafana-folder: /grafana-dashboard-definitions/Observatorium
   labels:
     grafana_dashboard: "true"
-  name: 'grafana-dashboard-slo{"apiJob": "observatorium-observatorium-mst-api", "datasource": "app-sre-stage-01-prometheus", "upNamespace": "observatorium-stage"}-stage'
+  name: grafana-dashboard-slomst-stage

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
@@ -1192,4 +1192,4 @@ metadata:
     grafana-folder: /grafana-dashboard-definitions/Observatorium
   labels:
     grafana_dashboard: "true"
-  name: 'grafana-dashboard-slo{"apiJob": "observatorium-observatorium-api", "datasource": "telemeter-prod-01-prometheus", "upNamespace": "observatorium-production"}-production'
+  name: grafana-dashboard-slotelemeter-production

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
@@ -1192,4 +1192,4 @@ metadata:
     grafana-folder: /grafana-dashboard-definitions/Observatorium
   labels:
     grafana_dashboard: "true"
-  name: grafana-dashboard-slotelemeter-production
+  name: grafana-dashboard-slo-telemeter-production

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
@@ -1192,4 +1192,4 @@ metadata:
     grafana-folder: /grafana-dashboard-definitions/Observatorium
   labels:
     grafana_dashboard: "true"
-  name: grafana-dashboard-slotelemeter-stage
+  name: grafana-dashboard-slo-telemeter-stage

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
@@ -1192,4 +1192,4 @@ metadata:
     grafana-folder: /grafana-dashboard-definitions/Observatorium
   labels:
     grafana_dashboard: "true"
-  name: 'grafana-dashboard-slo{"apiJob": "observatorium-observatorium-api", "datasource": "app-sre-stage-01-prometheus", "upNamespace": "observatorium-stage"}-stage'
+  name: grafana-dashboard-slotelemeter-stage


### PR DESCRIPTION
Dashboards are currently [failing](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/28593) to deploy because the configmap naming is borked. This fixes that.

Signed-off-by: Ian Billett <ibillett@redhat.com>