### PR TITLE
Increasing getMultiBatchSize on indexCache memcached instance

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2063,7 +2063,7 @@ objects:
               "dns_provider_update_interval": "10s"
               "max_async_buffer_size": 200000
               "max_async_concurrency": 200
-              "max_get_multi_batch_size": 100
+              "max_get_multi_batch_size": 0
               "max_get_multi_concurrency": 0
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
@@ -2309,7 +2309,7 @@ objects:
               "dns_provider_update_interval": "10s"
               "max_async_buffer_size": 200000
               "max_async_concurrency": 200
-              "max_get_multi_batch_size": 100
+              "max_get_multi_batch_size": 0
               "max_get_multi_concurrency": 0
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
@@ -2555,7 +2555,7 @@ objects:
               "dns_provider_update_interval": "10s"
               "max_async_buffer_size": 200000
               "max_async_concurrency": 200
-              "max_get_multi_batch_size": 100
+              "max_get_multi_batch_size": 0
               "max_get_multi_concurrency": 0
               "max_idle_connections": 1300
               "max_item_size": "5MiB"

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -246,7 +246,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           timeout: '2s',  // default: 500ms
           max_async_buffer_size: 200000,  // default: 10_000
           max_async_concurrency: 200,  // default: 20
-          max_get_multi_batch_size: 100,  // default: 0 - No batching.
+          max_get_multi_batch_size: 0,  // default: 0 - Batch every request into one.
           max_get_multi_concurrency: 0,  // default: 100
           max_item_size: '5MiB',  // default: 1Mb
         },


### PR DESCRIPTION
Upon removing concurrency limits we're still observing timeouts on requests to memcache from store gateway. 

* Memached cpu/memory utilization remains minimal, so we believe there is capacity to service one large getMulti requests instead of several smaller ones
* StoreGW appears to be operating near its CPU limit, which might explain the timeouts on requests with no CPU resources to fulfil them. Reducing the number of requests may help with this also

Signed-off-by: mzardab <mzardab@redhat.com>