### PR TITLE
Add Thanos Query Frontend dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install all dependencies:
 jb install
 ```
 
-To update a dependency:
+To update a dependency, normally the process would be:
 
 ```console
 # Updates `kube-thanos` to master and sets the new hash in `jsonnetfile.lock.json`.
@@ -25,6 +25,9 @@ jb update https://github.com/thanos-io/kube-thanos/jsonnet/kube-thanos@main
 # Update all dependancies to master and sets the new hashes in `jsonnetfile.lock.json`.
 jb update
 ```
+
+Currently `jb update` does not seem to work properly - see https://github.com/jsonnet-bundler/jsonnet-bundler/issues/142.
+As a workaround, try following this workflow: https://github.com/openshift/cluster-monitoring-operator/blob/master/Documentation/development.md#updating-individual-vendored-jsonnet-code
 
 ## Grafana dashboards
 

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -182,8 +182,8 @@
           "subdir": "mixin"
         }
       },
-      "version": "30162377d15ef0b8b7c71081f22ceb7ab3ef0285",
-      "sum": "xfxEUIaq5JaN0aRDm7+3+26605Ye9UI7dm/7olEH3+U=",
+      "version": "4d7f710f22dce2900c7f5cc3a5d4c1b7df96706f",
+      "sum": "1Y1cPIeoPg2nCAEhKPCt8bAGuwuOP2eZ3kVF432mlMA=",
       "name": "thanos-mixin"
     }
   ],

--- a/observability/grafana.jsonnet
+++ b/observability/grafana.jsonnet
@@ -1,6 +1,7 @@
 local config = (import 'config.libsonnet');
 
 local thanos =
+  (import 'github.com/thanos-io/thanos/mixin/dashboards/query_frontend.libsonnet') +
   (import 'github.com/thanos-io/thanos/mixin/dashboards/query.libsonnet') +
   (import 'github.com/thanos-io/thanos/mixin/dashboards/store.libsonnet') +
   (import 'github.com/thanos-io/thanos/mixin/dashboards/receive.libsonnet') +

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-compact.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-compact.configmap.yaml
@@ -59,7 +59,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, group) (rate(thanos_compact_group_compactions_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, group) (rate(thanos_compact_group_compactions_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "compaction {{job}} {{group}}",
@@ -146,7 +146,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_compact_group_compactions_failures_total{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_compact_group_compactions_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_compact_group_compactions_failures_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_compact_group_compactions_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -244,7 +244,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, group) (rate(thanos_compact_downsample_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, group) (rate(thanos_compact_downsample_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "downsample {{job}} {{group}}",
@@ -331,7 +331,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_compact_downsample_failed_total{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_compact_downsample_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_compact_downsample_failed_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_compact_downsample_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -429,7 +429,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_compact_garbage_collection_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_compact_garbage_collection_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "garbage collection {{job}}",
@@ -516,7 +516,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_compact_garbage_collection_failures_total{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_compact_garbage_collection_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_compact_garbage_collection_failures_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_compact_garbage_collection_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -619,7 +619,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -629,7 +629,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -639,7 +639,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -740,7 +740,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_compact_blocks_cleaned_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_compact_blocks_cleaned_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Blocks cleanup {{job}}",
@@ -827,7 +827,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_compact_block_cleanup_failures_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_compact_block_cleanup_failures_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Blocks cleanup failures {{job}}",
@@ -914,7 +914,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_compact_blocks_marked_for_deletion_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_compact_blocks_marked_for_deletion_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Blocks marked {{job}}",
@@ -1013,7 +1013,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_blocks_meta_syncs_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_blocks_meta_syncs_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "sync {{job}}",
@@ -1100,7 +1100,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_blocks_meta_sync_failures_total{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_blocks_meta_syncs_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_blocks_meta_sync_failures_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_blocks_meta_syncs_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -1203,7 +1203,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -1213,7 +1213,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -1223,7 +1223,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -1324,7 +1324,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{job}} {{operation}}",
@@ -1411,7 +1411,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_objstore_bucket_operation_failures_total{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_objstore_bucket_operation_failures_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -1514,7 +1514,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -1524,7 +1524,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -1534,7 +1534,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -1634,7 +1634,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc all {{instance}}",
@@ -1642,7 +1642,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc heap {{instance}}",
@@ -1650,7 +1650,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", job=\"$job\"}[30s])",
+                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", job=~\"$job\"}[30s])",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc rate all {{instance}}",
@@ -1658,7 +1658,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}[30s])",
+                  "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}[30s])",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc rate heap {{instance}}",
@@ -1666,7 +1666,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "inuse heap {{instance}}",
@@ -1674,7 +1674,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "inuse stack {{instance}}",
@@ -1760,7 +1760,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_goroutines{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_goroutines{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{instance}}",
@@ -1846,7 +1846,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_gc_duration_seconds{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_gc_duration_seconds{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{quantile}} {{instance}}",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-query_frontend.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-query_frontend.configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  query.json: |-
+  query_frontend.json: |-
     {
       "annotations": {
         "list": [
@@ -28,7 +28,7 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": "$datasource",
-              "description": "Shows rate of requests against /query for the given time.",
+              "description": "Shows rate of requests against Query Frontend for the given time.",
               "fill": 10,
               "id": 1,
               "legend": {
@@ -73,12 +73,12 @@ data:
                 }
               ],
               "spaceLength": 10,
-              "span": 4,
+              "span": 3,
               "stack": true,
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, handler, code) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"query\"}[$interval]))",
+                  "expr": "sum by (namespace,  job, handler, code) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"query-frontend\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}} {{job}} {{handler}} {{code}}",
@@ -90,7 +90,7 @@ data:
               ],
               "timeFrom": null,
               "timeShift": null,
-              "title": "Rate",
+              "title": "Rate of requests",
               "tooltip": {
                 "shared": false,
                 "sort": 0,
@@ -127,239 +127,15 @@ data:
             },
             {
               "aliasColors": {
-                "error": "#E24D42"
+
               },
               "bars": false,
               "dashLength": 10,
               "dashes": false,
               "datasource": "$datasource",
-              "description": "Shows ratio of errors compared to the the total number of handled requests against /query.",
+              "description": "Shows rate of queries passing through Query Frontend",
               "fill": 10,
               "id": 2,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 0,
-              "links": [
-
-              ],
-              "nullPointMode": "null as zero",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [
-
-              ],
-              "spaceLength": 10,
-              "span": 4,
-              "stack": true,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"query\",code=~\"5..\"}[$interval])) / sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"query\"}[$interval]))",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "error",
-                  "step": 10
-                }
-              ],
-              "thresholds": [
-
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Errors",
-              "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [
-
-                ]
-              },
-              "yaxes": [
-                {
-                  "format": "percentunit",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ]
-            },
-            {
-              "aliasColors": {
-
-              },
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "$datasource",
-              "description": "Shows how long has it taken to handle requests in quantiles.",
-              "fill": 1,
-              "id": 3,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [
-
-              ],
-              "nullPointMode": "null as zero",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [
-                {
-                  "alias": "p99",
-                  "color": "#FA6400",
-                  "fill": 1,
-                  "fillGradient": 1
-                },
-                {
-                  "alias": "p90",
-                  "color": "#E0B400",
-                  "fill": 1,
-                  "fillGradient": 1
-                },
-                {
-                  "alias": "p50",
-                  "color": "#37872D",
-                  "fill": 10,
-                  "fillGradient": 0
-                }
-              ],
-              "spaceLength": 10,
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "p50 {{namespace}} {{job}}",
-                  "logBase": 10,
-                  "max": null,
-                  "min": null,
-                  "step": 10
-                },
-                {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "p90 {{namespace}} {{job}}",
-                  "logBase": 10,
-                  "max": null,
-                  "min": null,
-                  "step": 10
-                },
-                {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "p99 {{namespace}} {{job}}",
-                  "logBase": 10,
-                  "max": null,
-                  "min": null,
-                  "step": 10
-                }
-              ],
-              "thresholds": [
-
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Duration",
-              "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [
-
-                ]
-              },
-              "yaxes": [
-                {
-                  "format": "s",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ]
-            }
-          ],
-          "repeat": null,
-          "repeatIteration": null,
-          "repeatRowId": null,
-          "showTitle": true,
-          "title": "Instant Query API",
-          "titleSize": "h6"
-        },
-        {
-          "collapse": false,
-          "height": "250px",
-          "panels": [
-            {
-              "aliasColors": {
-
-              },
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "$datasource",
-              "description": "Shows rate of requests against /query_range for the given time range.",
-              "fill": 10,
-              "id": 4,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -402,12 +178,12 @@ data:
                 }
               ],
               "spaceLength": 10,
-              "span": 4,
+              "span": 3,
               "stack": true,
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, handler, code) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"query_range\"}[$interval]))",
+                  "expr": "sum by (namespace,  job, handler, code) (rate(thanos_query_frontend_queries_total{namespace=\"$namespace\", job=~\"$job\", op=\"query_range\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}} {{job}} {{handler}} {{code}}",
@@ -419,7 +195,7 @@ data:
               ],
               "timeFrom": null,
               "timeShift": null,
-              "title": "Rate",
+              "title": "Rate of queries",
               "tooltip": {
                 "shared": false,
                 "sort": 0,
@@ -462,9 +238,9 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": "$datasource",
-              "description": "Shows ratio of errors compared to the the total number of handled requests against /query_range.",
+              "description": "Shows ratio of errors compared to the the total number of handled requests against Query Frontend.",
               "fill": 10,
-              "id": 5,
+              "id": 3,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -488,12 +264,12 @@ data:
 
               ],
               "spaceLength": 10,
-              "span": 4,
+              "span": 3,
               "stack": true,
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"query_range\",code=~\"5..\"}[$interval])) / sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"query_range\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"query-frontend\",code=~\"5..\"}[$interval])) / sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"query-frontend\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -550,7 +326,7 @@ data:
               "datasource": "$datasource",
               "description": "Shows how long has it taken to handle requests in quantiles.",
               "fill": 1,
-              "id": 6,
+              "id": 4,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -591,12 +367,12 @@ data:
                 }
               ],
               "spaceLength": 10,
-              "span": 4,
+              "span": 3,
               "stack": false,
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"query-frontend\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -606,7 +382,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"query-frontend\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -616,7 +392,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"query-frontend\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -671,7 +447,7 @@ data:
           "repeatIteration": null,
           "repeatRowId": null,
           "showTitle": true,
-          "title": "Range Query API",
+          "title": "Query Frontend API",
           "titleSize": "h6"
         },
         {
@@ -686,9 +462,9 @@ data:
               "dashLength": 10,
               "dashes": false,
               "datasource": "$datasource",
-              "description": "Shows rate of handled Unary gRPC requests from other queriers.",
+              "description": "Show rate of cache requests.",
               "fill": 10,
-              "id": 7,
+              "id": 5,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -709,89 +485,19 @@ data:
               "points": false,
               "renderer": "flot",
               "seriesOverrides": [
-                {
-                  "alias": "/Aborted/",
-                  "color": "#EAB839"
-                },
-                {
-                  "alias": "/AlreadyExists/",
-                  "color": "#37872D"
-                },
-                {
-                  "alias": "/FailedPrecondition/",
-                  "color": "#E0B400"
-                },
-                {
-                  "alias": "/Unimplemented/",
-                  "color": "#E0B400"
-                },
-                {
-                  "alias": "/InvalidArgument/",
-                  "color": "#1F60C4"
-                },
-                {
-                  "alias": "/NotFound/",
-                  "color": "#1F60C4"
-                },
-                {
-                  "alias": "/PermissionDenied/",
-                  "color": "#1F60C4"
-                },
-                {
-                  "alias": "/Unauthenticated/",
-                  "color": "#1F60C4"
-                },
-                {
-                  "alias": "/Canceled/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/DataLoss/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/DeadlineExceeded/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/Internal/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/OutOfRange/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/ResourceExhausted/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/Unavailable/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/Unknown/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/OK/",
-                  "color": "#37872D"
-                },
-                {
-                  "alias": "error",
-                  "color": "#C4162A"
-                }
+
               ],
               "spaceLength": 10,
-              "span": 4,
+              "span": 3,
               "stack": true,
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_client_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
+                  "expr": "sum by (namespace, job, tripperware) (rate(cortex_cache_request_duration_seconds_count{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
-                  "legendFormat": "{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}",
+                  "legendFormat": "{{job}} {{tripperware}}",
+                  "legendLink": null,
                   "step": 10
                 }
               ],
@@ -800,7 +506,7 @@ data:
               ],
               "timeFrom": null,
               "timeShift": null,
-              "title": "Rate",
+              "title": "Requests",
               "tooltip": {
                 "shared": false,
                 "sort": 0,
@@ -837,13 +543,195 @@ data:
             },
             {
               "aliasColors": {
-                "error": "#E24D42"
+
               },
               "bars": false,
               "dashLength": 10,
               "dashes": false,
               "datasource": "$datasource",
-              "description": "Shows ratio of errors compared to the the total number of handled requests from other queriers.",
+              "description": "Show rate of Querier cache gets vs misses.",
+              "fill": 10,
+              "id": 6,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 0,
+              "links": [
+
+              ],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+
+              ],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": true,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (namespace, job, tripperware) (rate(querier_cache_gets_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Cache gets - {{job}} {{tripperware}}",
+                  "legendLink": null,
+                  "step": 10
+                },
+                {
+                  "expr": "sum by (namespace, job, tripperware) (rate(querier_cache_misses_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "Cache misses - {{job}} {{tripperware}}",
+                  "legendLink": null,
+                  "step": 10
+                }
+              ],
+              "thresholds": [
+
+              ],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Querier cache gets vs misses",
+              "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+
+                ]
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": 0,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {
+
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$datasource",
+              "description": "Shows rate of cortex fetched keys.",
+              "fill": 10,
+              "id": 7,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 0,
+              "links": [
+
+              ],
+              "nullPointMode": "null as zero",
+              "percentage": false,
+              "pointradius": 5,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [
+
+              ],
+              "spaceLength": 10,
+              "span": 3,
+              "stack": true,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "sum by (namespace, job, tripperware) (rate(cortex_cache_fetched_keys{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
+                  "format": "time_series",
+                  "intervalFactor": 2,
+                  "legendFormat": "{{job}} {{tripperware}}",
+                  "legendLink": null,
+                  "step": 10
+                }
+              ],
+              "thresholds": [
+
+              ],
+              "timeFrom": null,
+              "timeShift": null,
+              "title": "Cortex fetched keys",
+              "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [
+
+                ]
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": 0,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": false
+                }
+              ]
+            },
+            {
+              "aliasColors": {
+
+              },
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "$datasource",
+              "description": "Shows rate of cortex cache hits.",
               "fill": 10,
               "id": 8,
               "legend": {
@@ -869,620 +757,15 @@ data:
 
               ],
               "spaceLength": 10,
-              "span": 4,
+              "span": 3,
               "stack": true,
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval])) / sum by (namespace, job) (rate(grpc_client_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
+                  "expr": "sum by (namespace, job, tripperware) (rate(cortex_cache_hits{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
-                  "legendFormat": "error",
-                  "step": 10
-                }
-              ],
-              "thresholds": [
-
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Errors",
-              "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [
-
-                ]
-              },
-              "yaxes": [
-                {
-                  "format": "percentunit",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ]
-            },
-            {
-              "aliasColors": {
-
-              },
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "$datasource",
-              "description": "Shows how long has it taken to handle requests from other queriers, in quantiles.",
-              "fill": 1,
-              "id": 9,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [
-
-              ],
-              "nullPointMode": "null as zero",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [
-                {
-                  "alias": "p99",
-                  "color": "#FA6400",
-                  "fill": 1,
-                  "fillGradient": 1
-                },
-                {
-                  "alias": "p90",
-                  "color": "#E0B400",
-                  "fill": 1,
-                  "fillGradient": 1
-                },
-                {
-                  "alias": "p50",
-                  "color": "#37872D",
-                  "fill": 10,
-                  "fillGradient": 0
-                }
-              ],
-              "spaceLength": 10,
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_client_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "p50 {{namespace}} {{job}}",
-                  "logBase": 10,
-                  "max": null,
-                  "min": null,
-                  "step": 10
-                },
-                {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_client_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "p90 {{namespace}} {{job}}",
-                  "logBase": 10,
-                  "max": null,
-                  "min": null,
-                  "step": 10
-                },
-                {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_client_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "p99 {{namespace}} {{job}}",
-                  "logBase": 10,
-                  "max": null,
-                  "min": null,
-                  "step": 10
-                }
-              ],
-              "thresholds": [
-
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Duration",
-              "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [
-
-                ]
-              },
-              "yaxes": [
-                {
-                  "format": "s",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ]
-            }
-          ],
-          "repeat": null,
-          "repeatIteration": null,
-          "repeatRowId": null,
-          "showTitle": true,
-          "title": "gRPC (Unary)",
-          "titleSize": "h6"
-        },
-        {
-          "collapse": false,
-          "height": "250px",
-          "panels": [
-            {
-              "aliasColors": {
-
-              },
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "$datasource",
-              "description": "Shows rate of handled Streamed gRPC requests from other queriers.",
-              "fill": 10,
-              "id": 10,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 0,
-              "links": [
-
-              ],
-              "nullPointMode": "null as zero",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [
-                {
-                  "alias": "/Aborted/",
-                  "color": "#EAB839"
-                },
-                {
-                  "alias": "/AlreadyExists/",
-                  "color": "#37872D"
-                },
-                {
-                  "alias": "/FailedPrecondition/",
-                  "color": "#E0B400"
-                },
-                {
-                  "alias": "/Unimplemented/",
-                  "color": "#E0B400"
-                },
-                {
-                  "alias": "/InvalidArgument/",
-                  "color": "#1F60C4"
-                },
-                {
-                  "alias": "/NotFound/",
-                  "color": "#1F60C4"
-                },
-                {
-                  "alias": "/PermissionDenied/",
-                  "color": "#1F60C4"
-                },
-                {
-                  "alias": "/Unauthenticated/",
-                  "color": "#1F60C4"
-                },
-                {
-                  "alias": "/Canceled/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/DataLoss/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/DeadlineExceeded/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/Internal/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/OutOfRange/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/ResourceExhausted/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/Unavailable/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/Unknown/",
-                  "color": "#C4162A"
-                },
-                {
-                  "alias": "/OK/",
-                  "color": "#37872D"
-                },
-                {
-                  "alias": "error",
-                  "color": "#C4162A"
-                }
-              ],
-              "spaceLength": 10,
-              "span": 4,
-              "stack": true,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_client_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}",
-                  "step": 10
-                }
-              ],
-              "thresholds": [
-
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Rate",
-              "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [
-
-                ]
-              },
-              "yaxes": [
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ]
-            },
-            {
-              "aliasColors": {
-                "error": "#E24D42"
-              },
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "$datasource",
-              "description": "Shows ratio of errors compared to the the total number of handled requests from other queriers.",
-              "fill": 10,
-              "id": 11,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 0,
-              "links": [
-
-              ],
-              "nullPointMode": "null as zero",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [
-
-              ],
-              "spaceLength": 10,
-              "span": 4,
-              "stack": true,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by (namespace, job) (rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (namespace, job) (rate(grpc_client_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "error",
-                  "step": 10
-                }
-              ],
-              "thresholds": [
-
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Errors",
-              "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [
-
-                ]
-              },
-              "yaxes": [
-                {
-                  "format": "percentunit",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ]
-            },
-            {
-              "aliasColors": {
-
-              },
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "$datasource",
-              "description": "Shows how long has it taken to handle requests from other queriers, in quantiles",
-              "fill": 1,
-              "id": 12,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [
-
-              ],
-              "nullPointMode": "null as zero",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [
-                {
-                  "alias": "p99",
-                  "color": "#FA6400",
-                  "fill": 1,
-                  "fillGradient": 1
-                },
-                {
-                  "alias": "p90",
-                  "color": "#E0B400",
-                  "fill": 1,
-                  "fillGradient": 1
-                },
-                {
-                  "alias": "p50",
-                  "color": "#37872D",
-                  "fill": 10,
-                  "fillGradient": 0
-                }
-              ],
-              "spaceLength": 10,
-              "span": 4,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_client_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "p50 {{namespace}} {{job}}",
-                  "logBase": 10,
-                  "max": null,
-                  "min": null,
-                  "step": 10
-                },
-                {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_client_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "p90 {{namespace}} {{job}}",
-                  "logBase": 10,
-                  "max": null,
-                  "min": null,
-                  "step": 10
-                },
-                {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_client_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "p99 {{namespace}} {{job}}",
-                  "logBase": 10,
-                  "max": null,
-                  "min": null,
-                  "step": 10
-                }
-              ],
-              "thresholds": [
-
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Duration",
-              "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [
-
-                ]
-              },
-              "yaxes": [
-                {
-                  "format": "s",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ]
-            }
-          ],
-          "repeat": null,
-          "repeatIteration": null,
-          "repeatRowId": null,
-          "showTitle": true,
-          "title": "gRPC (Stream)",
-          "titleSize": "h6"
-        },
-        {
-          "collapse": false,
-          "height": "250px",
-          "panels": [
-            {
-              "aliasColors": {
-
-              },
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "$datasource",
-              "description": "Shows rate of DNS lookups to discover stores.",
-              "fill": 1,
-              "id": 13,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 1,
-              "links": [
-
-              ],
-              "nullPointMode": "null as zero",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [
-
-              ],
-              "spaceLength": 10,
-              "span": 6,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "lookups {{job}}",
+                  "legendFormat": "{{job}} {{tripperware}}",
                   "legendLink": null,
                   "step": 10
                 }
@@ -1492,7 +775,7 @@ data:
               ],
               "timeFrom": null,
               "timeShift": null,
-              "title": "Rate",
+              "title": "Cortex cache hits",
               "tooltip": {
                 "shared": false,
                 "sort": 0,
@@ -1511,92 +794,6 @@ data:
               "yaxes": [
                 {
                   "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": 0,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ]
-            },
-            {
-              "aliasColors": {
-                "error": "#E24D42"
-              },
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": "$datasource",
-              "description": "Shows ratio of failures compared to the the total number of executed DNS lookups.",
-              "fill": 10,
-              "id": 14,
-              "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-              },
-              "lines": true,
-              "linewidth": 0,
-              "links": [
-
-              ],
-              "nullPointMode": "null as zero",
-              "percentage": false,
-              "pointradius": 5,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [
-
-              ],
-              "spaceLength": 10,
-              "span": 6,
-              "stack": true,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by (namespace, job) (rate(thanos_query_store_apis_dns_failures_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
-                  "format": "time_series",
-                  "intervalFactor": 2,
-                  "legendFormat": "error",
-                  "step": 10
-                }
-              ],
-              "thresholds": [
-
-              ],
-              "timeFrom": null,
-              "timeShift": null,
-              "title": "Errors",
-              "tooltip": {
-                "shared": false,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [
-
-                ]
-              },
-              "yaxes": [
-                {
-                  "format": "percentunit",
                   "label": null,
                   "logBase": 1,
                   "max": null,
@@ -1618,7 +815,7 @@ data:
           "repeatIteration": null,
           "repeatRowId": null,
           "showTitle": true,
-          "title": "DNS",
+          "title": "Cache Operations",
           "titleSize": "h6"
         },
         {
@@ -1634,7 +831,7 @@ data:
               "dashes": false,
               "datasource": "$datasource",
               "fill": 1,
-              "id": 15,
+              "id": 9,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -1760,7 +957,7 @@ data:
               "dashes": false,
               "datasource": "$datasource",
               "fill": 1,
-              "id": 16,
+              "id": 10,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -1846,7 +1043,7 @@ data:
               "dashes": false,
               "datasource": "$datasource",
               "fill": 1,
-              "id": 17,
+              "id": 11,
               "legend": {
                 "avg": false,
                 "current": false,
@@ -2012,7 +1209,7 @@ data:
             "options": [
 
             ],
-            "query": "label_values(up{namespace=\"$namespace\", job=\"observatorium-thanos-query\"}, job)",
+            "query": "label_values(up{namespace=\"$namespace\", job=~\".*thanos-query-frontend.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,
@@ -2071,8 +1268,8 @@ data:
         ]
       },
       "timezone": "UTC",
-      "title": "Thanos / Query",
-      "uid": "af36c91291a603f1d9fbdabdd127ac4a",
+      "title": "Thanos / Query Frontend",
+      "uid": "303c4e660a475c4c8cf6aee97da3a24a",
       "version": 0
     }
 kind: ConfigMap
@@ -2081,4 +1278,4 @@ metadata:
     grafana-folder: /grafana-dashboard-definitions/Observatorium
   labels:
     grafana_dashboard: "true"
-  name: grafana-dashboard-observatorium-thanos-query
+  name: grafana-dashboard-observatorium-thanos-query_frontend

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-receive.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-receive.configmap.yaml
@@ -78,7 +78,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, handler, code) (rate(http_requests_total{namespace=\"$namespace\", job=\"$job\", handler=\"receive\"}[$interval]))",
+                  "expr": "sum by (namespace,  job, handler, code) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"receive\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}} {{job}} {{handler}} {{code}}",
@@ -164,7 +164,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=\"$job\", handler=\"receive\",code=~\"5..\"}[$interval])) / sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=\"$job\", handler=\"receive\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"receive\",code=~\"5..\"}[$interval])) / sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=~\"$job\", handler=\"receive\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -267,7 +267,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\", handler=\"receive\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"receive\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -277,7 +277,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\", handler=\"receive\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"receive\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -287,7 +287,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\", handler=\"receive\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", handler=\"receive\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -388,7 +388,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_receive_replications_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_receive_replications_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "all {{job}}",
@@ -475,7 +475,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_receive_replications_total{namespace=\"$namespace\", job=\"$job\", result=\"error\"}[$interval])) / sum by (namespace, job) (rate(thanos_receive_replications_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_receive_replications_total{namespace=\"$namespace\", job=~\"$job\", result=\"error\"}[$interval])) / sum by (namespace, job) (rate(thanos_receive_replications_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -573,7 +573,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_receive_forward_requests_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_receive_forward_requests_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "all {{job}}",
@@ -660,7 +660,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_receive_forward_requests_total{namespace=\"$namespace\", job=\"$job\", result=\"error\"}[$interval])) / sum by (namespace, job) (rate(thanos_receive_forward_requests_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_receive_forward_requests_total{namespace=\"$namespace\", job=~\"$job\", result=\"error\"}[$interval])) / sum by (namespace, job) (rate(thanos_receive_forward_requests_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -829,7 +829,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))",
+                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}",
@@ -915,7 +915,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -1018,7 +1018,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -1028,7 +1028,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -1038,7 +1038,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -1210,7 +1210,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))",
+                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}",
@@ -1296,7 +1296,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -1399,7 +1399,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -1409,7 +1409,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -1419,7 +1419,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -1591,7 +1591,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}",
@@ -1677,7 +1677,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -1780,7 +1780,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -1790,7 +1790,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -1800,7 +1800,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -1943,7 +1943,7 @@ data:
               ],
               "targets": [
                 {
-                  "expr": "time() - max by (namespace, job, bucket) (thanos_objstore_bucket_last_successful_upload_time{namespace=\"$namespace\", job=\"$job\"})",
+                  "expr": "time() - max by (namespace, job, bucket) (thanos_objstore_bucket_last_successful_upload_time{namespace=\"$namespace\", job=~\"$job\"})",
                   "format": "table",
                   "instant": true,
                   "intervalFactor": 2,
@@ -2043,7 +2043,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc all {{instance}}",
@@ -2051,7 +2051,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc heap {{instance}}",
@@ -2059,7 +2059,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", job=\"$job\"}[30s])",
+                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", job=~\"$job\"}[30s])",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc rate all {{instance}}",
@@ -2067,7 +2067,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}[30s])",
+                  "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}[30s])",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc rate heap {{instance}}",
@@ -2075,7 +2075,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "inuse heap {{instance}}",
@@ -2083,7 +2083,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "inuse stack {{instance}}",
@@ -2169,7 +2169,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_goroutines{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_goroutines{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{instance}}",
@@ -2255,7 +2255,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_gc_duration_seconds{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_gc_duration_seconds{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{quantile}} {{instance}}",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
@@ -58,7 +58,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, strategy) (rate(prometheus_rule_evaluations_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, strategy) (rate(prometheus_rule_evaluations_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{ strategy }}",
@@ -144,7 +144,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, strategy) (increase(prometheus_rule_group_iterations_missed_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, strategy) (increase(prometheus_rule_group_iterations_missed_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{ strategy }}",
@@ -230,7 +230,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "(\n  max by(namespace, job, rule_group) (prometheus_rule_group_last_duration_seconds{namespace=\"$namespace\", job=\"$job\"})\n  >\n  sum by(namespace, job, rule_group) (prometheus_rule_group_interval_seconds{namespace=\"$namespace\", job=\"$job\"})\n)\n",
+                  "expr": "(\n  max by(namespace, job, rule_group) (prometheus_rule_group_last_duration_seconds{namespace=\"$namespace\", job=~\"$job\"})\n  >\n  sum by(namespace, job, rule_group) (prometheus_rule_group_interval_seconds{namespace=\"$namespace\", job=~\"$job\"})\n)\n",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{ rule_group }}",
@@ -329,7 +329,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, alertmanager) (rate(thanos_alert_sender_alerts_dropped_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, alertmanager) (rate(thanos_alert_sender_alerts_dropped_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{alertmanager}}",
@@ -416,7 +416,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, alertmanager) (rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, alertmanager) (rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{alertmanager}}",
@@ -503,7 +503,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_alert_sender_errors_total{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_alert_sender_errors_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_alert_sender_alerts_sent_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -606,7 +606,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -616,7 +616,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -626,7 +626,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -727,7 +727,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{job}}",
@@ -814,7 +814,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_alert_queue_alerts_pushed_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_alert_queue_alerts_dropped_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_alert_queue_alerts_pushed_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -983,7 +983,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval]))",
+                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}",
@@ -1069,7 +1069,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -1172,7 +1172,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -1182,7 +1182,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -1192,7 +1192,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -1364,7 +1364,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}",
@@ -1450,7 +1450,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -1553,7 +1553,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -1563,7 +1563,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -1573,7 +1573,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -1673,7 +1673,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc all {{instance}}",
@@ -1681,7 +1681,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc heap {{instance}}",
@@ -1689,7 +1689,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", job=\"$job\"}[30s])",
+                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", job=~\"$job\"}[30s])",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc rate all {{instance}}",
@@ -1697,7 +1697,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}[30s])",
+                  "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}[30s])",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc rate heap {{instance}}",
@@ -1705,7 +1705,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "inuse heap {{instance}}",
@@ -1713,7 +1713,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "inuse stack {{instance}}",
@@ -1799,7 +1799,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_goroutines{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_goroutines{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{instance}}",
@@ -1885,7 +1885,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_gc_duration_seconds{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_gc_duration_seconds{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{quantile}} {{instance}}",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-store.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-store.configmap.yaml
@@ -130,7 +130,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval]))",
+                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}",
@@ -216,7 +216,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -319,7 +319,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -329,7 +329,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -339,7 +339,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -511,7 +511,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+                  "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}",
@@ -597,7 +597,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / sum by (namespace, job) (rate(grpc_server_handled_total{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -700,7 +700,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -710,7 +710,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -720,7 +720,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace=\"$namespace\", job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -821,7 +821,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{job}} {{operation}}",
@@ -908,7 +908,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operation_failures_total{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operation_failures_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operations_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{job}} {{operation}}",
@@ -995,7 +995,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "P99 {{job}}",
@@ -1003,7 +1003,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operation_duration_seconds_sum{namespace=\"$namespace\", job=\"$job\"}[$interval])) * 1  / sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operation_duration_seconds_count{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operation_duration_seconds_sum{namespace=\"$namespace\", job=~\"$job\"}[$interval])) * 1  / sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operation_duration_seconds_count{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "mean {{job}}",
@@ -1011,7 +1011,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "P50 {{job}}",
@@ -1110,7 +1110,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_block_loads_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_block_loads_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "block loads",
@@ -1197,7 +1197,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_block_load_failures_total{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_block_loads_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_block_load_failures_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_block_loads_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -1283,7 +1283,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, operation) (rate(thanos_bucket_store_block_drops_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, operation) (rate(thanos_bucket_store_block_drops_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "block drops {{job}}",
@@ -1370,7 +1370,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_block_drop_failures_total{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_block_drops_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_block_drop_failures_total{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_block_drops_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "error",
@@ -1468,7 +1468,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, item_type) (rate(thanos_store_index_cache_requests_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, item_type) (rate(thanos_store_index_cache_requests_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{job}} {{item_type}}",
@@ -1555,7 +1555,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, item_type) (rate(thanos_store_index_cache_hits_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, item_type) (rate(thanos_store_index_cache_hits_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{job}} {{item_type}}",
@@ -1642,7 +1642,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, item_type) (rate(thanos_store_index_cache_items_added_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, item_type) (rate(thanos_store_index_cache_items_added_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{job}} {{item_type}}",
@@ -1729,7 +1729,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "sum by (namespace, job, item_type) (rate(thanos_store_index_cache_items_evicted_total{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job, item_type) (rate(thanos_store_index_cache_items_evicted_total{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{job}} {{item_type}}",
@@ -1828,7 +1828,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval])))",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval])))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "P99",
@@ -1836,7 +1836,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_sent_chunk_size_bytes_sum{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_sent_chunk_size_bytes_count{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_sent_chunk_size_bytes_sum{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_sent_chunk_size_bytes_count{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "mean",
@@ -1844,7 +1844,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval])))",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval])))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "P50",
@@ -1942,7 +1942,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "thanos_bucket_store_series_blocks_queried{namespace=\"$namespace\", job=\"$job\", quantile=\"0.99\"}",
+                  "expr": "thanos_bucket_store_series_blocks_queried{namespace=\"$namespace\", job=~\"$job\", quantile=\"0.99\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "P99",
@@ -1950,7 +1950,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_series_blocks_queried_sum{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_series_blocks_queried_count{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_series_blocks_queried_sum{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_series_blocks_queried_count{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "mean {{job}}",
@@ -1958,7 +1958,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "thanos_bucket_store_series_blocks_queried{namespace=\"$namespace\", job=\"$job\", quantile=\"0.50\"}",
+                  "expr": "thanos_bucket_store_series_blocks_queried{namespace=\"$namespace\", job=~\"$job\", quantile=\"0.50\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "P50",
@@ -2045,7 +2045,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "thanos_bucket_store_series_data_fetched{namespace=\"$namespace\", job=\"$job\", quantile=\"0.99\"}",
+                  "expr": "thanos_bucket_store_series_data_fetched{namespace=\"$namespace\", job=~\"$job\", quantile=\"0.99\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "P99",
@@ -2053,7 +2053,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_series_data_fetched_sum{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_series_data_fetched_count{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_series_data_fetched_sum{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_series_data_fetched_count{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "mean {{job}}",
@@ -2061,7 +2061,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "thanos_bucket_store_series_data_fetched{namespace=\"$namespace\", job=\"$job\", quantile=\"0.50\"}",
+                  "expr": "thanos_bucket_store_series_data_fetched{namespace=\"$namespace\", job=~\"$job\", quantile=\"0.50\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "P50",
@@ -2147,7 +2147,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "thanos_bucket_store_series_result_series{namespace=\"$namespace\", job=\"$job\",quantile=\"0.99\"}",
+                  "expr": "thanos_bucket_store_series_result_series{namespace=\"$namespace\", job=~\"$job\",quantile=\"0.99\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "P99",
@@ -2155,7 +2155,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_series_result_series_sum{namespace=\"$namespace\", job=\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_series_result_series_count{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+                  "expr": "sum by (namespace, job) (rate(thanos_bucket_store_series_result_series_sum{namespace=\"$namespace\", job=~\"$job\"}[$interval])) / sum by (namespace, job) (rate(thanos_bucket_store_series_result_series_count{namespace=\"$namespace\", job=~\"$job\"}[$interval]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "mean {{job}}",
@@ -2163,7 +2163,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "thanos_bucket_store_series_result_series{namespace=\"$namespace\", job=\"$job\",quantile=\"0.50\"}",
+                  "expr": "thanos_bucket_store_series_result_series{namespace=\"$namespace\", job=~\"$job\",quantile=\"0.50\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "P50",
@@ -2279,7 +2279,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -2289,7 +2289,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -2299,7 +2299,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -2405,7 +2405,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -2415,7 +2415,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -2425,7 +2425,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -2531,7 +2531,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p50 {{namespace}} {{job}}",
@@ -2541,7 +2541,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p90 {{namespace}} {{job}}",
@@ -2551,7 +2551,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace=\"$namespace\", job=\"$job\"}[$interval]))) * 1",
+                  "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace=\"$namespace\", job=~\"$job\"}[$interval]))) * 1",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "p99 {{namespace}} {{job}}",
@@ -2651,7 +2651,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc all {{instance}}",
@@ -2659,7 +2659,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc heap {{instance}}",
@@ -2667,7 +2667,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", job=\"$job\"}[30s])",
+                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", job=~\"$job\"}[30s])",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc rate all {{instance}}",
@@ -2675,7 +2675,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=\"$job\"}[30s])",
+                  "expr": "rate(go_memstats_heap_alloc_bytes{namespace=\"$namespace\", job=~\"$job\"}[30s])",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "alloc rate heap {{instance}}",
@@ -2683,7 +2683,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_stack_inuse_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "inuse heap {{instance}}",
@@ -2691,7 +2691,7 @@ data:
                   "step": 10
                 },
                 {
-                  "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "inuse stack {{instance}}",
@@ -2777,7 +2777,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_goroutines{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_goroutines{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{instance}}",
@@ -2863,7 +2863,7 @@ data:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "go_gc_duration_seconds{namespace=\"$namespace\", job=\"$job\"}",
+                  "expr": "go_gc_duration_seconds{namespace=\"$namespace\", job=~\"$job\"}",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{quantile}} {{instance}}",

--- a/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
@@ -316,7 +316,7 @@ spec:
       for: 5m
       labels:
         service: telemeter
-        severity: medium
+        severity: high
     - alert: ThanosReceiveHighHashringFileRefreshFailures
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/916a852b00ccc5ed81056644718fa4fb/thanos-receive?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
@@ -362,6 +362,23 @@ spec:
       labels:
         service: telemeter
         severity: high
+    - alert: ThanosReceiveTrafficBelowThreshold
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/916a852b00ccc5ed81056644718fa4fb/thanos-receive?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        description: At Thanos Receive {{$labels.job}} in {{$labels.namespace}} , the average 1-hr avg. metrics ingestion rate  is {{$value | humanize}}% of 12-hr avg. ingestion rate.
+        message: At Thanos Receive {{$labels.job}} in {{$labels.namespace}} , the average 1-hr avg. metrics ingestion rate  is {{$value | humanize}}% of 12-hr avg. ingestion rate.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosreceivetrafficbelowthreshold
+        summary: Thanos Receive is experiencing low avg. 1-hr ingestion rate relative to avg. 12-hr ingestion rate.
+      expr: |
+        (
+          avg_over_time(rate(http_requests_total{job=~"observatorium-thanos-receive-default.*", code=~"2..", handler="receive"}[5m])[1h:5m])
+        /
+          avg_over_time(rate(http_requests_total{job=~"observatorium-thanos-receive-default.*", code=~"2..", handler="receive"}[5m])[12h:5m])
+        ) * 100 < 50
+      for: 1h
+      labels:
+        service: telemeter
+        severity: medium
   - name: thanos-store
     rules:
     - alert: ThanosStoreGrpcErrorRate

--- a/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
@@ -316,7 +316,7 @@ spec:
       for: 5m
       labels:
         service: telemeter
-        severity: medium
+        severity: high
     - alert: ThanosReceiveHighHashringFileRefreshFailures
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/916a852b00ccc5ed81056644718fa4fb/thanos-receive?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
@@ -362,6 +362,23 @@ spec:
       labels:
         service: telemeter
         severity: high
+    - alert: ThanosReceiveTrafficBelowThreshold
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/916a852b00ccc5ed81056644718fa4fb/thanos-receive?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        description: At Thanos Receive {{$labels.job}} in {{$labels.namespace}} , the average 1-hr avg. metrics ingestion rate  is {{$value | humanize}}% of 12-hr avg. ingestion rate.
+        message: At Thanos Receive {{$labels.job}} in {{$labels.namespace}} , the average 1-hr avg. metrics ingestion rate  is {{$value | humanize}}% of 12-hr avg. ingestion rate.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosreceivetrafficbelowthreshold
+        summary: Thanos Receive is experiencing low avg. 1-hr ingestion rate relative to avg. 12-hr ingestion rate.
+      expr: |
+        (
+          avg_over_time(rate(http_requests_total{job=~"observatorium-thanos-receive-default.*", code=~"2..", handler="receive"}[5m])[1h:5m])
+        /
+          avg_over_time(rate(http_requests_total{job=~"observatorium-thanos-receive-default.*", code=~"2..", handler="receive"}[5m])[12h:5m])
+        ) * 100 < 50
+      for: 1h
+      labels:
+        service: telemeter
+        severity: medium
   - name: thanos-store
     rules:
     - alert: ThanosStoreGrpcErrorRate


### PR DESCRIPTION
- Updates `thanos-mixin` dependency to get the latest `main` from the Thanos repo/mixin folder (I ran into some issues to update the dependency by using `jb update <repo_url_here>` - so after some research I found that this is an open issue in `jsonnet-bundler` (Updated the README that has a link to a workaround for it)
- Imports `query_frontend.libsonnet` to generate Query Frontend Grafana dashboard
- Runs `make grafana` (This also updated other Thanos dashboards, I think because now we updated the `thanos-mixin` version