### PR TITLE
Observatorium Metrics: Provide extra store(s) via file SD

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -234,6 +234,17 @@ objects:
           requests:
             storage: ${THANOS_COMPACTOR_PVC_REQUEST}
         storageClassName: ${STORAGE_CLASS}
+- apiVersion: v1
+  data:
+    file_sd.yaml: '- targets: ${THANOS_QUERIER_FILE_SD_TARGETS}'
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/part-of: observatorium
+    name: thanos-query-file-sd
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -292,7 +303,6 @@ objects:
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-1.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-2.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-receive-default.${NAMESPACE}.svc.cluster.local
-          - --store=dnssrv+_grpc._tcp.observatorium-thanos-metric-federation-rule.${NAMESPACE}.svc.cluster.local
           - --web.prefix-header=X-Forwarded-Prefix
           - --query.timeout=15m
           - --query.lookback-delta=15m
@@ -303,6 +313,7 @@ objects:
               "service_name": "thanos-query"
             "type": "JAEGER"
           - --query.auto-downsampling
+          - --store.sd-files=/etc/thanos/sd/file_sd.yaml
           env:
           - name: HOST_IP_ADDRESS
             valueFrom:
@@ -339,6 +350,9 @@ objects:
               cpu: ${THANOS_QUERIER_CPU_REQUEST}
               memory: ${THANOS_QUERIER_MEMORY_REQUEST}
           terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /etc/thanos/sd
+            name: file-sd
         - args:
           - -provider=openshift
           - -https-address=:9091
@@ -414,6 +428,9 @@ objects:
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
         volumes:
+        - configMap:
+            name: thanos-query-file-sd
+          name: file-sd
         - name: query-tls
           secret:
             secretName: query-tls
@@ -2694,6 +2711,8 @@ parameters:
   value: "3"
 - name: THANOS_QUERIER_SVC_URL
   value: http://thanos-querier.observatorium.svc:9090
+- name: THANOS_QUERIER_FILE_SD_TARGETS
+  value: '[]'
 - name: THANOS_QUERY_FRONTEND_CPU_LIMIT
   value: "1"
 - name: THANOS_QUERY_FRONTEND_CPU_REQUEST

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -60,6 +60,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_QUERIER_MEMORY_REQUEST', value: '256Mi' },
     { name: 'THANOS_QUERIER_REPLICAS', value: '3' },
     { name: 'THANOS_QUERIER_SVC_URL', value: 'http://thanos-querier.observatorium.svc:9090' },
+    { name: 'THANOS_QUERIER_FILE_SD_TARGETS', value: '[]' },
     { name: 'THANOS_QUERY_FRONTEND_CPU_LIMIT', value: '1' },
     { name: 'THANOS_QUERY_FRONTEND_CPU_REQUEST', value: '100m' },
     { name: 'THANOS_QUERY_FRONTEND_LOG_QUERIES_LONGER_THAN', value: '5s' },


### PR DESCRIPTION
We currently use the `observatorium-template` instance for both our "core" Observatorium instance and the MST Observatorium instance. However, there is an important difference between the instances, introduced recently due to the metric federation ruler change (https://github.com/rhobs/configuration/pull/56) - this ruler exists only in the "core" instance and not in the MST instance.

Trying to pass this ruler address to querier in the MST instance is causing a repeated error in logs:
```
level=error ts=2021-11-24T14:37:54.232621974Z caller=resolver.go:99 msg="failed to lookup SRV records" host=_grpc._tcp.observatorium-thanos-metric-federation-rule.observatorium-mst-stage.svc.cluster.local err="no such host"
```
This is less than ideal since the querier tries to resolve the non-existing address roughly every 30 seconds.

Since we're unable to differentiate stores between the instance with templating, the workaround here is to provide the extra store(s) via file SD. The change means:
- Creating and mounting new config map volume with SD file in YAML format
- Passing the `store.sd-files` flag to querier
- The content of the file can be dynamically changed with a parameter (`THANOS_QUERIER_FILE_SD_TARGETS`), 
- By default, the targets array in the SD file is empty, meaning no additional stores are added
- Keep stores that are shared between instances in the `store` flags