### PR TITLE
Add alerting for PVCs getting filled

### DIFF
--- a/docs/sop/observatorium.md
+++ b/docs/sop/observatorium.md
@@ -1136,6 +1136,65 @@ For the set availability guarantees the observatorium api or the thanos receiver
 
 ---
 
+## ObservatoriumPersistentVolumeUsageHigh
+
+### Impact
+
+A PVC belonging to an RHOBS service is filled beyond a comfortable level. If the volume is not increased, it might soon become critically filled.
+
+### Summary
+
+One or more PVCs are filled to more than 90%. The remaining free space might not suffice to handle the system's load for longer time.
+
+### Severity
+
+`warning`
+
+### Access Required
+
+- Console access to the cluster that runs Observatorium (Currently [telemeter-prod-01 OSD](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/k8s/cluster/projects/telemeter-production))
+- Edit access to the Telemeter namespaces (Observatorium uses Telemeter namespaces):
+  - `observatorium-metrics-stage`
+  - `observatorium-metrics-production`
+  - `observatorium-mst-stage`
+  - `observatorium-mst-production`
+
+### Steps
+
+- Check the alert and establish which component is the one affected by the filled PVC
+- Assess how much free space on the PVC is there left and how long will it last
+- If extending the PVC is necessary, locate the affected deployment in the [AppSRE Interface](https://gitlab.cee.redhat.com/service/app-interface/-/tree/master/data/services/rhobs), depending on which namespace the alert is coming from
+- Increase the size of the PVC by adjusting the relevant parameter in one of the `saas.yaml` files
+
+## ObservatoriumPersistentVolumeUsageCritical
+
+### Impact
+
+A PVC belonging to an RHOBS service is critically filled - if the PVC fills beyoned this level, the functionality of the system will be impacted.
+
+### Summary
+
+One or more PVCs are filled to more than 95%. The remaining free space does not suffice to sustain the normal system load.
+
+### Severity
+
+`high`
+
+### Access Required
+
+- Console access to the cluster that runs Observatorium (Currently [telemeter-prod-01 OSD](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/k8s/cluster/projects/telemeter-production))
+- Edit access to the Telemeter namespaces (Observatorium uses Telemeter namespaces):
+  - `observatorium-metrics-stage`
+  - `observatorium-metrics-production`
+  - `observatorium-mst-stage`
+  - `observatorium-mst-production`
+
+### Steps
+
+- Check the alert and establish which component is the one affected by the filled PVC
+- Check the pods belonging to the component and establish what object do they belong to
+- Locate the affected deployment in the [AppSRE Interface](https://gitlab.cee.redhat.com/service/app-interface/-/tree/master/data/services/rhobs), depending on which namespace the alert is coming from
+- Increase the size of the PVC by adjusting the relevant parameter in one of the `saas.yaml` files
 ## GubernatorIsDown
 
 ### Impact

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -517,6 +517,38 @@ local renderAlerts(name, environment, mixin) = {
                 severity: 'critical',
               },
             },
+            {
+              alert: 'ObservatoriumPersistentVolumeUsageHigh',
+              annotations: {
+                description: 'The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} has {{ printf "%0.2f" $value }}% of free space',
+                summary: 'One or more of the PersistentVolumes in Observatorium is over 90% full. They might need to be extended.',
+              },
+              expr: |||
+                100 * kubelet_volume_stats_available_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"}
+                /
+                kubelet_volume_stats_capacity_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"} < 10
+              |||,
+              'for': '10m',
+              labels: {
+                severity: 'warning',
+              },
+            },
+            {
+              alert: 'ObservatoriumPersistentVolumeUsageCritical',
+              annotations: {
+                description: 'The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is only {{ printf "%0.2f" $value }}% free',
+                summary: 'One or more of the PersistentVolumes in Observatorium is critically filled. They need to be extended.',
+              },
+              expr: |||
+                100 * kubelet_volume_stats_available_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"}
+                /
+                kubelet_volume_stats_capacity_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"} < 5
+              |||,
+              'for': '10m',
+              labels: {
+                severity: 'critical',
+              },
+            },
           ],
         },
       ],

--- a/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml
@@ -24,3 +24,33 @@ spec:
       labels:
         service: telemeter
         severity: critical
+    - alert: ObservatoriumPersistentVolumeUsageHigh
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/no-dashboard/observatorium-metrics?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} has {{ printf "%0.2f" $value }}% of free space
+        message: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} has {{ printf "%0.2f" $value }}% of free space
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumpersistentvolumeusagehigh
+        summary: One or more of the PersistentVolumes in Observatorium is over 90% full. They might need to be extended.
+      expr: |
+        100 * kubelet_volume_stats_available_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"}
+        /
+        kubelet_volume_stats_capacity_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"} < 10
+      for: 10m
+      labels:
+        service: telemeter
+        severity: medium
+    - alert: ObservatoriumPersistentVolumeUsageCritical
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/no-dashboard/observatorium-metrics?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is only {{ printf "%0.2f" $value }}% free
+        message: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is only {{ printf "%0.2f" $value }}% free
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumpersistentvolumeusagecritical
+        summary: One or more of the PersistentVolumes in Observatorium is critically filled. They need to be extended.
+      expr: |
+        100 * kubelet_volume_stats_available_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"}
+        /
+        kubelet_volume_stats_capacity_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"} < 5
+      for: 10m
+      labels:
+        service: telemeter
+        severity: critical

--- a/resources/observability/prometheusrules/observatorium-custom-metrics-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-custom-metrics-stage.prometheusrules.yaml
@@ -24,3 +24,33 @@ spec:
       labels:
         service: telemeter
         severity: high
+    - alert: ObservatoriumPersistentVolumeUsageHigh
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/no-dashboard/observatorium-metrics?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} has {{ printf "%0.2f" $value }}% of free space
+        message: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} has {{ printf "%0.2f" $value }}% of free space
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumpersistentvolumeusagehigh
+        summary: One or more of the PersistentVolumes in Observatorium is over 90% full. They might need to be extended.
+      expr: |
+        100 * kubelet_volume_stats_available_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"}
+        /
+        kubelet_volume_stats_capacity_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"} < 10
+      for: 10m
+      labels:
+        service: telemeter
+        severity: medium
+    - alert: ObservatoriumPersistentVolumeUsageCritical
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/no-dashboard/observatorium-metrics?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is only {{ printf "%0.2f" $value }}% free
+        message: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is only {{ printf "%0.2f" $value }}% free
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumpersistentvolumeusagecritical
+        summary: One or more of the PersistentVolumes in Observatorium is critically filled. They need to be extended.
+      expr: |
+        100 * kubelet_volume_stats_available_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"}
+        /
+        kubelet_volume_stats_capacity_bytes{job="kubelet",namespace!~"^openshift-.*$",persistentvolumeclaim=~"data-observatorium-thanos-.*"} < 5
+      for: 10m
+      labels:
+        service: telemeter
+        severity: high


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

This PR adds alerts to improve our visibility into issues with PVC getting filled. It is proposed to add two alerts:
- `ObservatoriumPersistentVolumeUsageHigh` which has low severity and should serve as a warning that the PVC is being filled beyond a level that cannot be sustained long term (i.e. does not require immediate action but needs to be addressed soon).
- `ObservatoriumPersistentVolumeUsageCritical` which has high severity and is meant to alert on cases when the PVC got filled beyond a critical threshold (95%). This requires immediate action, i.e. PVC extension.

Since PVCs are used only on critical components (store, receiver and ruler), I'd suggest to _not_ carve out exclusions for certain namespaces etc. but rather alert on all PVCs.