### PR TITLE
Invert the SLO for latency budgets

### DIFF
--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -283,7 +283,7 @@ local renderAlerts(name, environment, mixin) = {
           // We can't use !~ operator in these selectors
           selectors: ['job="telemeter-server"', 'handler=~"upload|receive"', 'code=~"^(2..|3..|5..)$"'],
           latencyTarget: 5,
-          latencyBudget: 0.9,
+          latencyBudget: 0.1,  // The budget is 1 - SLO
         }),
       ],
     },
@@ -316,7 +316,7 @@ local renderAlerts(name, environment, mixin) = {
             // We can't use !~ operator in these selectors
             selectors: [apiJobSelector, 'handler="receive"', 'code=~"^(2..|3..|5..)$"'],
             latencyTarget: 5,
-            latencyBudget: 0.9,
+            latencyBudget: 0.1,  // The budget is 1 - SLO
           }),
         ],
       },
@@ -350,7 +350,7 @@ local renderAlerts(name, environment, mixin) = {
             metric: 'up_custom_query_duration_seconds',
             selectors: ['query="query-path-sli-1M-samples"', upNamespaceSelector],
             latencyTarget: 2.0113571874999994,
-            latencyBudget: 0.9,
+            latencyBudget: 0.1,  // The budget is 1 - SLO
           }),
           slo.latencyburn({
             alertName: 'APIMetricsReadLatencyErrorBudgetBurning',
@@ -358,7 +358,7 @@ local renderAlerts(name, environment, mixin) = {
             metric: 'up_custom_query_duration_seconds',
             selectors: ['query="query-path-sli-10M-samples"', upNamespaceSelector],
             latencyTarget: 10.761264004567169,
-            latencyBudget: 0.9,
+            latencyBudget: 0.1,  // The budget is 1 - SLO
           }),
           slo.latencyburn({
             alertName: 'APIMetricsReadLatencyErrorBudgetBurning',
@@ -367,7 +367,7 @@ local renderAlerts(name, environment, mixin) = {
             // We can't use !~ operator in these selectors
             selectors: ['query="query-path-sli-100M-samples"', upNamespaceSelector],
             latencyTarget: 21.6447457021712,
-            latencyBudget: 0.9,
+            latencyBudget: 0.1,  // The budget is 1 - SLO
           }),
         ],
       },

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -136,15 +136,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
         )
       labels:
         handler: receive
@@ -159,15 +159,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
         )
       labels:
         handler: receive
@@ -495,15 +495,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.100000)
         )
       labels:
         latency: "2.0113571874999994"
@@ -518,15 +518,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.100000)
         )
       labels:
         latency: "2.0113571874999994"
@@ -618,15 +618,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.100000)
         )
       labels:
         latency: "10.761264004567169"
@@ -641,15 +641,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.100000)
         )
       labels:
         latency: "10.761264004567169"
@@ -741,15 +741,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.100000)
         )
       labels:
         latency: "21.6447457021712"
@@ -764,15 +764,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.100000)
         )
       labels:
         latency: "21.6447457021712"

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -136,15 +136,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
         )
       labels:
         handler: receive
@@ -159,15 +159,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
         )
       labels:
         handler: receive
@@ -495,15 +495,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (6*0.100000)
         )
       labels:
         latency: "2.0113571874999994"
@@ -518,15 +518,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (0.100000)
         )
       labels:
         latency: "2.0113571874999994"
@@ -618,15 +618,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (6*0.100000)
         )
       labels:
         latency: "10.761264004567169"
@@ -641,15 +641,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (0.100000)
         )
       labels:
         latency: "10.761264004567169"
@@ -741,15 +741,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (6*0.100000)
         )
       labels:
         latency: "21.6447457021712"
@@ -764,15 +764,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (0.100000)
         )
       labels:
         latency: "21.6447457021712"

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -125,15 +125,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate1h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate5m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate30m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
         )
       labels:
         handler: upload|receive
@@ -148,15 +148,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate1d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate2h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate3d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
         )
       labels:
         handler: upload|receive
@@ -368,15 +368,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
         )
       labels:
         handler: receive
@@ -391,15 +391,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
         )
       labels:
         handler: receive
@@ -727,15 +727,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.100000)
         )
       labels:
         latency: "2.0113571874999994"
@@ -750,15 +750,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.100000)
         )
       labels:
         latency: "2.0113571874999994"
@@ -850,15 +850,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.100000)
         )
       labels:
         latency: "10.761264004567169"
@@ -873,15 +873,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.100000)
         )
       labels:
         latency: "10.761264004567169"
@@ -973,15 +973,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.100000)
         )
       labels:
         latency: "21.6447457021712"
@@ -996,15 +996,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.100000)
         )
       labels:
         latency: "21.6447457021712"

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -125,15 +125,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate1h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate5m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate30m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
         )
       labels:
         handler: upload|receive
@@ -148,15 +148,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate1d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate2h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate3d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
         )
       labels:
         handler: upload|receive
@@ -368,15 +368,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.900000)
+          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.900000)
+          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
         )
       labels:
         handler: receive
@@ -391,15 +391,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.900000)
+          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.900000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
         )
       labels:
         handler: receive
@@ -727,15 +727,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (6*0.100000)
         )
       labels:
         latency: "2.0113571874999994"
@@ -750,15 +750,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (0.100000)
         )
       labels:
         latency: "2.0113571874999994"
@@ -850,15 +850,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (6*0.100000)
         )
       labels:
         latency: "10.761264004567169"
@@ -873,15 +873,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (0.100000)
         )
       labels:
         latency: "10.761264004567169"
@@ -973,15 +973,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (14.4*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (6*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (6*0.100000)
         )
       labels:
         latency: "21.6447457021712"
@@ -996,15 +996,15 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (3*0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (0.900000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (0.100000)
         )
       labels:
         latency: "21.6447457021712"


### PR DESCRIPTION
Trying to figure out why our latency alerts were not firing - turns out that the library wanted the _budget_, not the SLO itself :facepalm: 

Signed-off-by: Ian Billett <ibillett@redhat.com>