### PR TITLE
Fix dashboard error budget bug

### DIFF
--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -204,7 +204,7 @@ function(instanceName, environment, dashboardName) {
             clamp_min(
             ( 1 -
                 (
-                    %(errorCase)s or vector(0)
+                    (%(errorCase)s or vector(0))
                     /
                     %(totalCase)s
                 ) - %(target)s

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
@@ -174,7 +174,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -508,7 +508,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -667,7 +667,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
@@ -174,7 +174,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -508,7 +508,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -667,7 +667,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
@@ -174,7 +174,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0)\n        /\n        sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\", code!=\"4xx\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0))\n        /\n        sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\", code!=\"4xx\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -508,7 +508,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -842,7 +842,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1001,7 +1001,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
@@ -174,7 +174,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0)\n        /\n        sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\", code!=\"4xx\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0))\n        /\n        sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\", code!=\"4xx\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -508,7 +508,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -842,7 +842,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1001,7 +1001,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0)\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",


### PR DESCRIPTION
This is a subtle bug that has made out SLO error budgets look much worse off than they actually are :smile: 

If we don't wrap `vector(0)` in the parenthesis, we will report periods of 100% availability as 0% instead.
