### PR TITLE
Add runbook for ThanosReceiveTrafficBelowThreshold alert

### DIFF
--- a/docs/sop/observatorium.md
+++ b/docs/sop/observatorium.md
@@ -1048,7 +1048,7 @@ NOTE: This must be done with a 4.x version of the oc client.
 
 ### Impact
 
-If there is an unusual drop in traffic/ingestion rate, a *symptom* is that some data loss may happen or that data is not correctly forwarded from Thanos Query -> Thanos Receive. As a consequence, less data is forwarded to Object Storage.
+If there is an unusual drop in traffic/ingestion rate, a *symptom* is that some data loss may happen or that data is not correctly forwarded to Thanos Receive. As a consequence, less data is forwarded to Object Storage.
 
 ### Summary
 

--- a/docs/sop/observatorium.md
+++ b/docs/sop/observatorium.md
@@ -3,57 +3,58 @@
 <!-- TOC depthTo:2 -->
 
 - Observatorium
-    - [Verify components are running](#verify-components-are-running)
+  - [Verify components are running](#verify-components-are-running)
 - Observatorium Proactive Monitoring
-    - [ObservatoriumHttpTrafficErrorRateHigh](#observatoriumhttptrafficerrorratehigh)
-    - [ObservatoriumProActiveMetricsQueryErrorRateHigh](#observatoriumproactivemetricsqueryerrorratehigh)
+  - [ObservatoriumHttpTrafficErrorRateHigh](#observatoriumhttptrafficerrorratehigh)
+  - [ObservatoriumProActiveMetricsQueryErrorRateHigh](#observatoriumproactivemetricsqueryerrorratehigh)
 - Observatorium Tenants
-    - [ObservatoriumTenantsFailedOIDCRegistrations](#observatoriumtenantsfailedoidcregistrations)
-    - [ObservatoriumTenantsSkippedDuringConfiguration](#observatoriumtenantsskippedduringconfiguration)
+  - [ObservatoriumTenantsFailedOIDCRegistrations](#observatoriumtenantsfailedoidcregistrations)
+  - [ObservatoriumTenantsSkippedDuringConfiguration](#observatoriumtenantsskippedduringconfiguration)
 - Observatorium Logs
-    - [LokiRequestErrors](#lokirequesterrors)
-    - [LokiRequestPanics](#lokirequestpanics)
-    - [LokiRequestLatency](#lokirequestlatency)
-    - [LokiTenantRateLimitWarning](#lokitenantratelimitwarning)
-    - [ObservatoriumAPILogsErrorsSLOBudgetBurn](#observatoriumapilogserrorsslobudgetburn)
+  - [LokiRequestErrors](#lokirequesterrors)
+  - [LokiRequestPanics](#lokirequestpanics)
+  - [LokiRequestLatency](#lokirequestlatency)
+  - [LokiTenantRateLimitWarning](#lokitenantratelimitwarning)
+  - [ObservatoriumAPILogsErrorsSLOBudgetBurn](#observatoriumapilogserrorsslobudgetburn)
 - Observatorium Metrics
-    - [ThanosCompactMultipleRunning](#thanoscompactmultiplerunning)
-    - [ThanosCompactIsNotRunning](#thanoscompactisnotrunning)
-    - [ThanosCompactHalted](#thanoscompacthalted)
-    - [ThanosCompactHighCompactionFailures](#thanoscompacthighcompactionfailures)
-    - [ThanosCompactBucketHighOperationFailures](#thanoscompactbuckethighoperationfailures)
-    - [ThanosCompactHasNotRun](#thanoscompacthasnotrun)
-    - [ThanosCompactIsDown](#thanoscompactisdown)
-    - [ThanosQuerierGrpcServerErrorRate](#thanosqueriergrpcservererrorrate)
-    - [ThanosQuerierGrpcClientErrorRate](#thanosqueriergrpcclienterrorrate)
-    - [ThanosQuerierHighDNSFailures](#thanosquerierhighdnsfailures)
-    - [ThanosQuerierInstantLatencyHigh](#thanosquerierinstantlatencyhigh)
-    - [ThanosQuerierRangeLatencyHigh](#thanosquerierrangelatencyhigh)
-    - [ThanosQuerierIsDown](#thanosqueryisdown)
-    - [ThanosReceiveHttpRequestLatencyHigh](#thanosreceivehttprequestlatencyhigh)
-    - [ThanosReceiveHighForwardRequestFailures](#thanosreceivehighforwardrequestfailures)
-    - [ThanosReceiveHighHashringFileRefreshFailures](#thanosreceivehighhashringfilerefreshfailures)
-    - [ThanosReceiveConfigReloadFailure](#thanosreceiveconfigreloadfailure)
-    - [ThanosReceiveIsDown](#thanosreceiveisdown)
-    - [ThanosStoreGrpcErrorRate](#thanosstoregrpcerrorrate)
-    - [ThanosStoreSeriesGateLatencyHigh](#thanosstoreseriesgatelatencyhigh)
-    - [ThanosStoreBucketHighOperationFailures](#thanosstorebuckethighoperationfailures)
-    - [ThanosStoreObjstoreOperationLatencyHigh](#thanosstoreobjstoreoperationlatencyhigh)
-    - [ThanosStoreIsDown](#thanosstoreisdown)
-    - [ThanosReceiveControllerReconcileErrorRate](#thanosreceivecontrollerreconcileerrorrate)
-    - [ThanosReceiveControllerConfigmapChangeErrorRate](#thanosreceivecontrollerconfigmapchangeerrorrate)
-    - [ThanosReceiveControllerIsDown](#thanosreceivecontrollerisdown)
-    - [ThanosReceiveConfigStale](#thanosreceiveconfigstale)
-    - [ThanosReceiveConfigInconsistent](#thanosreceiveconfiginconsistent)
-    - [ThanosReceiveNoUpload](#thanosreceivenoupload)
-    - [ThanosRuleHighRuleEvaluationFailures](#thanosrulehighruleevaluationfailures)
-    - [ThanosNoRuleEvaluations](#thanosnoruleevaluations)
-    - [ThanosRuleRuleEvaluationLatencyHigh](#thanosruleruleevaluationlatencyhigh)
-    - [ThanosRuleTSDBNotIngestingSamples](#thanosruletsdbnotingestingsamples)
-    - [ThanosRuleIsDown](#thanosruleisdown)
-    - [ObservatoriumAPIMetricsErrorsSLOBudgetBurn](#observatoriumapimetricserrorsslobudgetburn)
-    - [GubernatorIsDown](#gubernatorisdown)
-    - [Escalations](#escalations)
+  - [ThanosCompactMultipleRunning](#thanoscompactmultiplerunning)
+  - [ThanosCompactIsNotRunning](#thanoscompactisnotrunning)
+  - [ThanosCompactHalted](#thanoscompacthalted)
+  - [ThanosCompactHighCompactionFailures](#thanoscompacthighcompactionfailures)
+  - [ThanosCompactBucketHighOperationFailures](#thanoscompactbuckethighoperationfailures)
+  - [ThanosCompactHasNotRun](#thanoscompacthasnotrun)
+  - [ThanosCompactIsDown](#thanoscompactisdown)
+  - [ThanosQuerierGrpcServerErrorRate](#thanosqueriergrpcservererrorrate)
+  - [ThanosQuerierGrpcClientErrorRate](#thanosqueriergrpcclienterrorrate)
+  - [ThanosQuerierHighDNSFailures](#thanosquerierhighdnsfailures)
+  - [ThanosQuerierInstantLatencyHigh](#thanosquerierinstantlatencyhigh)
+  - [ThanosQuerierRangeLatencyHigh](#thanosquerierrangelatencyhigh)
+  - [ThanosQuerierIsDown](#thanosqueryisdown)
+  - [ThanosReceiveHttpRequestLatencyHigh](#thanosreceivehttprequestlatencyhigh)
+  - [ThanosReceiveHighForwardRequestFailures](#thanosreceivehighforwardrequestfailures)
+  - [ThanosReceiveHighHashringFileRefreshFailures](#thanosreceivehighhashringfilerefreshfailures)
+  - [ThanosReceiveConfigReloadFailure](#thanosreceiveconfigreloadfailure)
+  - [ThanosReceiveIsDown](#thanosreceiveisdown)
+  - [ThanosStoreGrpcErrorRate](#thanosstoregrpcerrorrate)
+  - [ThanosStoreSeriesGateLatencyHigh](#thanosstoreseriesgatelatencyhigh)
+  - [ThanosStoreBucketHighOperationFailures](#thanosstorebuckethighoperationfailures)
+  - [ThanosStoreObjstoreOperationLatencyHigh](#thanosstoreobjstoreoperationlatencyhigh)
+  - [ThanosStoreIsDown](#thanosstoreisdown)
+  - [ThanosReceiveControllerReconcileErrorRate](#thanosreceivecontrollerreconcileerrorrate)
+  - [ThanosReceiveControllerConfigmapChangeErrorRate](#thanosreceivecontrollerconfigmapchangeerrorrate)
+  - [ThanosReceiveControllerIsDown](#thanosreceivecontrollerisdown)
+  - [ThanosReceiveConfigStale](#thanosreceiveconfigstale)
+  - [ThanosReceiveConfigInconsistent](#thanosreceiveconfiginconsistent)
+  - [ThanosReceiveNoUpload](#thanosreceivenoupload)
+  - [ThanosReceiveTrafficBelowThreshold](#thanosreceivetrafficbelowthreshold)
+  - [ThanosRuleHighRuleEvaluationFailures](#thanosrulehighruleevaluationfailures)
+  - [ThanosNoRuleEvaluations](#thanosnoruleevaluations)
+  - [ThanosRuleRuleEvaluationLatencyHigh](#thanosruleruleevaluationlatencyhigh)
+  - [ThanosRuleTSDBNotIngestingSamples](#thanosruletsdbnotingestingsamples)
+  - [ThanosRuleIsDown](#thanosruleisdown)
+  - [ObservatoriumAPIMetricsErrorsSLOBudgetBurn](#observatoriumapimetricserrorsslobudgetburn)
+  - [GubernatorIsDown](#gubernatorisdown)
+  - [Escalations](#escalations)
 
 <!-- /TOC -->
 
@@ -65,28 +66,27 @@ Check targets are UP in app-sre Prometheus:
 
 ### Logs
 
-- `loki-distributor`: https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-loki-distributor-production%2f0
+- `loki-distributor`: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-loki-distributor-production%2f0>
 
-- `loki-ingester`: https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-loki-ingester-production%2f0
+- `loki-ingester`: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-loki-ingester-production%2f0>
 
-- `loki-querier`: https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-loki-querier-production%2f0
+- `loki-querier`: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-loki-querier-production%2f0>
 
-- `loki-query-frontend`: https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-loki-query-frontend-production%2f0
+- `loki-query-frontend`: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-loki-query-frontend-production%2f0>
 
-- `loki-compactor`: https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-loki-compactor-production%2f0
+- `loki-compactor`: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-loki-compactor-production%2f0>
 
 ### Metrics
 
-- `thanos-querier`: https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-thanos-querier-production%2f0
+- `thanos-querier`: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-thanos-querier-production%2f0>
 
-- `thanos-receive`: https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-thanos-receive-default-production%2f0
+- `thanos-receive`: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-thanos-receive-default-production%2f0>
 
-- `thanos-store`: https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-thanos-store-production%2f0
+- `thanos-store`: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-thanos-store-production%2f0>
 
-- `thanos-receive-controller`: https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-thanos-receive-controller-production%2f0
+- `thanos-receive-controller`: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-thanos-receive-controller-production%2f0>
 
-- `thanos-compactor`: https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-thanos-compactor-production%2f0
-
+- `thanos-compactor`: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-app-sre-observability-production%2fobservatorium-thanos-compactor-production%2f0>
 
 ---
 
@@ -110,13 +110,13 @@ Users of RHOBS are not able to access API endpoints for either reading, writing 
 - Access to Vault secret for `tenants.yaml` (link for [staging](https://vault.devshift.net/ui/vault/secrets/app-interface/show/app-sre-stage/telemeter-stage/observatorium-observatorium-api); for [production](https://vault.devshift.net/ui/vault/secrets/app-interface/show/app-sre/telemeter-production/observatorium-observatorium-api) you will most likely need to contact [App-SRE](https://coreos.slack.com/archives/CCRND57FW))
 
 ### Steps
+
 - Check for any outage at Red Hat SSO.
 - Check the Vault secret for `tenants.yaml` (link for [staging](https://vault.devshift.net/ui/vault/secrets/app-interface/show/app-sre-stage/telemeter-stage/observatorium-observatorium-api); for [production](https://vault.devshift.net/ui/vault/secrets/app-interface/show/app-sre/telemeter-production/observatorium-observatorium-api) for valid Yaml content, valid tenant name, auth information under 'oidc', 'opa' sections and rate limiting information under 'rateLimits' section.
 - Check the logs of Observatorium API deployment's for telemeter tenant [pods](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/k8s/ns/observatorium-production/deployments/observatorium-observatorium-api)
 - Check the logs of Observatorium UP deployment's for telemeter tenant [pods](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/k8s/ns/observatorium-production/deployments/observatorium-observatorium-up)
 - Check the logs of Observatorium API deployment's for MST tenant [pods](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/k8s/ns/observatorium-mst-production/deployments/observatorium-observatorium-mst-api)
 - Check the logs of Observatorium UP deployment's for MST tenant [pods](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/k8s/ns/observatorium-mst-production/deployments/observatorium-observatorium-up)
-
 
 ## ObservatoriumProActiveMetricsQueryErrorRateHigh
 
@@ -138,6 +138,7 @@ Metrics queries generated by Proactive monitoring are failing.
 - Access to Vault secret for `tenants.yaml` (link for [staging](https://vault.devshift.net/ui/vault/secrets/app-interface/show/app-sre-stage/telemeter-stage/observatorium-observatorium-api); for [production](https://vault.devshift.net/ui/vault/secrets/app-interface/show/app-sre/telemeter-production/observatorium-observatorium-api) you will most likely need to contact [App-SRE](https://coreos.slack.com/archives/CCRND57FW))
 
 ### Steps
+
 - Check the Vault secret for `tenants.yaml` (link for [staging](https://vault.devshift.net/ui/vault/secrets/app-interface/show/app-sre-stage/telemeter-stage/observatorium-observatorium-api); for [production](https://vault.devshift.net/ui/vault/secrets/app-interface/show/app-sre/telemeter-production/observatorium-observatorium-api) for valid Yaml content, valid tenant name, auth information under 'oidc' and 'opa' sections and rate limiting information under 'rateLimits' section.
 - Check the logs of Observatorium UP deployment's for telemeter tenant [pods](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/k8s/ns/observatorium-production/deployments/observatorium-observatorium-up)
 - Check the logs of Observatorium API deployment's for telemeter tenant [pods](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/k8s/ns/observatorium-production/deployments/observatorium-observatorium-api)
@@ -981,7 +982,9 @@ The configuration of the instances of Thanos Receive are not same with Receive C
 ---
 
 ## ThanosRuleHighRuleEvaluationFailures
+
 ## ThanosNoRuleEvaluations
+
 ## ThanosRuleRuleEvaluationLatencyHigh
 
 ### Impact
@@ -1010,9 +1013,9 @@ Thanos Rulers are querying Thanos Queriers like any other user of Thanos, in tur
 - Check the [Thanos Rule dashboard](https://grafana.app-sre.devshift.net/d/35da848f5f92b2dc612e0c3a0577b8a1/thanos-rule?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace=telemeter-production&var-job=All&var-pod=All&var-interval=5m) to get a general overview.
 - Check the [Thanos Query dashboard](https://grafana.app-sre.devshift.net/d/af36c91291a603f1d9fbdabdd127ac4a/thanos-query?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace=telemeter-production&var-job=All&var-pod=All&var-interval=5m). Most likely you can focus on the Instant Query API RED metrics.
 - Drill down into the [Thanos Store dashboard](https://grafana.app-sre.devshift.net/d/e832e8f26403d95fac0ea1c59837588b/thanos-store?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace=telemeter-production&var-job=All&var-pod=All&var-interval=5m) and [Thanos Receiver dashboard](https://grafana.app-sre.devshift.net/d/916a852b00ccc5ed81056644718fa4fb/thanos-receive?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace=telemeter-production&var-job=All&var-pod=All&var-interval=5m). Depending on which one of them has the same elevated error rate, concentrate on that component.
-   - Probably, the Thanos Receiver is the problem, as the Thanos Ruler mostly looks at very recent data (like last 5min).
+  - Probably, the Thanos Receiver is the problem, as the Thanos Ruler mostly looks at very recent data (like last 5min).
 - Now that you, hopefully, know which component is causing the errors, dive into its logs, query it's raw metrics (check the dashboards as examples).
-   - Reach out to Observability Team (team-observability-platform@redhat.com), [`#forum-observatorium`](https://slack.com/app_redirect?channel=forum-observatorium) at CoreOS Slack, to get help in the investigation.
+  - Reach out to Observability Team (team-observability-platform@redhat.com), [`#forum-observatorium`](https://slack.com/app_redirect?channel=forum-observatorium) at CoreOS Slack, to get help in the investigation.
 
 ---
 
@@ -1041,6 +1044,37 @@ NOTE: This must be done with a 4.x version of the oc client.
 
 ---
 
+## ThanosReceiveTrafficBelowThreshold
+
+### Impact
+
+If there is an unusual drop in traffic/ingestion rate, a *symptom* is that some data loss may happen or that data is not correctly forwarded from Thanos Query -> Thanos Receive. As a consequence, less data is forwarded to Object Storage.
+
+### Summary
+
+Thanos Receive is experiencing low average 1h ingestion rate relative to average 12h ingestion rate. This may indicate an unusual low amount of data being received.
+
+### Severity
+
+`medium`
+
+### Access Required
+
+- Console access to the cluster that runs Observatorium (Currently [telemeter-prod-01 OSD](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/project-details/all-namespaces)) and [telemeter-stage-01 OSD](https://console-openshift-console.apps.app-sre-stage-0.k3s7.p1.openshiftapps.com/project-details/all-namespaces))
+- Edit access to the Observatorium namespaces:
+  - `observatorium-metrics-stage`
+  - `observatorium-metrics-production`
+  - `observatorium-mst-stage`
+  - `observatorium-mst-production`
+
+### Steps
+
+- Check [Thanos Receive dashboard](https://grafana.app-sre.devshift.net/d/916a852b00ccc5ed81056644718fa4fb/thanos-receive?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace=observatorium-mst-production&var-job=All&var-pod=All&var-interval=5m):
+  1. Select the desired namespace (`observatorium-metrics-production` or `observatorium-mst-production`)
+  2. Check for the `Rate` and `error` panels. The gRPC rows refer to the gRPC Store API.
+
+- Reach out to Observability Team and ping @observatorium-support at [`#forum-observatorium`](https://slack.com/app_redirect?channel=forum-observatorium) at CoreOS Slack, to get help in the investigation.
+
 ## ThanosRuleTSDBNotIngestingSamples
 
 ### Impact
@@ -1064,18 +1098,24 @@ Both Thanos Rule replicas internal TSDB failed to ingest samples.
 
 ### Steps
 
-- Recently we are hitting some issues where both replicas are stuck. We are investigating, but both replica pod restart mitigates the problem for some time (days). See: https://issues.redhat.com/browse/OBS-210
+- Recently we are hitting some issues where both replicas are stuck. We are investigating, but both replica pod restart mitigates the problem for some time (days). See: <https://issues.redhat.com/browse/OBS-210>
 - Inspect logs and events of failing jobs, using [OpenShift console](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/k8s/ns/telemeter-production/statefulsets/observatbility-thanos-rule/pods).
 - Reach out to Observability Team (team-observability-platform@redhat.com), [`#forum-observatorium`](https://slack.com/app_redirect?channel=forum-observatorium) at CoreOS Slack, to get help in the investigation.
 
 ---
 
 ## MandatoryThanosComponentIsDown
+
 ## ThanosCompactIsDown
+
 ## ThanosQueryIsDown
+
 ## ThanosReceiveIsDown
+
 ## ThanosStoreIsDown
+
 ## ThanosReceiveControllerIsDown
+
 ## ThanosRuleIsDown
 
 ### Impact
@@ -1194,23 +1234,23 @@ During the last 6 hours, not even a single Thanos Store block has been loaded.
 ### Steps
 
 - Check the namespace of RHOBS causing this alert to fire.
-- Check logs, configuration for Thanos compact, store and receive components for possible cause(s). 
+- Check logs, configuration for Thanos compact, store and receive components for possible cause(s).
 - Check Thanos compact Statefulset
-    - Check dashboard of Thanos compact
-    - Check the logs of Thanos compact pods for any errors.
-    - Check for valid configuration as per https://thanos.io/tip/components/compact.md/
-      - Object Store configuration (--objstore.config)
-      - Downsampling configuration (--retention.resolution-*)
-          - Currently Thanos compact works as expected if the retention.resolution-raw, retention.resolution-5m and retention.resolution-1h are set for the same duration. 
-    - Also check guidelines for these downsampling Thanos compact command line args at: https://thanos.io/tip/components/compact.md/
+  - Check dashboard of Thanos compact
+  - Check the logs of Thanos compact pods for any errors.
+  - Check for valid configuration as per <https://thanos.io/tip/components/compact.md/>
+    - Object Store configuration (--objstore.config)
+    - Downsampling configuration (--retention.resolution-*)
+      - Currently Thanos compact works as expected if the retention.resolution-raw, retention.resolution-5m and retention.resolution-1h are set for the same duration.
+  - Also check guidelines for these downsampling Thanos compact command line args at: <https://thanos.io/tip/components/compact.md/>
           - --retention.resolution-5m needs more than 40 hours
           - --retention.resolution-1h needs to be more than 10 days
 - Check Thanos store statefulset
-    - Check the logs of Thanos store pods for any errors related to blocks loading from Object store.
-    - Check for valid Object store configuration (--objstore.config) as per https://thanos.io/tip/components/store.md/
+  - Check the logs of Thanos store pods for any errors related to blocks loading from Object store.
+  - Check for valid Object store configuration (--objstore.config) as per <https://thanos.io/tip/components/store.md/>
 - Check Thanos receive Statefulset
-    - Check the logs of Thanos receive pods for any errors related to blocks uploaded to Object store.
-    - Check for valid Object store configuration (--objstore.config) as per https://thanos.io/tip/components/receive.md/
+  - Check the logs of Thanos receive pods for any errors related to blocks uploaded to Object store.
+  - Check for valid Object store configuration (--objstore.config) as per <https://thanos.io/tip/components/receive.md/>
 
 ## ObservatoriumPersistentVolumeUsageCritical
 
@@ -1241,6 +1281,7 @@ One or more PVCs are filled to more than 95%. The remaining free space does not 
 - Check the pods belonging to the component and establish what object do they belong to
 - Locate the affected deployment in the [AppSRE Interface](https://gitlab.cee.redhat.com/service/app-interface/-/tree/master/data/services/rhobs), depending on which namespace the alert is coming from
 - Increase the size of the PVC by adjusting the relevant parameter in one of the `saas.yaml` files
+
 ## GubernatorIsDown
 
 ### Impact

--- a/docs/sop/observatorium.md
+++ b/docs/sop/observatorium.md
@@ -1069,10 +1069,12 @@ Thanos Receive is experiencing low average 1h ingestion rate relative to average
 
 ### Steps
 
-- Check [Thanos Receive dashboard](https://grafana.app-sre.devshift.net/d/916a852b00ccc5ed81056644718fa4fb/thanos-receive?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace=observatorium-mst-production&var-job=All&var-pod=All&var-interval=5m):
-  1. Select the desired namespace (`observatorium-metrics-production` or `observatorium-mst-production`)
-  2. Check for the `Rate` and `error` panels. The gRPC rows refer to the gRPC Store API.
-
+- Check on the status of Thanos Receive:
+  1. Check [Thanos Receive dashboard](https://grafana.app-sre.devshift.net/d/916a852b00ccc5ed81056644718fa4fb/thanos-receive?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace=observatorium-mst-production&var-job=All&var-pod=All&var-interval=5m) (selecting the desired namespace (`observatorium-metrics-production` or `observatorium-mst-production`)). Check for the `Rate` and `error` panels. The gRPC rows refer to the gRPC Store API.
+  2. Check Thanos Receive logs
+- Check on the status of Observatorium API:
+  1. Check [Observatorium API dashboard](https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/api?orgId=1&refresh=1m&var-datasource=telemeter-prod-01-prometheus&var-namespace=observatorium-metrics-production&var-handler=All) (selecting the desired namespace (`observatorium-metrics-production` or `observatorium-mst-production`)).
+  2. Check API logs for potential errors
 - Reach out to Observability Team and ping @observatorium-support at [`#forum-observatorium`](https://slack.com/app_redirect?channel=forum-observatorium) at CoreOS Slack, to get help in the investigation.
 
 ## ThanosRuleTSDBNotIngestingSamples

--- a/docs/sop/telemeter.md
+++ b/docs/sop/telemeter.md
@@ -10,34 +10,34 @@
     - [Access required](#access-required)
     - [Steps](#steps)
   - [AuthorizeClientErrorsHigh](#authorizeclienterrorshigh)
-    - [Impact:](#impact-1)
-    - [Summary:](#summary-1)
-    - [Access required:](#access-required-1)
-    - [Steps:](#steps-1)
+    - [Impact](#impact-1)
+    - [Summary](#summary-1)
+    - [Access required](#access-required-1)
+    - [Steps](#steps-1)
   - [TelemeterAuthorizeErrorBudgetBurning](#telemeterauthorizeerrorbudgetburning)
   - [OAuthClientErrorsHigh](#oauthclienterrorshigh)
-    - [Impact:](#impact-2)
-    - [Summary:](#summary-2)
-    - [Access required:](#access-required-2)
-    - [Relevant secrets:](#relevant-secrets)
-    - [Steps:](#steps-2)
+    - [Impact](#impact-2)
+    - [Summary](#summary-2)
+    - [Access required](#access-required-2)
+    - [Relevant secrets](#relevant-secrets)
+    - [Steps](#steps-2)
   - [TelemeterDown](#telemeterdown)
-    - [Impact:](#impact-3)
-    - [Summary:](#summary-3)
-    - [Access required:](#access-required-3)
-    - [Steps:](#steps-3)
+    - [Impact](#impact-3)
+    - [Summary](#summary-3)
+    - [Access required](#access-required-3)
+    - [Steps](#steps-3)
   - [TelemeterUploadErrorBudgetBurning](#telemeteruploaderrorbudgetburning)
   - [UploadHandlerErrorsHigh](#uploadhandlererrorshigh)
-    - [Impact:](#impact-4)
-    - [Summary:](#summary-4)
-    - [Access required:](#access-required-4)
-    - [Relevant secrets:](#relevant-secrets-1)
-    - [Steps:](#steps-4)
+    - [Impact](#impact-4)
+    - [Summary](#summary-4)
+    - [Access required](#access-required-4)
+    - [Relevant secrets](#relevant-secrets-1)
+    - [Steps](#steps-4)
   - [TelemeterCapacity[Medium | High | Critical]](#telemetercapacitymedium--high--critical)
-    - [Impact:](#impact-5)
-    - [Summary:](#summary-5)
-    - [Access required:](#access-required-5)
-    - [Steps:](#steps-5)
+    - [Impact](#impact-5)
+    - [Summary](#summary-5)
+    - [Access required](#access-required-5)
+    - [Steps](#steps-5)
   - [Escalations](#escalations)
 
 <!-- /TOC -->
@@ -46,9 +46,9 @@
 
 ## Verify it's working
 
-- `telemeter-server` targets are UP in info-gw: https://infogw-data.api.openshift.com/targets#job-telemeter-server
-- `telemeter-server` targets are UP in `telemeter-prod-01` prom: https://prometheus.telemeter-prod-01.devshift.net/targets#job-telemeter-server
-- `Upload Handler` is returning 200s: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADJ/telemeter?orgId=1&from=now-6h&to=now
+- `telemeter-server` targets are UP in info-gw: <https://infogw-data.api.openshift.com/targets#job-telemeter-server>
+- `telemeter-server` targets are UP in `telemeter-prod-01` prom: <https://prometheus.telemeter-prod-01.devshift.net/targets#job-telemeter-server>
+- `Upload Handler` is returning 200s: <https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADJ/telemeter?orgId=1&from=now-6h&to=now>
 
 ## InfoGW Probe Failing
 
@@ -73,6 +73,7 @@ Prometheus blackbox exporter probes the target (also providing a bearer token to
   - `telemeter-production`, `observatorium-metrics-production`, `observatorium-production` for production
 
 ### Steps
+
 1. Check the generic SOP for failing `2xx` black-box probes in [AppSRE Interface repository](https://gitlab.cee.redhat.com/service/app-interface/blob/master/docs/app-sre/sop/blackbox-exporter-2xxProbeFailing.md).
 2. If probe is failing due to the authentication (e.g. you are seeing `403` or similar response in the probe log), make sure the bearer token secrets in Vault listed above are configured and valid.
 3. Log into the console for the relevant cluster (links above in `Access required`):
@@ -86,7 +87,7 @@ Prometheus blackbox exporter probes the target (also providing a bearer token to
 
 ## AuthorizeClientErrorsHigh
 
-### Impact:
+### Impact
 
 New clusters are not able to fetch an authorization token.
 We are lucky if clusters are already authorized.
@@ -94,22 +95,23 @@ We issue clusters inside telemeter a JWT token for 12 hours.
 All existing clusters will be okay for 12h window since last authorized.
 
 The error is related to clusters which are either:
+
 - New clusters trying to authorize.
 - Existing clusters who already have authorized,
 but the 12h window for the token has expired
 
-### Summary:
+### Summary
 
 Telemeter is recieving errors at a high rate from Keycloak.
 
-### Access required:
+### Access required
 
 - Console access to the cluster that runs telemeter (Currently `telemeter-prod-01` for production; `app-sre-stage-01` for staging`)
 - Edit access to the Telemeter namespaces:
-    - telemeter-stage on `app-sre-stage-01`
-    - telemeter-production on `telemeter-prod-01`
+  - telemeter-stage on `app-sre-stage-01`
+  - telemeter-production on `telemeter-prod-01`
 
-### Steps:
+### Steps
 
 1. Go to the [Telemeter dashboards](https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADJ/telemeter?orgId=1&refresh=1m&from=now-3h&to=now) and check the /authorize errors. Are the error rates elevated?
 1. Check if the issues come from us or upstream with this [Prometheus Query](https://prometheus.telemeter-prod-01.devshift.net/graph?g0.range_input=3h&g0.expr=sum(rate(client_api_requests_total%7Bclient%3D%22authorize%22%2Cjob%3D%22telemeter-server%22%2Cnamespace%3D%22telemeter-production%22%2Cstatus%3D~%225..%22%7D%5B5m%5D))%20or%20vector(0)%0A%2F%0Asum(rate(client_api_requests_total%7Bclient%3D%22authorize%22%2Cjob%3D%22telemeter-server%22%2Cnamespace%3D%22telemeter-production%22%7D%5B5m%5D))&g0.tab=0)
@@ -131,27 +133,27 @@ _Note: Soon this new alert will replace the inferior one below._
 
 ## OAuthClientErrorsHigh
 
-### Impact:
+### Impact
 
 Clusters are not able to fetch a new authorization token or renew it.
 
-### Summary:
+### Summary
 
 Telemeter server itself uses OAuth to authorize against tollbooth.
 It uses an access token, issued by RedHat's OAuth server (Keycloak).
 Telemeter is receiving error responses when trying to refresh the access token
 at a high rate from Keycloak.
 
-### Access required:
+### Access required
 
 - Console access to the cluster that runs telemeter (Currently `telemeter-prod-01` for production; `app-sre-stage-01` for staging`)
 - Edit access to the Telemeter namespaces:
-    - telemeter-stage on `app-sre-stage-01`
-    - telemeter-production on `telemeter-prod-01`
+  - telemeter-stage on `app-sre-stage-01`
+  - telemeter-production on `telemeter-prod-01`
 
-### Relevant secrets:
+### Relevant secrets
 
-### Steps:
+### Steps
 
 1. Go to the [Telemeter dashboards](https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADJ/telemeter?orgId=1&refresh=1m&from=now-3h&to=now) and check the /authorize errors. Are the error rates elevated?
 1. Check if the issues come from us or upstream with this [Prometheus Query](https://prometheus.telemeter-prod-01.devshift.net/graph?g0.range_input=3h&g0.expr=sum(rate(client_api_requests_total%7Bclient%3D%22oauth%22%2Cjob%3D%22telemeter-server%22%2Cnamespace%3D%22telemeter-production%22%2Cstatus%3D~%225..%22%7D%5B5m%5D))%20or%20vector(0)%0A%2F%0Asum(rate(client_api_requests_total%7Bclient%3D%22oauth%22%2Cjob%3D%22telemeter-server%22%2Cnamespace%3D%22telemeter-production%22%7D%5B5m%5D))&g0.tab=0)
@@ -164,24 +166,23 @@ at a high rate from Keycloak.
 
 ## TelemeterDown
 
-### Impact:
+### Impact
 
 If Telemeter is down for too long, then OpenShift clusters are not able to push metrics anymore and we start losing data.
 This may result in OCM showing erros and overall business metrics missing datapoints.
 
-### Summary:
+### Summary
 
 Telemeter Server might be down and not serving any requests.
 
-### Access required:
+### Access required
 
 - Console access to the cluster that runs telemeter (Currently `telemeter-prod-01` for production; `app-sre-stage-01` for staging`)
 - Edit access to the Telemeter namespaces:
-    - telemeter-stage on `app-sre-stage-01`
-    - telemeter-production on `telemeter-prod-01`### Severity: Critical
+  - telemeter-stage on `app-sre-stage-01`
+  - telemeter-production on `telemeter-prod-01`### Severity: Critical
 
-### Steps:
-
+### Steps
 
 1. Check if this problem is visibile to the outside. Can you see elevated error rates on [the Telemeter dashboard](https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADJ/telemeter?orgId=1&refresh=1m&from=now-3h&to=now)?
 1. Are there still Telemeter Pods? Are they crash looping? Are they ready? Check the OpenShift console for the `telemeter-production` namespace.
@@ -204,26 +205,25 @@ _Note: Soon this new alert will replace the inferior one below._
 
 ## UploadHandlerErrorsHigh
 
-### Impact:
+### Impact
 
 Clusters are not able to push metrics.
 
-### Summary:
+### Summary
 
 Upload errors happen, when metrics data is malformed or validation of metrics fails.
 Most likely the metrics payload is broken and thus possibly the telemeter metrics client.
 
-### Access required:
+### Access required
 
 - Console access to the cluster that runs telemeter (Currently `telemeter-prod-01` for production; `app-sre-stage-01` for staging`)
 - Edit access to the Telemeter namespaces:
-    - telemeter-stage on `app-sre-stage-01`
-    - telemeter-production on `telemeter-prod-01`
+  - telemeter-stage on `app-sre-stage-01`
+  - telemeter-production on `telemeter-prod-01`
 
+### Relevant secrets
 
-### Relevant secrets:
-
-### Steps:
+### Steps
 
 - Contact monitoring engineering team to help in the investigation.
 - Examine metrics payload by enabling the --verbose setting on telemeter client
@@ -238,22 +238,22 @@ on a cluster that is failing to push metrics.
 
 ## TelemeterCapacity[Medium | High | Critical]
 
-### Impact:
+### Impact
 
 Telemeter Prometheus may not be able to handle the total number of active timeseries and may crash.
 
-### Summary:
+### Summary
 
 Telemeter Prometheus is reaching to its limit of active timeseries and will be unable to handle the load. Soon Telemeter Prometheus may crash.
 
-### Access required:
+### Access required
 
 - Console access to the cluster that runs telemeter (Currently `telemeter-prod-01` for production; `app-sre-stage-01` for staging`)
 - Edit access to the Telemeter namespaces:
-    - telemeter-stage on `app-sre-stage-01`
-    - telemeter-production on `telemeter-prod-01`### Severity: Critical
+  - telemeter-stage on `app-sre-stage-01`
+  - telemeter-production on `telemeter-prod-01`### Severity: Critical
 
-### Steps:
+### Steps
 
 - Contact monitoring engineering team for help.
 - Inspect Telemeter Prometheus logs and metrics.


### PR DESCRIPTION
- Adds a runbook for ThanosReceiveTrafficBelowThreshold. After the runbook is merged, we can add `ThanosReceiveTrafficBelowThreshold` alert to RHOBS infrastructure via app interface (essentially reopen this [MR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/29529) to stage and to production afterwards)
- Some formatting changes for better readability (they were done automatically by this markdown-lint extension I have integrated in my editor) 

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>