### PR TITLE
fix: Share directory between Rule Syncer sidecar and Ruler

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1713,7 +1713,7 @@ objects:
           - --tsdb.retention=48h
           - --tsdb.block-duration=2h
           - --query=dnssrv+_http._tcp.observatorium-thanos-query.${NAMESPACE}.svc.cluster.local
-          - --rule-file=/etc/thanos/rules/observatorium-rule-syncer.yaml
+          - --rule-file=/etc/thanos/rules/rule-syncer/observatorium.yaml
           - --alertmanagers.url=dnssrv+_http._tcp.observatorium-alertmanager.${NAMESPACE}.svc.cluster.local
           - --rule-file=/etc/thanos/rules/observatorium-rules/observatorium.yaml
           - |-
@@ -1782,6 +1782,8 @@ objects:
             readOnly: false
           - mountPath: /etc/thanos/rules/observatorium-rules
             name: observatorium-rules
+          - mountPath: /etc/thanos/rules/rule-syncer
+            name: rule-syncer
         - args:
           - -webhook-url=http://localhost:10902/-/reload
           - -volume-dir=/etc/thanos/rules/observatorium-rules
@@ -1826,7 +1828,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         - args:
-          - -file=/etc/thanos/rules/observatorium-rule-syncer.yaml
+          - -file=/etc/thanos-rule-syncer/observatorium.yaml
           - -interval=60
           - -rules-backend-url=http://rules-objstore.${OBSERVATORIUM_NAMESPACE}.svc:8080
           - -thanos-rule-url=http://localhost:10902
@@ -1839,6 +1841,9 @@ objects:
             requests:
               cpu: 32m
               memory: 64Mi
+          volumeMounts:
+          - mountPath: /etc/thanos-rule-syncer
+            name: rule-syncer
         nodeSelector:
           beta.kubernetes.io/os: linux
         securityContext: {}
@@ -1847,6 +1852,8 @@ objects:
         - configMap:
             name: observatorium-rules
           name: observatorium-rules
+        - emptyDir: {}
+          name: rule-syncer
     volumeClaimTemplates:
     - metadata:
         labels:

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -33,10 +33,12 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
     collectorAddress: 'dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250',
   }),
 
+  local ruleSyncerVolume = 'rule-syncer',
   local ruleSyncerSidecar = thanosRuleSyncer({
     image: '${THANOS_RULE_SYNCER_IMAGE}:${THANOS_RULE_SYNCER_IMAGE_TAG}',
     rulesBackendURL: 'http://rules-objstore.${OBSERVATORIUM_NAMESPACE}.svc:8080',
-    file: '/etc/thanos/rules/observatorium-rule-syncer.yaml',
+    volumeName: ruleSyncerVolume,
+    fileName: 'observatorium.yaml',
   }),
 
   thanos+:: {
@@ -110,6 +112,10 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
               containers: [
                 if c.name == 'thanos-rule' then c {
                   env+: s3EnvVars,
+                  volumeMounts+: [{
+                    name: ruleSyncerVolume,
+                    mountPath: '/etc/thanos/rules/rule-syncer',
+                  }],
                 } else c
                 for c in super.containers
               ],

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -88,7 +88,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
         },
       ],
       ruleFiles: [
-        '/etc/thanos/rules/observatorium-rule-syncer.yaml',
+        '/etc/thanos/rules/rule-syncer/observatorium.yaml',
       ],
       resources: {
         limits: {


### PR DESCRIPTION
The rules written by Thanos Rule Syncer were not accessible to Ruler before as they didn't have any shared volume. This change fixes this by mounting a shared `emptyDir` volume on both containers.

Signed-off-by: Prem Saraswat <prmsrswt@gmail.com>