### PR TITLE
lower the severity of the alert

### DIFF
--- a/docs/sop/observatorium.md
+++ b/docs/sop/observatorium.md
@@ -101,7 +101,7 @@ Users of RHOBS are not able to access API endpoints for either reading, writing 
 
 ### Severity
 
-`critical`
+`medium`
 
 ### Access Required
 

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -606,7 +606,7 @@ local renderAlerts(name, environment, mixin) = {
                 (sum by (route) (rate(haproxy_backend_http_responses_total{route=~"observatorium.*|telemeter.*|infogw.*", code="5xx"} [5m])) / sum by (route) (rate(haproxy_backend_http_responses_total{route=~"observatorium.*|telemeter.*|infogw.*"}[5m]))) * 100 > 25
               |||,
               labels: {
-                severity: 'critical',
+                severity: 'warning',
               },
             },
           ],

--- a/resources/observability/prometheusrules/observatorium-http-traffic-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-http-traffic-production.prometheusrules.yaml
@@ -20,4 +20,4 @@ spec:
         (sum by (route) (rate(haproxy_backend_http_responses_total{route=~"observatorium.*|telemeter.*|infogw.*", code="5xx"} [5m])) / sum by (route) (rate(haproxy_backend_http_responses_total{route=~"observatorium.*|telemeter.*|infogw.*"}[5m]))) * 100 > 25
       labels:
         service: telemeter
-        severity: critical
+        severity: medium

--- a/resources/observability/prometheusrules/observatorium-http-traffic-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-http-traffic-stage.prometheusrules.yaml
@@ -20,4 +20,4 @@ spec:
         (sum by (route) (rate(haproxy_backend_http_responses_total{route=~"observatorium.*|telemeter.*|infogw.*", code="5xx"} [5m])) / sum by (route) (rate(haproxy_backend_http_responses_total{route=~"observatorium.*|telemeter.*|infogw.*"}[5m]))) * 100 > 25
       labels:
         service: telemeter
-        severity: high
+        severity: medium


### PR DESCRIPTION
As requested by SRE team, This PR lowers the severity of the `ObservatoriumHttpTrafficErrorRateHigh` alert.