### PR TITLE
Increasing max_get_multi_concurrency from 0 => 100

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2079,7 +2079,7 @@ objects:
               "max_async_buffer_size": 10000000
               "max_async_concurrency": 1000
               "max_get_multi_batch_size": 10000
-              "max_get_multi_concurrency": 0
+              "max_get_multi_concurrency": 100
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
               "timeout": "2s"
@@ -2325,7 +2325,7 @@ objects:
               "max_async_buffer_size": 10000000
               "max_async_concurrency": 1000
               "max_get_multi_batch_size": 10000
-              "max_get_multi_concurrency": 0
+              "max_get_multi_concurrency": 100
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
               "timeout": "2s"
@@ -2571,7 +2571,7 @@ objects:
               "max_async_buffer_size": 10000000
               "max_async_concurrency": 1000
               "max_get_multi_batch_size": 10000
-              "max_get_multi_concurrency": 0
+              "max_get_multi_concurrency": 100
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
               "timeout": "2s"

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -250,7 +250,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           max_async_buffer_size: 10000000,  // default: 10_000
           max_async_concurrency: 1000,  // default: 20
           max_get_multi_batch_size: 10000,  // default: 0 - No batching.
-          max_get_multi_concurrency: 0,  // default: 100
+          max_get_multi_concurrency: 100,  // default: 100
           max_item_size: '5MiB',  // default: 1Mb
         },
       },


### PR DESCRIPTION
The changes so far have yielded fruit: 

### No skipped operations
![image](https://user-images.githubusercontent.com/50833398/152013694-699ac97a-7270-4c99-9887-936c61f8e6b0.png)

### `getMulti` timeouts on production version vs now
![image](https://user-images.githubusercontent.com/50833398/152014401-01445529-b21a-42f7-be9a-87899f94e635.png)

### Closer look @ `getMulti` timeouts for most recent version, but non-zero
![image](https://user-images.githubusercontent.com/50833398/152014679-17b138c2-f182-480b-ae1f-41fe86de4039.png)

This change is intended to flush the getMulti request queue by increasing concurrency. As we have reintroduced batching, the aim is to reduce the timeouts we are seeing even further/

Signed-off-by: mzardab <mzardab@redhat.com>