### PR TITLE
Fix mount path bug

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -297,7 +297,7 @@ objects:
         containers:
         - args:
           - --config.file=/etc/config/alertmanager.yaml
-          - --storage.path="data/"
+          - --storage.path=/data
           - --web.listen-address=:9093
           - --cluster.listen-address=
           image: quay.io/prometheus/alertmanager:main

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -773,8 +773,8 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
                 name: cfg.name,
                 image: cfg.image,
                 args: [
-                  '--config.file=%s/%s' % cfg.configMountPath, cfg.routingConfigFileName,
-                  '--storage.path="%s"' % cfg.dataMountPath,
+                  '--config.file=%s/%s' % [cfg.configMountPath, cfg.routingConfigFileName],
+                  '--storage.path=%s' % cfg.dataMountPath,
                   '--web.listen-address=:' + cfg.port,
                   '--cluster.listen-address=',  // Disabled cluster gossiping while we only have one replica
                 ],

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -702,6 +702,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
         namespace: thanosSharedConfig.namespace,
         image: 'quay.io/prometheus/alertmanager:main',
         persistentVolumeClaimName: 'alertmanager-data',
+        dataMountPath: '/data',
         routingConfigName: 'alertmanager-config',
         routingConfigFileName: 'alertmanager.yaml',
         port: 9093,
@@ -772,7 +773,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
                 image: cfg.image,
                 args: [
                   '--config.file=/etc/config/' + cfg.routingConfigFileName,
-                  '--storage.path="data/"',
+                  '--storage.path="%s"' % cfg.dataMountPath,
                   '--web.listen-address=:' + cfg.port,
                   '--cluster.listen-address=',  // Disabled cluster gossiping while we only have one replica
                 ],
@@ -783,7 +784,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
                   },
                 ],
                 volumeMounts: [
-                  { name: 'alertmanager-data', mountPath: '/data', readOnly: false },
+                  { name: 'alertmanager-data', mountPath: cfg.dataMountPath, readOnly: false },
                   { name: cfg.routingConfigName, mountPath: '/etc/config', readOnly: true },
                 ],
                 livenessProbe: { failureThreshold: 4, periodSeconds: 30, httpGet: {

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -703,6 +703,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
         image: 'quay.io/prometheus/alertmanager:main',
         persistentVolumeClaimName: 'alertmanager-data',
         dataMountPath: '/data',
+        configMountPath: '/etc/config',
         routingConfigName: 'alertmanager-config',
         routingConfigFileName: 'alertmanager.yaml',
         port: 9093,
@@ -772,7 +773,7 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
                 name: cfg.name,
                 image: cfg.image,
                 args: [
-                  '--config.file=/etc/config/' + cfg.routingConfigFileName,
+                  '--config.file=%s/%s' % cfg.configMountPath, cfg.routingConfigFileName,
                   '--storage.path="%s"' % cfg.dataMountPath,
                   '--web.listen-address=:' + cfg.port,
                   '--cluster.listen-address=',  // Disabled cluster gossiping while we only have one replica
@@ -784,8 +785,8 @@ local tenants = (import '../configuration/observatorium/tenants.libsonnet');
                   },
                 ],
                 volumeMounts: [
-                  { name: 'alertmanager-data', mountPath: cfg.dataMountPath, readOnly: false },
-                  { name: cfg.routingConfigName, mountPath: '/etc/config', readOnly: true },
+                  { name: cfg.persistentVolumeClaimName, mountPath: cfg.dataMountPath, readOnly: false },
+                  { name: cfg.routingConfigName, mountPath: cfg.configMountPath, readOnly: true },
                 ],
                 livenessProbe: { failureThreshold: 4, periodSeconds: 30, httpGet: {
                   scheme: 'HTTP',


### PR DESCRIPTION
Currently `observatorium-alertmanager` is failing to come up with
```
level=error ts=2022-02-04T10:49:54.360Z caller=main.go:232 msg="Unable to create data directory" err="mkdir \"data: permission denied"
```
I haven't been able to confirm this fix via a testing cluster yet (it's going to take 30 mins to spin up), but I'm pretty sure this is the problem.

Also do some tidying up of the jsonnet.