### PR TITLE
Memcached: Add service accounts with pull secret

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -27,6 +27,18 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  imagePullSecrets:
+  - name: quay.io
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/component: chunk-cache
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+    name: observatorium-loki-chunk-cache
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
@@ -127,6 +139,18 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  imagePullSecrets:
+  - name: quay.io
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/component: index-query-cache
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+    name: observatorium-loki-index-query-cache
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
@@ -227,6 +251,18 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: loki
       app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  imagePullSecrets:
+  - name: quay.io
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/component: results-cache
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+    name: observatorium-loki-results-cache
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1617,6 +1617,8 @@ objects:
       app.kubernetes.io/name: memcached
       app.kubernetes.io/part-of: observatorium
 - apiVersion: v1
+  imagePullSecrets:
+  - name: quay.io
   kind: ServiceAccount
   metadata:
     labels:
@@ -1732,6 +1734,8 @@ objects:
       app.kubernetes.io/name: memcached
       app.kubernetes.io/part-of: observatorium
 - apiVersion: v1
+  imagePullSecrets:
+  - name: quay.io
   kind: ServiceAccount
   metadata:
     labels:

--- a/services/components/loki-caches.libsonnet
+++ b/services/components/loki-caches.libsonnet
@@ -104,7 +104,11 @@ function(params) {
         },
       },
     },
-  }),
+  }) {
+    serviceAccount+: {
+      imagePullSecrets+: [{ name: 'quay.io' }],
+    },
+  },
 
   indexQueryCache:: memcached({
     name: lc.config.name + '-' + lc.config.commonLabels['app.kubernetes.io/name'] + '-index-query-cache',
@@ -131,7 +135,11 @@ function(params) {
         },
       },
     },
-  }),
+  }) {
+    serviceAccount+: {
+      imagePullSecrets+: [{ name: 'quay.io' }],
+    },
+  },
 
   resultsCache:: memcached({
     name: lc.config.name + '-' + lc.config.commonLabels['app.kubernetes.io/name'] + '-results-cache',
@@ -158,7 +166,11 @@ function(params) {
       },
     },
 
-  }),
+  }) {
+    serviceAccount+: {
+      imagePullSecrets+: [{ name: 'quay.io' }],
+    },
+  },
 
   manifests::
     {} +
@@ -166,15 +178,18 @@ function(params) {
        'chunk-cache-service': lc.chunkCache.service,
        'chunk-cache-statefulset': lc.chunkCache.statefulSet,
        'chunk-cache-service-monitor': lc.chunkCache.serviceMonitor,
+       'chunk-cache-service-account': lc.chunkCache.serviceAccount,
      } else {}) +
     (if std.objectHas(lc.config.components, 'indexQueryCache') && lc.config.components.indexQueryCache.replicas > 0 then {
        'index-query-cache-service': lc.indexQueryCache.service,
        'index-query-cache-statefulset': lc.indexQueryCache.statefulSet,
        'index-query-cache-service-monitor': lc.indexQueryCache.serviceMonitor,
+       'index-query-cache-service-account': lc.indexQueryCache.serviceAccount,
      } else {}) +
     (if std.objectHas(lc.config.components, 'resultsCache') && lc.config.components.resultsCache.replicas > 0 then {
        'results-cache-service': lc.resultsCache.service,
        'results-cache-statefulset': lc.resultsCache.statefulSet,
        'results-cache-service-monitor': lc.resultsCache.serviceMonitor,
+       'results-cache-service-account': lc.resultsCache.serviceAccount,
      } else {}),
 }

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -357,7 +357,11 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           },
         },
       },
-    }),
+    }) {
+      serviceAccount+: {
+        imagePullSecrets+: [{ name: 'quay.io' }],
+      },
+    },
 
     storeBucketCache:: memcached({
       local cfg = self,
@@ -402,7 +406,11 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           },
         },
       },
-    }),
+    }) {
+      serviceAccount+: {
+        imagePullSecrets+: [{ name: 'quay.io' }],
+      },
+    },
 
     query:: t.query(thanosSharedConfig {
       name: 'observatorium-thanos-query',


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

All our service accounts attached to memcached will need to be able to pull a private image from the Quay repository. This follows PR https://github.com/rhobs/configuration/pull/89 and adds the service accounts for our remaining memcached deployments in `observatorium-metrics` and `observatorium-logs` templates.