### PR TITLE
Changing step rate for query_range SLOs

### DIFF
--- a/configuration/observatorium/queries.libsonnet
+++ b/configuration/observatorium/queries.libsonnet
@@ -8,7 +8,7 @@
       name: 'query-range-path-sli-1M-samples',
       query: 'avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"}[1h])',
       duration: '1h',
-      step: '30s',
+      step: '1h',
     },
     {
       name: 'query-path-sli-10M-samples',
@@ -18,7 +18,7 @@
       name: 'query-range-path-sli-10M-samples',
       query: 'avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"}[10h])',
       duration: '10h',
-      step: '30s',
+      step: '10h',
     },
     {
       name: 'query-path-sli-100M-samples',
@@ -28,7 +28,7 @@
       name: 'query-range-path-sli-100M-samples',
       query: 'avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"}[100h])',
       duration: '100h',
-      step: '30s',
+      step: '100h',
     },
   ],
 }

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -810,19 +810,19 @@ objects:
       - "duration": "1h"
         "name": "query-range-path-sli-1M-samples"
         "query": "avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[1h])"
-        "step": "30s"
+        "step": "1h"
       - "name": "query-path-sli-10M-samples"
         "query": "avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[10h])"
       - "duration": "10h"
         "name": "query-range-path-sli-10M-samples"
         "query": "avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[10h])"
-        "step": "30s"
+        "step": "10h"
       - "name": "query-path-sli-100M-samples"
         "query": "avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[100h])"
       - "duration": "100h"
         "name": "query-range-path-sli-100M-samples"
         "query": "avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[100h])"
-        "step": "30s"
+        "step": "100h"
   kind: ConfigMap
   metadata:
     annotations:


### PR DESCRIPTION
In order to create range query SLOs that touch the same number of samples as our instant queries, the step has to be equivalent to the range vector param. This is so that it only computes the `avg_over_time` once for the entire subset of the query. 

Signed-off-by: mzardab <mzardab@redhat.com>