### PR TITLE
Adding -vv flag to indexCache memcached config

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2071,7 +2071,7 @@ objects:
           - -m ${THANOS_STORE_INDEX_CACHE_MEMORY_LIMIT_MB}
           - -I 5m
           - -c ${THANOS_STORE_INDEX_CACHE_CONNECTION_LIMIT}
-          - -v
+          - -vv
           image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}
           name: memcached
           ports:

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -189,6 +189,11 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
         spec+: {
           template+: {
             spec+: {
+              containers: [
+                super.containers[0] {
+                  args: super.args[:3] + ['-vv'],
+                },
+              ] + super.containers[1:],
               securityContext: {},
             },
           },


### PR DESCRIPTION
* Why are we manually setting the param in the template? 
a) Args are not parameterised on the memcached observatorium config provider, so adding that would require multiple PR's, a provider update
b) This change is temporary, and will be removed before rolling out into production to get better visibility on where the connections are terminating/timing out 

Signed-off-by: mzardab <mzardab@redhat.com>