### PR TITLE
Increase max async buffer size index cache

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2061,7 +2061,7 @@ objects:
               "addresses":
               - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
               "dns_provider_update_interval": "10s"
-              "max_async_buffer_size": 200000
+              "max_async_buffer_size": 400000
               "max_async_concurrency": 200
               "max_get_multi_batch_size": 100
               "max_get_multi_concurrency": 0
@@ -2307,7 +2307,7 @@ objects:
               "addresses":
               - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
               "dns_provider_update_interval": "10s"
-              "max_async_buffer_size": 200000
+              "max_async_buffer_size": 400000
               "max_async_concurrency": 200
               "max_get_multi_batch_size": 100
               "max_get_multi_concurrency": 0
@@ -2553,7 +2553,7 @@ objects:
               "addresses":
               - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
               "dns_provider_update_interval": "10s"
-              "max_async_buffer_size": 200000
+              "max_async_buffer_size": 400000
               "max_async_concurrency": 200
               "max_get_multi_batch_size": 100
               "max_get_multi_concurrency": 0

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -244,7 +244,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           // Default Memcached Max Connection Limit is '3072', this is related to concurrency.
           max_idle_connections: 1300,  // default: 100 - For better performances, this should be set to a number higher than your peak parallel requests.
           timeout: '2s',  // default: 500ms
-          max_async_buffer_size: 200000,  // default: 10_000
+          max_async_buffer_size: 400000,  // default: 10_000
           max_async_concurrency: 200,  // default: 20
           max_get_multi_batch_size: 100,  // default: 0 - No batching.
           max_get_multi_concurrency: 0,  // default: 100

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -246,7 +246,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           timeout: '2s',  // default: 500ms
           max_async_buffer_size: 400000,  // default: 10_000
           max_async_concurrency: 200,  // default: 20
-          max_get_multi_batch_size: 100,  // default: 0 - No batching.
+          max_get_multi_batch_size: 0,  // default: 0 - No batching.
           max_get_multi_concurrency: 0,  // default: 100
           max_item_size: '5MiB',  // default: 1Mb
         },


### PR DESCRIPTION
After fixing getMulti timeouts, we have write-limited thanos-store. The consequence is the async buffer fills up before it can be exhausted and skips operations. This will bump the async buffer size to allow it more time to commit the writes. 