### PR TITLE
Update allow list with nto_custom_profiles:count

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -76,6 +76,7 @@
   "{__name__=\"node_uname_info\"}",
   "{__name__=\"noobaa_accounts_num\"}",
   "{__name__=\"noobaa_total_usage\"}",
+  "{__name__=\"nto_custom_profiles:count\"}",
   "{__name__=\"olm_resolution_duration_seconds\"}",
   "{__name__=\"openshift:build_by_strategy:sum\"}",
   "{__name__=\"openshift:cpu_usage_cores:sum\"}",

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -170,6 +170,7 @@ objects:
           - --whitelist={__name__="node_uname_info"}
           - --whitelist={__name__="noobaa_accounts_num"}
           - --whitelist={__name__="noobaa_total_usage"}
+          - --whitelist={__name__="nto_custom_profiles:count"}
           - --whitelist={__name__="olm_resolution_duration_seconds"}
           - --whitelist={__name__="openshift:build_by_strategy:sum"}
           - --whitelist={__name__="openshift:cpu_usage_cores:sum"}
@@ -359,6 +360,7 @@ objects:
           - --whitelist={__name__="node_uname_info"}
           - --whitelist={__name__="noobaa_accounts_num"}
           - --whitelist={__name__="noobaa_total_usage"}
+          - --whitelist={__name__="nto_custom_profiles:count"}
           - --whitelist={__name__="olm_resolution_duration_seconds"}
           - --whitelist={__name__="openshift:build_by_strategy:sum"}
           - --whitelist={__name__="openshift:cpu_usage_cores:sum"}


### PR DESCRIPTION
Allow list new metric added in https://github.com/openshift/cluster-monitoring-operator/pull/1484.

Note:
Running `make all` also touched several other files (removing resources/observability/*prometheusrule.yaml). I left these changes out, please let me know if these should be added back in.