### PR TITLE
Add MST SLO alerts & refactor SLO generator

### DIFF
--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -238,6 +238,8 @@ local renderAlerts(name, environment, mixin) = {
 };
 
 {
+  // This function is required to convert the output format of the slo-libsonnet library to the format expected
+  // for the prometheus rules file.
   local flatten(originalSLOs) = {
     prometheusAlerts+:: {
       groups: [

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -266,7 +266,7 @@ local renderAlerts(name, environment, mixin) = {
       slos: [
         slo.errorburn({
           alertName: 'TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning',
-          alertMessage: 'Telemeter Server /upload or /receive is burning too much error budget to gurantee availability SLOs',
+          alertMessage: 'Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs',
           metric: 'haproxy_server_http_responses_total',
           selectors: ['route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive"', 'code=~"^(2..|3..|5..)$"'],
           errorSelectors: ['code="5xx"'],
@@ -279,7 +279,7 @@ local renderAlerts(name, environment, mixin) = {
       slos: [
         slo.latencyburn({
           alertName: 'TelemeterServerMetricsWriteLatencyErrorBudgetBurning',
-          alertMessage: 'Telemeter Server /upload or /receive is burning too much error budget to gurantee latency SLOs',
+          alertMessage: 'Telemeter Server /upload or /receive is burning too much error budget to guarantee latency SLOs',
           metric: 'http_request_duration_seconds',
           // We can't use !~ operator in these selectors
           selectors: ['job="telemeter-server"', 'handler=~"upload|receive"', 'code=~"^(2..|3..|5..)$"'],
@@ -299,7 +299,7 @@ local renderAlerts(name, environment, mixin) = {
         slos: [
           slo.errorburn({
             alertName: 'APIMetricsWriteAvailabilityErrorBudgetBurning',
-            alertMessage: 'API /receive handler is burning too much error budget to gurantee availability SLOs',
+            alertMessage: 'API /receive handler is burning too much error budget to guarantee availability SLOs',
             metric: 'http_requests_total',
             selectors: [apiJobSelector, 'handler=~"receive"', 'code=~"^(2..|3..|5..)$"'],
             errorSelectors: ['code=~"5.+"'],
@@ -312,7 +312,7 @@ local renderAlerts(name, environment, mixin) = {
         slos: [
           slo.latencyburn({
             alertName: 'TelemeterAPIMetricsWriteLatencyErrorBudgetBurning',
-            alertMessage: 'API /receive handler is burning too much error budget to gurantee latency SLOs',
+            alertMessage: 'API /receive handler is burning too much error budget to guarantee latency SLOs',
             metric: 'http_request_duration_seconds',
             // We can't use !~ operator in these selectors
             selectors: [apiJobSelector, 'handler="receive"', 'code=~"^(2..|3..|5..)$"'],
@@ -326,7 +326,7 @@ local renderAlerts(name, environment, mixin) = {
         slos: [
           slo.errorburn({
             alertName: 'APIMetricsReadAvailabilityErrorBudgetBurning',
-            alertMessage: 'API /query handler is burning too much error budget to gurantee availability SLOs',
+            alertMessage: 'API /query handler is burning too much error budget to guarantee availability SLOs',
             metric: 'http_requests_total',
             selectors: [apiJobSelector, 'handler="query"', 'code=~"^(2..|3..|5..)$"'],
             errorSelectors: ['code=~"5.+"'],
@@ -334,7 +334,7 @@ local renderAlerts(name, environment, mixin) = {
           }),
           slo.errorburn({
             alertName: 'TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning',
-            alertMessage: 'API /query_range handler is burning too much error budget to gurantee availability SLOs',
+            alertMessage: 'API /query_range handler is burning too much error budget to guarantee availability SLOs',
             metric: 'http_requests_total',
             selectors: [apiJobSelector, 'handler="query_range"', 'code=~"^(2..|3..|5..)$"'],
             errorSelectors: ['code=~"5.+"'],
@@ -347,7 +347,7 @@ local renderAlerts(name, environment, mixin) = {
         slos: [
           slo.latencyburn({
             alertName: 'APIMetricsReadLatencyErrorBudgetBurning',
-            alertMessage: 'API /query endpoint is burning too much error budget to gurantee latency SLOs',
+            alertMessage: 'API /query endpoint is burning too much error budget to guarantee latency SLOs',
             metric: 'up_custom_query_duration_seconds',
             selectors: ['query="query-path-sli-1M-samples"', upNamespaceSelector],
             latencyTarget: 2.0113571874999994,
@@ -355,7 +355,7 @@ local renderAlerts(name, environment, mixin) = {
           }),
           slo.latencyburn({
             alertName: 'APIMetricsReadLatencyErrorBudgetBurning',
-            alertMessage: 'API /query endpoint is burning too much error budget to gurantee latency SLOs',
+            alertMessage: 'API /query endpoint is burning too much error budget to guarantee latency SLOs',
             metric: 'up_custom_query_duration_seconds',
             selectors: ['query="query-path-sli-10M-samples"', upNamespaceSelector],
             latencyTarget: 10.761264004567169,
@@ -363,7 +363,7 @@ local renderAlerts(name, environment, mixin) = {
           }),
           slo.latencyburn({
             alertName: 'APIMetricsReadLatencyErrorBudgetBurning',
-            alertMessage: 'API /query endpoint is burning too much error budget to gurantee latency SLOs',
+            alertMessage: 'API /query endpoint is burning too much error budget to guarantee latency SLOs',
             metric: 'up_custom_query_duration_seconds',
             // We can't use !~ operator in these selectors
             selectors: ['query="query-path-sli-100M-samples"', upNamespaceSelector],

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -311,7 +311,7 @@ local renderAlerts(name, environment, mixin) = {
         name: 'rhobs-' + instance + '-api-metrics-write-latency.slo',
         slos: [
           slo.latencyburn({
-            alertName: 'TelemeterAPIMetricsWriteLatencyErrorBudgetBurning',
+            alertName: 'APIMetricsWriteLatencyErrorBudgetBurning',
             alertMessage: 'API /receive handler is burning too much error budget to guarantee latency SLOs',
             metric: 'http_request_duration_seconds',
             // We can't use !~ operator in these selectors
@@ -333,7 +333,7 @@ local renderAlerts(name, environment, mixin) = {
             target: 0.95,
           }),
           slo.errorburn({
-            alertName: 'TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning',
+            alertName: 'APIMetricsReadAvailabilityErrorBudgetBurning',
             alertMessage: 'API /query_range handler is burning too much error budget to guarantee availability SLOs',
             metric: 'http_requests_total',
             selectors: [apiJobSelector, 'handler="query_range"', 'code=~"^(2..|3..|5..)$"'],

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -1,0 +1,832 @@
+---
+$schema: /openshift/prometheus-rule-1.yml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: app-sre
+    role: alert-rules
+  name: rhobs-slos-mst-production
+spec:
+  groups:
+  - name: rhobs-mst-api-metrics-write-availability.slo
+    rules:
+    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: critical
+    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: critical
+    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-mst-api-metrics-write-latency.slo
+    rules:
+    - alert: MSTAPIMetricsWriteLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswritelatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          and
+          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+        )
+        or
+        (
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          and
+          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+        service: telemeter
+        severity: critical
+    - alert: MSTAPIMetricsWriteLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswritelatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          and
+          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+        )
+        or
+        (
+          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          and
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+        service: telemeter
+        severity: medium
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[5m]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[5m]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate5m
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[30m]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[30m]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate30m
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[1h]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate1h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[2h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[2h]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate2h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[6h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[6h]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate6h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1d]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[1d]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate1d
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[3d]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[3d]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate3d
+  - name: rhobs-mst-api-metrics-read-availability.slo
+    rules:
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: critical
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: critical
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate6h
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: critical
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: critical
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-mst-api-metrics-read-latency.slo
+    rules:
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=2.0113571874999994 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.900000)
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: critical
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=2.0113571874999994 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.900000)
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[5m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[5m]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[30m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[30m]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[1h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[1h]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[2h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[2h]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[6h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[6h]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[1d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[1d]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[3d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[3d]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=10.761264004567169 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.900000)
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: critical
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=10.761264004567169 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.900000)
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[5m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[5m]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[30m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[30m]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[1h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[1h]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[2h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[2h]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[6h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[6h]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[1d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[1d]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[3d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[3d]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=21.6447457021712 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.900000)
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: critical
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=21.6447457021712 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.900000)
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[5m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[5m]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[30m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[30m]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[1h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[1h]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[2h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[2h]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[6h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[6h]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[1d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[1d]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[3d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[3d]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -14,7 +14,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -29,7 +29,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -44,7 +44,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -59,7 +59,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
@@ -257,7 +257,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -272,7 +272,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -287,7 +287,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -302,7 +302,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
@@ -373,7 +373,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -388,7 +388,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -403,7 +403,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -418,7 +418,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -11,11 +11,11 @@ spec:
   groups:
   - name: rhobs-mst-api-metrics-write-availability.slo
     rules:
-    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -26,11 +26,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: critical
-    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -41,11 +41,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: critical
-    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -56,11 +56,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
-    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
@@ -129,11 +129,11 @@ spec:
       record: http_requests_total:burnrate6h
   - name: rhobs-mst-api-metrics-write-latency.slo
     rules:
-    - alert: MSTAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
@@ -152,11 +152,11 @@ spec:
         latency: "5"
         service: telemeter
         severity: critical
-    - alert: MSTAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
@@ -254,11 +254,11 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate3d
   - name: rhobs-mst-api-metrics-read-availability.slo
     rules:
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -269,11 +269,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: critical
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -284,11 +284,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: critical
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -299,11 +299,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
@@ -370,11 +370,11 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -385,11 +385,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: critical
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -400,11 +400,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: critical
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -415,11 +415,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
@@ -488,11 +488,11 @@ spec:
       record: http_requests_total:burnrate6h
   - name: rhobs-mst-api-metrics-read-latency.slo
     rules:
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=2.0113571874999994 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.900000)
@@ -510,11 +510,11 @@ spec:
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=2.0113571874999994 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.900000)
@@ -602,11 +602,11 @@ spec:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-production
       record: latencytarget:up_custom_query_duration_seconds:rate3d
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=10.761264004567169 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.900000)
@@ -624,11 +624,11 @@ spec:
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=10.761264004567169 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.900000)
@@ -716,11 +716,11 @@ spec:
         latency: "10.761264004567169"
         namespace: observatorium-mst-production
       record: latencytarget:up_custom_query_duration_seconds:rate3d
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=21.6447457021712 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.900000)
@@ -738,11 +738,11 @@ spec:
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=21.6447457021712 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.900000)

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -129,11 +129,11 @@ spec:
       record: http_requests_total:burnrate6h
   - name: rhobs-mst-api-metrics-write-latency.slo
     rules:
-    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
@@ -152,11 +152,11 @@ spec:
         latency: "5"
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
@@ -370,11 +370,11 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -385,11 +385,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -400,11 +400,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -415,11 +415,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -14,7 +14,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -29,7 +29,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -44,7 +44,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -59,7 +59,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
@@ -257,7 +257,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -272,7 +272,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -287,7 +287,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -302,7 +302,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
@@ -373,7 +373,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -388,7 +388,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -403,7 +403,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -418,7 +418,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -1,0 +1,832 @@
+---
+$schema: /openshift/prometheus-rule-1.yml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: app-sre
+    role: alert-rules
+  name: rhobs-slos-mst-stage
+spec:
+  groups:
+  - name: rhobs-mst-api-metrics-write-availability.slo
+    rules:
+    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: high
+    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: high
+    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-mst-api-metrics-write-latency.slo
+    rules:
+    - alert: MSTAPIMetricsWriteLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswritelatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          and
+          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+        )
+        or
+        (
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          and
+          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+        service: telemeter
+        severity: high
+    - alert: MSTAPIMetricsWriteLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswritelatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          and
+          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+        )
+        or
+        (
+          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          and
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+        service: telemeter
+        severity: medium
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[5m]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[5m]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate5m
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[30m]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[30m]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate30m
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[1h]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate1h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[2h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[2h]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate2h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[6h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[6h]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate6h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1d]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[1d]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate1d
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[3d]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[3d]))
+        )
+      labels:
+        handler: receive
+        job: observatorium-observatorium-mst-api
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate3d
+  - name: rhobs-mst-api-metrics-read-availability.slo
+    rules:
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: high
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: high
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        handler: query
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate6h
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: high
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: high
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        handler: query_range
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-mst-api-metrics-read-latency.slo
+    rules:
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=2.0113571874999994 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.900000)
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: high
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=2.0113571874999994 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.900000)
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[5m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[5m]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[30m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[30m]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[1h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[1h]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[2h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[2h]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[6h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[6h]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[1d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[1d]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[3d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[3d]))
+        )
+      labels:
+        latency: "2.0113571874999994"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=10.761264004567169 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.900000)
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: high
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=10.761264004567169 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.900000)
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[5m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[5m]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[30m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[30m]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[1h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[1h]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[2h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[2h]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[6h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[6h]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[1d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[1d]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[3d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[3d]))
+        )
+      labels:
+        latency: "10.761264004567169"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=21.6447457021712 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.900000)
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: high
+    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=21.6447457021712 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.900000)
+        )
+        or
+        (
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.900000)
+          and
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.900000)
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[5m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[5m]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[30m]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[30m]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[1h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[1h]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[2h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[2h]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[6h]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[6h]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[1d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[1d]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
+    - expr: |
+        1 - (
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[3d]))
+          /
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[3d]))
+        )
+      labels:
+        latency: "21.6447457021712"
+        namespace: observatorium-mst-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -11,11 +11,11 @@ spec:
   groups:
   - name: rhobs-mst-api-metrics-write-availability.slo
     rules:
-    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -26,11 +26,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: high
-    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -41,11 +41,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: high
-    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -56,11 +56,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
-    - alert: MSTAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
@@ -129,11 +129,11 @@ spec:
       record: http_requests_total:burnrate6h
   - name: rhobs-mst-api-metrics-write-latency.slo
     rules:
-    - alert: MSTAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
@@ -152,11 +152,11 @@ spec:
         latency: "5"
         service: telemeter
         severity: high
-    - alert: MSTAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
@@ -254,11 +254,11 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate3d
   - name: rhobs-mst-api-metrics-read-availability.slo
     rules:
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -269,11 +269,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: high
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -284,11 +284,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: high
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -299,11 +299,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
@@ -370,11 +370,11 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -385,11 +385,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: high
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -400,11 +400,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: high
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -415,11 +415,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
-    - alert: MSTAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
@@ -488,345 +488,345 @@ spec:
       record: http_requests_total:burnrate6h
   - name: rhobs-mst-api-metrics-read-latency.slo
     rules:
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=2.0113571874999994 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-stage,latency=2.0113571874999994 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (6*0.900000)
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
         service: telemeter
         severity: high
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=2.0113571874999994 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-stage,latency=2.0113571874999994 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (0.900000)
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[5m]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[30m]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[1h]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[2h]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[6h]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[1d]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[3d]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate3d
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=10.761264004567169 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-stage,latency=10.761264004567169 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (6*0.900000)
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
         service: telemeter
         severity: high
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=10.761264004567169 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-stage,latency=10.761264004567169 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (0.900000)
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[5m]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[30m]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[1h]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[2h]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[6h]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[1d]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[3d]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate3d
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=21.6447457021712 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-stage,latency=21.6447457021712 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (6*0.900000)
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
         service: telemeter
         severity: high
-    - alert: MSTAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=21.6447457021712 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#mstapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-stage,latency=21.6447457021712 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (0.900000)
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[5m]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[30m]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[1h]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[2h]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[6h]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[1d]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[3d]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-mst-production
+        namespace: observatorium-mst-stage
       record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -129,11 +129,11 @@ spec:
       record: http_requests_total:burnrate6h
   - name: rhobs-mst-api-metrics-write-latency.slo
     rules:
-    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
@@ -152,11 +152,11 @@ spec:
         latency: "5"
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
@@ -370,11 +370,11 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -385,11 +385,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -400,11 +400,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -415,11 +415,11 @@ spec:
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -361,11 +361,11 @@ spec:
       record: http_requests_total:burnrate6h
   - name: rhobs-telemeter-api-metrics-write-latency.slo
     rules:
-    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
@@ -384,11 +384,11 @@ spec:
         latency: "5"
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
@@ -602,11 +602,11 @@ spec:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -617,11 +617,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -632,11 +632,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -647,11 +647,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -723,315 +723,342 @@ spec:
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=2.0113571874999994 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1h{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate5m{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate30m{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.900000)
         )
       labels:
         latency: "2.0113571874999994"
+        namespace: observatorium-production
         service: telemeter
         severity: critical
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=2.0113571874999994 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1d{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate2h{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate3d{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.900000)
         )
       labels:
         latency: "2.0113571874999994"
+        namespace: observatorium-production
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[5m]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate5m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[30m]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate30m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[1h]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[2h]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate2h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[6h]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate6h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[1d]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[3d]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate3d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=10.761264004567169 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1h{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate5m{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate30m{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.900000)
         )
       labels:
         latency: "10.761264004567169"
+        namespace: observatorium-production
         service: telemeter
         severity: critical
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=10.761264004567169 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1d{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate2h{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate3d{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.900000)
         )
       labels:
         latency: "10.761264004567169"
+        namespace: observatorium-production
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[5m]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate5m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[30m]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate30m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[1h]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[2h]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate2h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[6h]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate6h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[1d]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[3d]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate3d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=21.6447457021712 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1h{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate5m{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate30m{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.900000)
         )
       labels:
         latency: "21.6447457021712"
+        namespace: observatorium-production
         service: telemeter
         severity: critical
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=21.6447457021712 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1d{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate2h{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate3d{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.900000)
         )
       labels:
         latency: "21.6447457021712"
+        namespace: observatorium-production
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[5m]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate5m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[30m]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate30m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[1h]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[2h]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate2h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[6h]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate6h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[1d]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[3d]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate3d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -14,7 +14,7 @@ spec:
     - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to gurantee availability SLOs
+        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(haproxy_server_http_responses_total:burnrate5m{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -28,7 +28,7 @@ spec:
     - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to gurantee availability SLOs
+        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(haproxy_server_http_responses_total:burnrate30m{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -42,7 +42,7 @@ spec:
     - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to gurantee availability SLOs
+        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(haproxy_server_http_responses_total:burnrate2h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -56,7 +56,7 @@ spec:
     - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to gurantee availability SLOs
+        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(haproxy_server_http_responses_total:burnrate6h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
@@ -246,7 +246,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -261,7 +261,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -276,7 +276,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -291,7 +291,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
@@ -489,7 +489,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -504,7 +504,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -519,7 +519,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -534,7 +534,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
@@ -605,7 +605,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -620,7 +620,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -635,7 +635,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -650,7 +650,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -243,11 +243,11 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate3d
   - name: rhobs-telemeter-api-metrics-write-availability.slo
     rules:
-    - alert: TelemeterAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -258,11 +258,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -273,11 +273,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -288,11 +288,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
-    - alert: TelemeterAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
@@ -486,11 +486,11 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate3d
   - name: rhobs-telemeter-api-metrics-read-availability.slo
     rules:
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -501,11 +501,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -516,11 +516,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -531,11 +531,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
@@ -720,11 +720,11 @@ spec:
       record: http_requests_total:burnrate6h
   - name: rhobs-telemeter-api-metrics-read-latency.slo
     rules:
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=2.0113571874999994 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.900000)
@@ -742,11 +742,11 @@ spec:
         namespace: observatorium-production
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=2.0113571874999994 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.900000)
@@ -834,11 +834,11 @@ spec:
         latency: "2.0113571874999994"
         namespace: observatorium-production
       record: latencytarget:up_custom_query_duration_seconds:rate3d
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=10.761264004567169 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.900000)
@@ -856,11 +856,11 @@ spec:
         namespace: observatorium-production
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=10.761264004567169 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.900000)
@@ -948,11 +948,11 @@ spec:
         latency: "10.761264004567169"
         namespace: observatorium-production
       record: latencytarget:up_custom_query_duration_seconds:rate3d
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=21.6447457021712 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.900000)
@@ -970,11 +970,11 @@ spec:
         namespace: observatorium-production
         service: telemeter
         severity: critical
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=21.6447457021712 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
           latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.900000)

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -723,315 +723,342 @@ spec:
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=2.0113571874999994 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1h{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate5m{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate30m{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.900000)
         )
       labels:
         latency: "2.0113571874999994"
+        namespace: observatorium-production
         service: telemeter
         severity: high
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=2.0113571874999994 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1d{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate2h{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate3d{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-1M-samples",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.900000)
         )
       labels:
         latency: "2.0113571874999994"
+        namespace: observatorium-production
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[5m]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate5m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[30m]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate30m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[1h]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[2h]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate2h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[6h]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate6h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[1d]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-1M-samples",le="2.0113571874999994",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-1M-samples"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[3d]))
         )
       labels:
         latency: "2.0113571874999994"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate3d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=10.761264004567169 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1h{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate5m{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate30m{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.900000)
         )
       labels:
         latency: "10.761264004567169"
+        namespace: observatorium-production
         service: telemeter
         severity: high
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=10.761264004567169 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1d{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate2h{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate3d{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-10M-samples",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.900000)
         )
       labels:
         latency: "10.761264004567169"
+        namespace: observatorium-production
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[5m]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate5m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[30m]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate30m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[1h]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[2h]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate2h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[6h]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate6h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[1d]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-10M-samples",le="10.761264004567169",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-10M-samples"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[3d]))
         )
       labels:
         latency: "10.761264004567169"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate3d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=21.6447457021712 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1h{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate5m{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate30m{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.900000)
         )
       labels:
         latency: "21.6447457021712"
+        namespace: observatorium-production
         service: telemeter
         severity: high
     - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=21.6447457021712 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate1d{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate2h{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds_bucket:rate3d{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds_bucket:rate6h{query="query-path-sli-100M-samples",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.900000)
         )
       labels:
         latency: "21.6447457021712"
+        namespace: observatorium-production
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[5m]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate5m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[30m]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate30m
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[1h]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[2h]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate2h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[6h]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate6h
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[1d]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate1d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket_bucket{query="query-path-sli-100M-samples",le="21.6447457021712",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_bucket_count{query="query-path-sli-100M-samples"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[3d]))
         )
       labels:
         latency: "21.6447457021712"
-      record: latencytarget:up_custom_query_duration_seconds_bucket:rate3d
+        namespace: observatorium-production
+      record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -243,11 +243,11 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate3d
   - name: rhobs-telemeter-api-metrics-write-availability.slo
     rules:
-    - alert: TelemeterAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -258,11 +258,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -273,11 +273,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -288,11 +288,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
-    - alert: TelemeterAPIMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /receive handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswriteavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
@@ -486,11 +486,11 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate3d
   - name: rhobs-telemeter-api-metrics-read-availability.slo
     rules:
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -501,11 +501,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -516,11 +516,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -531,11 +531,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query handler is burning too much error budget to gurantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
@@ -720,345 +720,345 @@ spec:
       record: http_requests_total:burnrate6h
   - name: rhobs-telemeter-api-metrics-read-latency.slo
     rules:
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=2.0113571874999994 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-stage,latency=2.0113571874999994 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (6*0.900000)
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-production
+        namespace: observatorium-stage
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=2.0113571874999994 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-stage,latency=2.0113571874999994 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (0.900000)
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-production
+        namespace: observatorium-stage
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[5m]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[30m]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[1h]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[2h]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[6h]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[1d]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[3d]))
         )
       labels:
         latency: "2.0113571874999994"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate3d
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=10.761264004567169 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-stage,latency=10.761264004567169 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (6*0.900000)
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-production
+        namespace: observatorium-stage
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=10.761264004567169 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-stage,latency=10.761264004567169 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (0.900000)
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-production
+        namespace: observatorium-stage
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[5m]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[30m]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[1h]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[2h]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[6h]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[1d]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[3d]))
         )
       labels:
         latency: "10.761264004567169"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate3d
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=21.6447457021712 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-stage,latency=21.6447457021712 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (14.4*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (14.4*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (6*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (6*0.900000)
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-production
+        namespace: observatorium-stage
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsReadLatencyErrorBudgetBurning
+    - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=21.6447457021712 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadlatencyerrorbudgetburning
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-stage,latency=21.6447457021712 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (3*0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (3*0.900000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (0.900000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (0.900000)
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-production
+        namespace: observatorium-stage
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[5m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[5m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[5m]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[30m]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[30m]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[30m]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[1h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[1h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[1h]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[2h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[2h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[2h]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[6h]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[6h]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[6h]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[1d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[1d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[1d]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[3d]))
           /
-          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[3d]))
+          sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[3d]))
         )
       labels:
         latency: "21.6447457021712"
-        namespace: observatorium-production
+        namespace: observatorium-stage
       record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -361,11 +361,11 @@ spec:
       record: http_requests_total:burnrate6h
   - name: rhobs-telemeter-api-metrics-write-latency.slo
     rules:
-    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
@@ -384,11 +384,11 @@ spec:
         latency: "5"
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsWriteLatencyErrorBudgetBurning
+    - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricswritelatencyerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
           latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
@@ -602,11 +602,11 @@ spec:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
@@ -617,11 +617,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
@@ -632,11 +632,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: high
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
@@ -647,11 +647,11 @@ spec:
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
-    - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
+    - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -14,7 +14,7 @@ spec:
     - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to gurantee availability SLOs
+        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(haproxy_server_http_responses_total:burnrate5m{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -28,7 +28,7 @@ spec:
     - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to gurantee availability SLOs
+        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(haproxy_server_http_responses_total:burnrate30m{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -42,7 +42,7 @@ spec:
     - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to gurantee availability SLOs
+        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(haproxy_server_http_responses_total:burnrate2h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -56,7 +56,7 @@ spec:
     - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to gurantee availability SLOs
+        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(haproxy_server_http_responses_total:burnrate6h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
@@ -246,7 +246,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -261,7 +261,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -276,7 +276,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -291,7 +291,7 @@ spec:
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /receive handler is burning too much error budget to gurantee availability SLOs
+        message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
@@ -489,7 +489,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -504,7 +504,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -519,7 +519,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -534,7 +534,7 @@ spec:
     - alert: APIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to gurantee availability SLOs
+        message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
@@ -605,7 +605,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
@@ -620,7 +620,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
@@ -635,7 +635,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
@@ -650,7 +650,7 @@ spec:
     - alert: TelemeterAPIMetricsReadAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query_range handler is burning too much error budget to gurantee availability SLOs
+        message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterapimetricsreadavailabilityerrorbudgetburning
       expr: |
         sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))


### PR DESCRIPTION
This PR adds SLO alerts for the MST instance. Given the length of the app-interface MR cycles it makes sense to define them all now and only go through one more iteration cycle.

We also refactor out the common parts from both the Telemeter & MST SLOs.

We will only ship the production alerts once we've checked staging & when all of the associated run books have been written.