### PR TITLE
Add query label to SLO rule definitions

### DIFF
--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -126,7 +126,6 @@ local appSREOverwrites(environment) = {
     labels: std.prune(labels {
       group: null,
       code: null,
-      query: null,
     }),
   },
 

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -508,6 +508,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-production
+        query: query-path-sli-1M-samples
         service: telemeter
         severity: critical
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -530,6 +531,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-production
+        query: query-path-sli-1M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -541,6 +543,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -551,6 +554,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -561,6 +565,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -571,6 +576,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -581,6 +587,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -591,6 +598,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -601,6 +609,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
@@ -622,6 +631,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-production
+        query: query-path-sli-10M-samples
         service: telemeter
         severity: critical
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -644,6 +654,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-production
+        query: query-path-sli-10M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -655,6 +666,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -665,6 +677,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -675,6 +688,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -685,6 +699,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -695,6 +710,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -705,6 +721,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -715,6 +732,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
@@ -736,6 +754,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-production
+        query: query-path-sli-100M-samples
         service: telemeter
         severity: critical
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -758,6 +777,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-production
+        query: query-path-sli-100M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -769,6 +789,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -779,6 +800,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -789,6 +811,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -799,6 +822,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -809,6 +833,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -819,6 +844,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -829,4 +855,5 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -508,6 +508,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-stage
+        query: query-path-sli-1M-samples
         service: telemeter
         severity: high
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -530,6 +531,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-stage
+        query: query-path-sli-1M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -541,6 +543,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -551,6 +554,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -561,6 +565,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -571,6 +576,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -581,6 +587,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -591,6 +598,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -601,6 +609,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-mst-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
@@ -622,6 +631,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-stage
+        query: query-path-sli-10M-samples
         service: telemeter
         severity: high
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -644,6 +654,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-stage
+        query: query-path-sli-10M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -655,6 +666,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -665,6 +677,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -675,6 +688,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -685,6 +699,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -695,6 +710,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -705,6 +721,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -715,6 +732,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-mst-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
@@ -736,6 +754,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-stage
+        query: query-path-sli-100M-samples
         service: telemeter
         severity: high
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -758,6 +777,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-stage
+        query: query-path-sli-100M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -769,6 +789,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -779,6 +800,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -789,6 +811,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -799,6 +822,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -809,6 +833,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -819,6 +844,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -829,4 +855,5 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-mst-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -740,6 +740,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-production
+        query: query-path-sli-1M-samples
         service: telemeter
         severity: critical
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -762,6 +763,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-production
+        query: query-path-sli-1M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -773,6 +775,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -783,6 +786,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -793,6 +797,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -803,6 +808,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -813,6 +819,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -823,6 +830,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -833,6 +841,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-production
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
@@ -854,6 +863,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-production
+        query: query-path-sli-10M-samples
         service: telemeter
         severity: critical
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -876,6 +886,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-production
+        query: query-path-sli-10M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -887,6 +898,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -897,6 +909,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -907,6 +920,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -917,6 +931,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -927,6 +942,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -937,6 +953,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -947,6 +964,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-production
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
@@ -968,6 +986,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-production
+        query: query-path-sli-100M-samples
         service: telemeter
         severity: critical
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -990,6 +1009,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-production
+        query: query-path-sli-100M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -1001,6 +1021,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -1011,6 +1032,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -1021,6 +1043,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -1031,6 +1054,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -1041,6 +1065,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -1051,6 +1076,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -1061,4 +1087,5 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-production
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -740,6 +740,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-stage
+        query: query-path-sli-1M-samples
         service: telemeter
         severity: high
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -762,6 +763,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-stage
+        query: query-path-sli-1M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -773,6 +775,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -783,6 +786,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -793,6 +797,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -803,6 +808,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -813,6 +819,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -823,6 +830,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -833,6 +841,7 @@ spec:
       labels:
         latency: "2.0113571874999994"
         namespace: observatorium-stage
+        query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
@@ -854,6 +863,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-stage
+        query: query-path-sli-10M-samples
         service: telemeter
         severity: high
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -876,6 +886,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-stage
+        query: query-path-sli-10M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -887,6 +898,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -897,6 +909,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -907,6 +920,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -917,6 +931,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -927,6 +942,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -937,6 +953,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -947,6 +964,7 @@ spec:
       labels:
         latency: "10.761264004567169"
         namespace: observatorium-stage
+        query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
@@ -968,6 +986,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-stage
+        query: query-path-sli-100M-samples
         service: telemeter
         severity: high
     - alert: APIMetricsReadLatencyErrorBudgetBurning
@@ -990,6 +1009,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-stage
+        query: query-path-sli-100M-samples
         service: telemeter
         severity: medium
     - expr: |
@@ -1001,6 +1021,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
@@ -1011,6 +1032,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
@@ -1021,6 +1043,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
@@ -1031,6 +1054,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
@@ -1041,6 +1065,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
@@ -1051,6 +1076,7 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
@@ -1061,4 +1087,5 @@ spec:
       labels:
         latency: "21.6447457021712"
         namespace: observatorium-stage
+        query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d


### PR DESCRIPTION
We need the `query` label in order to alert on our read path latency SLOs. Without this label, the alert evaluation always returns empty due to a missing label in the `latencytarget*` family of [rules](https://prometheus.app-sre-stage-01.devshift.net/graph?g0.expr=(latencytarget%3Aup_custom_query_duration_seconds%3Arate1d%7Blatency%3D%222.0113571874999994%22%2Cnamespace%3D%22observatorium-mst-stage%22%2Cquery%3D%22query-path-sli-1M-samples%22%7D%20%3E%20(3%20*%200.9)%20and%20latencytarget%3Aup_custom_query_duration_seconds%3Arate2h%7Blatency%3D%222.0113571874999994%22%2Cnamespace%3D%22observatorium-mst-stage%22%2Cquery%3D%22query-path-sli-1M-samples%22%7D%20%3E%20(3%20*%200.9))%20or%20(latencytarget%3Aup_custom_query_duration_seconds%3Arate3d%7Blatency%3D%222.0113571874999994%22%2Cnamespace%3D%22observatorium-mst-stage%22%2Cquery%3D%22query-path-sli-1M-samples%22%7D%20%3E%20(0.9)%20and%20latencytarget%3Aup_custom_query_duration_seconds%3Arate6h%7Blatency%3D%222.0113571874999994%22%2Cnamespace%3D%22observatorium-mst-stage%22%2Cquery%3D%22query-path-sli-1M-samples%22%7D%20%3E%20(0.9))&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h&g1.expr=latencytarget%3Aup_custom_query_duration_seconds%3Arate1d&g1.tab=1&g1.stacked=0&g1.show_exemplars=0&g1.range_input=1h&g2.expr=up_custom_query_duration_seconds_count&g2.tab=1&g2.stacked=0&g2.show_exemplars=0&g2.range_input=1h).

Previously, we excluded it to pass app-interface validation, PR to add query label to the prometheus rule schema is [here](https://github.com/app-sre/qontract-schemas/pull/67).

We need to wait for :point_up: to be merged before merging & shipping this change. 

Signed-off-by: Ian Billett <ibillett@redhat.com>