### PR TITLE
Increasing index cache memcache get multi concurrency

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2181,7 +2181,7 @@ objects:
               "max_async_buffer_size": 200000
               "max_async_concurrency": 200
               "max_get_multi_batch_size": 100
-              "max_get_multi_concurrency": 1000
+              "max_get_multi_concurrency": 0
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
               "timeout": "2s"
@@ -2427,7 +2427,7 @@ objects:
               "max_async_buffer_size": 200000
               "max_async_concurrency": 200
               "max_get_multi_batch_size": 100
-              "max_get_multi_concurrency": 1000
+              "max_get_multi_concurrency": 0
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
               "timeout": "2s"
@@ -2673,7 +2673,7 @@ objects:
               "max_async_buffer_size": 200000
               "max_async_concurrency": 200
               "max_get_multi_batch_size": 100
-              "max_get_multi_concurrency": 1000
+              "max_get_multi_concurrency": 0
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
               "timeout": "2s"

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -247,7 +247,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           max_async_buffer_size: 200000,  // default: 10_000
           max_async_concurrency: 200,  // default: 20
           max_get_multi_batch_size: 100,  // default: 0 - No batching.
-          max_get_multi_concurrency: 1000,  // default: 100
+          max_get_multi_concurrency: 0,  // default: 100
           max_item_size: '5MiB',  // default: 1Mb
         },
       },


### PR DESCRIPTION
Currently we're suffering from intermittent `ThoreStoreGrpcErrorRate` increases that we have attributed to `get_multi` timeouts between Thanos store shards and their respective memcache instances. 

### Around the time Thanos Store started timing out we saw an increase in `getmulti` timeouts on the index-cache
![image](https://user-images.githubusercontent.com/50833398/151403865-49cf64b7-9569-4c0a-8b17-63c21a01ac50.png)


### Looking further we see an equivalent spike in `thanos_memcached_getmulti_gate_duration_seconds_bucket` (requests waiting to be dispatched to memcache) 
![image](https://user-images.githubusercontent.com/50833398/151403383-6176f878-f838-48a0-914a-4576c518079c.png)

### We also see Thanos store executing the `max_get_multi` requests it is configured to (1000 prior to this PR) 
![image](https://user-images.githubusercontent.com/50833398/151403520-93fed96d-5921-487a-85f5-729b9506dd30.png)

We would like to uncap this limit to stop get_multi requests timing out waiting for their turn. 


[Queries in question](https://prometheus.telemeter-prod-01.devshift.net/graph?g0.range_input=1h&g0.end_input=2022-01-27%2016%3A00&g0.expr=thanos_memcached_getmulti_gate_queries_in_flight%7Bnamespace%3D%22observatorium-metrics-production%22%2C%20name%3D%22index-cache%22%7D&g0.tab=0&g1.range_input=1h&g1.end_input=2022-01-27%2016%3A00&g1.expr=histogram_quantile(0.90%2C%20rate(thanos_memcached_getmulti_gate_duration_seconds_bucket%7B%20namespace%3D%22observatorium-metrics-production%22%2C%20name%3D%22index-cache%22%7D%5B5m%5D))&g1.tab=0&g2.range_input=1h&g2.end_input=2022-01-27%2016%3A00&g2.expr=rate(thanos_memcached_operation_failures_total%7Bnamespace%3D%22observatorium-metrics-production%22%2C%20operation%3D%22getmulti%22%2C%20name%3D%22index-cache%22%2C%20reason%3D%22timeout%22%7D%5B5m%5D)&g2.tab=0)

