### PR TITLE
Increasing index max_async_concurrenct to 1000 and setting max_get_multi_batch_size to 10000

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2062,8 +2062,8 @@ objects:
               - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
               "dns_provider_update_interval": "10s"
               "max_async_buffer_size": 400000
-              "max_async_concurrency": 200
-              "max_get_multi_batch_size": 0
+              "max_async_concurrency": 1000
+              "max_get_multi_batch_size": 10000
               "max_get_multi_concurrency": 0
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
@@ -2308,8 +2308,8 @@ objects:
               - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
               "dns_provider_update_interval": "10s"
               "max_async_buffer_size": 400000
-              "max_async_concurrency": 200
-              "max_get_multi_batch_size": 0
+              "max_async_concurrency": 1000
+              "max_get_multi_batch_size": 10000
               "max_get_multi_concurrency": 0
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
@@ -2554,8 +2554,8 @@ objects:
               - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
               "dns_provider_update_interval": "10s"
               "max_async_buffer_size": 400000
-              "max_async_concurrency": 200
-              "max_get_multi_batch_size": 0
+              "max_async_concurrency": 1000
+              "max_get_multi_batch_size": 10000
               "max_get_multi_concurrency": 0
               "max_idle_connections": 1300
               "max_item_size": "5MiB"

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -245,8 +245,8 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           max_idle_connections: 1300,  // default: 100 - For better performances, this should be set to a number higher than your peak parallel requests.
           timeout: '2s',  // default: 500ms
           max_async_buffer_size: 400000,  // default: 10_000
-          max_async_concurrency: 200,  // default: 20
-          max_get_multi_batch_size: 0,  // default: 0 - No batching.
+          max_async_concurrency: 1000,  // default: 20
+          max_get_multi_batch_size: 10000,  // default: 0 - No batching.
           max_get_multi_concurrency: 0,  // default: 100
           max_item_size: '5MiB',  // default: 1Mb
         },


### PR DESCRIPTION
Through the repro in staging we have:
* Managed to reduce `getMulti` timeouts by sending a single large request
![image](https://user-images.githubusercontent.com/50833398/151790184-c67da1c7-4aa0-46dc-8a5f-1bcf11b8b28b.png)

* The single large request appears to introduce client-side contention, causing Thanos Store's memcached client to skip index-cache `set` operations 
![image](https://user-images.githubusercontent.com/50833398/151789878-30fc4b96-4aeb-4e02-9551-63143968a5a3.png)

This PR aims to help Thanos Store
  * Flush pending `set` operations by increasing `max_async_concurrency` to `1000` from `200` 
  * Reduce impact of `getMulti` single request contention by introducing a higher batch size from the original `100`. This means for the max we observed in the repro (40k keys get) we are sending 4 requests instead of 400



Signed-off-by: mzardab <mzardab@redhat.com>