### PR TITLE
Bump storage for Thanos store, receive components to 100Gi

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1203,7 +1203,7 @@ objects:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 100Gi
         storageClassName: ${STORAGE_CLASS}
 - apiVersion: v1
   kind: Service
@@ -2097,7 +2097,7 @@ objects:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 100Gi
         storageClassName: ${STORAGE_CLASS}
 - apiVersion: v1
   kind: Service
@@ -2343,7 +2343,7 @@ objects:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 100Gi
         storageClassName: ${STORAGE_CLASS}
 - apiVersion: v1
   kind: Service
@@ -2589,7 +2589,7 @@ objects:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 100Gi
         storageClassName: ${STORAGE_CLASS}
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -223,7 +223,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           storageClassName: '${STORAGE_CLASS}',
           resources: {
             requests: {
-              storage: '50Gi',
+              storage: '100Gi',
             },
           },
         },
@@ -570,7 +570,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           storageClassName: '${STORAGE_CLASS}',
           resources: {
             requests: {
-              storage: '50Gi',
+              storage: '100Gi',
             },
           },
         },


### PR DESCRIPTION
Bumps storage for Thanos store, receive components to 100Gi (from 50Gi). Parameterizing the storage limit will be taken care as part of another PR.