### PR TITLE
Increasing max_get_multi_concurrency from 100 => 1000 and doubling max_get_multi_batch_size

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2206,8 +2206,8 @@ objects:
               "dns_provider_update_interval": "10s"
               "max_async_buffer_size": 10000000
               "max_async_concurrency": 1000
-              "max_get_multi_batch_size": 10000
-              "max_get_multi_concurrency": 100
+              "max_get_multi_batch_size": 20000
+              "max_get_multi_concurrency": 1000
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
               "timeout": "2s"
@@ -2452,8 +2452,8 @@ objects:
               "dns_provider_update_interval": "10s"
               "max_async_buffer_size": 10000000
               "max_async_concurrency": 1000
-              "max_get_multi_batch_size": 10000
-              "max_get_multi_concurrency": 100
+              "max_get_multi_batch_size": 20000
+              "max_get_multi_concurrency": 1000
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
               "timeout": "2s"
@@ -2698,8 +2698,8 @@ objects:
               "dns_provider_update_interval": "10s"
               "max_async_buffer_size": 10000000
               "max_async_concurrency": 1000
-              "max_get_multi_batch_size": 10000
-              "max_get_multi_concurrency": 100
+              "max_get_multi_batch_size": 20000
+              "max_get_multi_concurrency": 1000
               "max_idle_connections": 1300
               "max_item_size": "5MiB"
               "timeout": "2s"

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -251,8 +251,8 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
           timeout: '2s',  // default: 500ms
           max_async_buffer_size: 10000000,  // default: 10_000
           max_async_concurrency: 1000,  // default: 20
-          max_get_multi_batch_size: 10000,  // default: 0 - No batching.
-          max_get_multi_concurrency: 100,  // default: 100
+          max_get_multi_batch_size: 20000,  // default: 0 - No batching.
+          max_get_multi_concurrency: 1000,  // default: 100
           max_item_size: '5MiB',  // default: 1Mb
         },
       },


### PR DESCRIPTION
`max_get_multi_concurrency` was `1000` before our changes, just resetting it to that value 
`max_get_multi_batch_size` as the async_pool has fixed our write limiting, (and we've found larger batch sizes are less likely to timeout) we should push this a little further to minimize timeouts. 


Signed-off-by: mzardab <mzardab@redhat.com>