### PR TITLE
Updating memcached max_item_size flag to match Thanos QFE memcache client config

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -641,7 +641,7 @@ objects:
         containers:
         - args:
           - -m ${THANOS_QUERY_FRONTEND_QUERY_CACHE_MEMORY_LIMIT_MB}
-          - -I 5m
+          - -I 64m
           - -c ${THANOS_QUERY_FRONTEND_QUERY_CACHE_CONNECTION_LIMIT}
           - -v
           image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -562,7 +562,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
       exporterImage: '%s:%s' % ['${MEMCACHED_EXPORTER_IMAGE}', cfg.exporterVersion],
       connectionLimit: '${THANOS_QUERY_FRONTEND_QUERY_CACHE_CONNECTION_LIMIT}',
       memoryLimitMb: '${THANOS_QUERY_FRONTEND_QUERY_CACHE_MEMORY_LIMIT_MB}',
-      maxItemSize: '5m',
+      maxItemSize: '64m',
       replicas: 1,  // overwritten in observatorium-metrics-template.libsonnet
       resources: {
         memcached: {


### PR DESCRIPTION
Currently we time slice by 24h, it's quite easy to get >5mb response with a vanilla query. To improve cacheability i want to: 
* Increase max_item_size to increase the number of potential responses that can be cached
* Memcache currently underutilized, I'm suspecting some responses are not getting cached when they could due to exceeding the response size threshold 

Signed-off-by: mzardab <mzardab@redhat.com>