### PR TITLE
Prometheus Rules: Add tenant misconfiguration rule test

### DIFF
--- a/observability/prometheus_rule_tests/observatorium-tenants.prometheusrulestests.yaml
+++ b/observability/prometheus_rule_tests/observatorium-tenants.prometheusrulestests.yaml
@@ -1,0 +1,53 @@
+---
+$schema: /app-interface/prometheus-rule-test-1.yml
+
+rule_files:
+# For upstream:
+# - /observability/prometheusrules/observatorium-tenants-stage.prometheusrules.yaml
+- /observability/prometheusrules/observatorium-tenants-production.prometheusrules.yaml
+# For local testing:
+# - observatorium-tenants-production.prometheusrules.yaml.test
+
+evaluation_interval: 1m
+
+tests:
+- interval: 1m
+  input_series:
+  - series: observatorium_api_tenants_skipped_invalid_configuration{namespace="observatorium-metrics", tenant="test"}
+    values: '0 0 0 0 1 1'
+  promql_expr_test:
+    - expr: observatorium_api_tenants_skipped_invalid_configuration{tenant="test"}
+      eval_time: 1m
+      exp_samples:
+        - labels: '{__name__="observatorium_api_tenants_skipped_invalid_configuration", namespace="observatorium-metrics", tenant="test"}'
+          value: 0
+    - expr: observatorium_api_tenants_skipped_invalid_configuration{tenant="test"}
+      eval_time: 5m
+      exp_samples:
+        - labels: '{__name__="observatorium_api_tenants_skipped_invalid_configuration", namespace="observatorium-metrics", tenant="test"}'
+          value: 1
+    - expr: sum(increase(observatorium_api_tenants_skipped_invalid_configuration[5m])) by (tenant)
+      eval_time: 1m
+      exp_samples:
+        - labels: '{tenant="test"}'
+          value: 0
+    - expr: sum(increase(observatorium_api_tenants_skipped_invalid_configuration[5m])) by (tenant)
+      eval_time: 5m
+      exp_samples:
+        - labels: '{tenant="test"}'
+          value: 1
+  alert_rule_test:
+  - eval_time: 1m
+    alertname: ObservatoriumTenantsSkippedDuringConfiguration
+  - eval_time: 5m
+    alertname: ObservatoriumTenantsSkippedDuringConfiguration
+    exp_alerts:
+    - exp_labels:
+        service: telemeter
+        severity: medium
+        tenant: test
+        namespace: observatorium-metrics
+      exp_annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/no-dashboard/observatorium-tenants?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace=observatorium-metrics&var-job=All&var-pod=All&var-interval=5m
+        message: Tenant test was skipped due to misconfiguration
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumtenantsskippedduringconfiguration

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -553,7 +553,7 @@ local renderAlerts(name, environment, mixin) = {
                 message: 'Tenant {{ $labels.tenant }} was skipped due to misconfiguration',
               },
               expr: |||
-                sum(increase(observatorium_api_tenants_skipped_invalid_configuration[5m])) by (tenant) > 0
+                sum(increase(observatorium_api_tenants_skipped_invalid_configuration[5m])) by (tenant, namespace) > 0
               |||,
               labels: {
                 severity: 'warning',

--- a/resources/observability/prometheusrules/observatorium-tenants-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-tenants-production.prometheusrules.yaml
@@ -27,7 +27,7 @@ spec:
         message: Tenant {{ $labels.tenant }} was skipped due to misconfiguration
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumtenantsskippedduringconfiguration
       expr: |
-        sum(increase(observatorium_api_tenants_skipped_invalid_configuration[5m])) by (tenant) > 0
+        sum(increase(observatorium_api_tenants_skipped_invalid_configuration[5m])) by (tenant, namespace) > 0
       labels:
         service: telemeter
         severity: medium

--- a/resources/observability/prometheusrules/observatorium-tenants-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-tenants-stage.prometheusrules.yaml
@@ -27,7 +27,7 @@ spec:
         message: Tenant {{ $labels.tenant }} was skipped due to misconfiguration
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumtenantsskippedduringconfiguration
       expr: |
-        sum(increase(observatorium_api_tenants_skipped_invalid_configuration[5m])) by (tenant) > 0
+        sum(increase(observatorium_api_tenants_skipped_invalid_configuration[5m])) by (tenant, namespace) > 0
       labels:
         service: telemeter
         severity: medium

--- a/resources/observability/prometheusrules/observatorium-tenants.prometheusrulestests.yaml
+++ b/resources/observability/prometheusrules/observatorium-tenants.prometheusrulestests.yaml
@@ -1,0 +1,53 @@
+---
+$schema: /app-interface/prometheus-rule-test-1.yml
+
+rule_files:
+# For upstream:
+# - /observability/prometheusrules/observatorium-tenants-stage.prometheusrules.yaml
+- /observability/prometheusrules/observatorium-tenants-production.prometheusrules.yaml
+# For local testing:
+# - observatorium-tenants-production.prometheusrules.yaml.test
+
+evaluation_interval: 1m
+
+tests:
+- interval: 1m
+  input_series:
+  - series: observatorium_api_tenants_skipped_invalid_configuration{namespace="observatorium-metrics", tenant="test"}
+    values: '0 0 0 0 1 1'
+  promql_expr_test:
+    - expr: observatorium_api_tenants_skipped_invalid_configuration{tenant="test"}
+      eval_time: 1m
+      exp_samples:
+        - labels: '{__name__="observatorium_api_tenants_skipped_invalid_configuration", namespace="observatorium-metrics", tenant="test"}'
+          value: 0
+    - expr: observatorium_api_tenants_skipped_invalid_configuration{tenant="test"}
+      eval_time: 5m
+      exp_samples:
+        - labels: '{__name__="observatorium_api_tenants_skipped_invalid_configuration", namespace="observatorium-metrics", tenant="test"}'
+          value: 1
+    - expr: sum(increase(observatorium_api_tenants_skipped_invalid_configuration[5m])) by (tenant)
+      eval_time: 1m
+      exp_samples:
+        - labels: '{tenant="test"}'
+          value: 0
+    - expr: sum(increase(observatorium_api_tenants_skipped_invalid_configuration[5m])) by (tenant)
+      eval_time: 5m
+      exp_samples:
+        - labels: '{tenant="test"}'
+          value: 1
+  alert_rule_test:
+  - eval_time: 1m
+    alertname: ObservatoriumTenantsSkippedDuringConfiguration
+  - eval_time: 5m
+    alertname: ObservatoriumTenantsSkippedDuringConfiguration
+    exp_alerts:
+    - exp_labels:
+        service: telemeter
+        severity: medium
+        tenant: test
+        namespace: observatorium-metrics
+      exp_annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/no-dashboard/observatorium-tenants?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace=observatorium-metrics&var-job=All&var-pod=All&var-interval=5m
+        message: Tenant test was skipped due to misconfiguration
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumtenantsskippedduringconfiguration


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Adding test for recently introduced alerting rule - `ObservatoriumTenantsSkippedDuringConfiguration` (was asked for by AppSRE before it's rolled out).