### PR TITLE
Enable stateless Rulers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ VENDOR_DIR = vendor
 $(VENDOR_DIR): $(JB) jsonnetfile.json jsonnetfile.lock.json
 	@$(JB) install
 
+.PHONY: update
+update: $(JB) jsonnetfile.json jsonnetfile.lock.json
+	@$(JB) update
+
 JSONNET_SRC = $(shell find . -type f -not -path './*vendor/*' \( -name '*.libsonnet' -o -name '*.jsonnet' \))
 
 .PHONY: format

--- a/configuration/observatorium/ruler-remote-write.libsonnet
+++ b/configuration/observatorium/ruler-remote-write.libsonnet
@@ -1,0 +1,34 @@
+function(params) {
+  assert std.isString(params.url),
+
+  remote_write: [
+    {
+      url: params.url,
+      name: 'receive-rhobs',
+      headers: {
+        'THANOS-TENANT': '770c1124-6ae8-4324-a9d4-9ce08590094b',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: '770c1124-6ae8-4324-a9d4-9ce08590094b',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-telemeter',
+      headers: {
+        'THANOS-TENANT': 'FB870BF3-9F3A-44FF-9BF7-D7A047A52F43',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: 'FB870BF3-9F3A-44FF-9BF7-D7A047A52F43',
+          action: 'keep',
+        },
+      ],
+    },
+  ],
+}

--- a/configuration/observatorium/ruler-remote-write.libsonnet
+++ b/configuration/observatorium/ruler-remote-write.libsonnet
@@ -6,12 +6,12 @@ function(params) {
       url: params.url,
       name: 'receive-rhobs',
       headers: {
-        'THANOS-TENANT': '770c1124-6ae8-4324-a9d4-9ce08590094b',
+        'THANOS-TENANT': '0fc2b00e-201b-4c17-b9f2-19d91adc4fd2',
       },
       write_relabel_configs: [
         {
           source_labels: ['tenant_id'],
-          regex: '770c1124-6ae8-4324-a9d4-9ce08590094b',
+          regex: '0fc2b00e-201b-4c17-b9f2-19d91adc4fd2',
           action: 'keep',
         },
       ],
@@ -26,6 +26,48 @@ function(params) {
         {
           source_labels: ['tenant_id'],
           regex: 'FB870BF3-9F3A-44FF-9BF7-D7A047A52F43',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-dptp',
+      headers: {
+        'THANOS-TENANT': 'AC879303-C60F-4D0D-A6D5-A485CFD638B8',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: 'AC879303-C60F-4D0D-A6D5-A485CFD638B8',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-osd',
+      headers: {
+        'THANOS-TENANT': '770c1124-6ae8-4324-a9d4-9ce08590094b',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: '770c1124-6ae8-4324-a9d4-9ce08590094b',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-managedkafka',
+      headers: {
+        'THANOS-TENANT': '63e320cd-622a-4d05-9585-ffd48342633e',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: '63e320cd-622a-4d05-9585-ffd48342633e',
           action: 'keep',
         },
       ],

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -183,8 +183,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "e1a68590f56034ca1a43d59401f03e72fd01ac5f",
-      "sum": "9g4HwpZ8Vpi950O6x92HNM47Yqa0+Nfv+7YbwwKpt3o="
+      "version": "336482e12c794f048bd7ec9105281c7b3d76214c",
+      "sum": "8Wh4rZIGaC/LFGbA5astHL27/Lxu+GEq6sPu/ajdjZY="
     },
     {
       "source": {

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -44,6 +44,36 @@ objects:
       app.kubernetes.io/part-of: observatorium
     name: metric-federation-rules
 - apiVersion: v1
+  data:
+    rw-config.yaml: |-
+      "remote_write":
+      - "headers":
+          "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+        "name": "receive-rhobs"
+        "url": "http://observatorium-thanos-receive.${THANOS_QUERIER_NAMESPACE}.svc.cluster.local:19291"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+        "name": "receive-telemeter"
+        "url": "http://observatorium-thanos-receive.${THANOS_QUERIER_NAMESPACE}.svc.cluster.local:19291"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "source_labels":
+          - "tenant_id"
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/part-of: observatorium
+    name: metric-federation-ruler-remote-write-config
+- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -158,6 +188,7 @@ objects:
               "sampler_type": "ratelimiting"
               "service_name": "thanos-rule"
             "type": "JAEGER"
+          - --remote-write.config-file=/etc/thanos/config/metric-federation-ruler-remote-write-config/rw-config.yaml
           env:
           - name: NAME
             valueFrom:
@@ -221,15 +252,21 @@ objects:
             readOnly: false
           - mountPath: /etc/thanos/rules/metric-federation-rules
             name: metric-federation-rules
+          - mountPath: /etc/thanos/config/metric-federation-ruler-remote-write-config
+            name: metric-federation-ruler-remote-write-config
+            readOnly: true
         - args:
           - -webhook-url=http://localhost:10902/-/reload
           - -volume-dir=/etc/thanos/rules/metric-federation-rules
+          - -volume-dir=/etc/thanos/config/metric-federation-ruler-remote-write-config
           image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           name: configmap-reloader
           volumeMounts:
           - mountPath: /etc/thanos/rules/metric-federation-rules
             name: metric-federation-rules
+          - mountPath: /etc/thanos/config/metric-federation-ruler-remote-write-config
+            name: metric-federation-ruler-remote-write-config
         - args:
           - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
           - --reporter.type=grpc
@@ -273,6 +310,9 @@ objects:
         - configMap:
             name: metric-federation-rules
           name: metric-federation-rules
+        - configMap:
+            name: metric-federation-ruler-remote-write-config
+          name: metric-federation-ruler-remote-write-config
     volumeClaimTemplates:
     - metadata:
         labels:

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -50,7 +50,7 @@ objects:
       - "headers":
           "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
         "name": "receive-rhobs"
-        "url": "http://observatorium-thanos-receive.${THANOS_QUERIER_NAMESPACE}.svc.cluster.local:19291"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
         "write_relabel_configs":
         - "action": "keep"
           "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
@@ -59,7 +59,7 @@ objects:
       - "headers":
           "THANOS-TENANT": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
         "name": "receive-telemeter"
-        "url": "http://observatorium-thanos-receive.${THANOS_QUERIER_NAMESPACE}.svc.cluster.local:19291"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
         "write_relabel_configs":
         - "action": "keep"
           "regex": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -48,12 +48,12 @@ objects:
     rw-config.yaml: |-
       "remote_write":
       - "headers":
-          "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "THANOS-TENANT": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
         "name": "receive-rhobs"
         "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
         "write_relabel_configs":
         - "action": "keep"
-          "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "regex": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
           "source_labels":
           - "tenant_id"
       - "headers":
@@ -63,6 +63,33 @@ objects:
         "write_relabel_configs":
         - "action": "keep"
           "regex": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+        "name": "receive-dptp"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+        "name": "receive-osd"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "63e320cd-622a-4d05-9585-ffd48342633e"
+        "name": "receive-managedkafka"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "63e320cd-622a-4d05-9585-ffd48342633e"
           "source_labels":
           - "tenant_id"
   kind: ConfigMap

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -62,6 +62,9 @@ objects:
     - name: http
       port: 10902
       targetPort: 10902
+    - name: reloader
+      port: 9533
+      targetPort: 9533
     selector:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: metric-federation
@@ -96,6 +99,7 @@ objects:
         - namespace
         - pod
         targetLabel: instance
+    - port: reloader
     namespaceSelector:
       matchNames: ${{NAMESPACES}}
     selector:
@@ -179,6 +183,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 24
             httpGet:
@@ -192,6 +197,8 @@ objects:
             name: grpc
           - containerPort: 10902
             name: http
+          - containerPort: 9533
+            name: reloader
           readinessProbe:
             failureThreshold: 18
             httpGet:
@@ -218,6 +225,7 @@ objects:
           - -webhook-url=http://localhost:10902/-/reload
           - -volume-dir=/etc/thanos/rules/metric-federation-rules
           image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: configmap-reloader
           volumeMounts:
           - mountPath: /etc/thanos/rules/metric-federation-rules
@@ -258,7 +266,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         volumes:

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -29,6 +29,7 @@ objects:
       app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
     name: observatorium-thanos-compact
   spec:
+    clusterIP: None
     ports:
     - name: http
       port: 10902
@@ -106,6 +107,24 @@ objects:
           app.kubernetes.io/part-of: observatorium
           app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - thanos-compact
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                    - observatorium
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - compact
@@ -143,6 +162,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 4
             httpGet:
@@ -208,7 +228,7 @@ objects:
             name: compact-proxy
             readOnly: false
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -496,6 +516,7 @@ objects:
               fieldRef:
                 fieldPath: status.hostIP
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 4
             httpGet:
@@ -599,7 +620,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -811,6 +832,7 @@ objects:
               fieldRef:
                 fieldPath: status.hostIP
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 4
             httpGet:
@@ -907,7 +929,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -1355,12 +1377,12 @@ objects:
           - --http-address=0.0.0.0:10902
           - --remote-write.address=0.0.0.0:19291
           - --receive.replication-factor=3
-          - --objstore.config=$(OBJSTORE_CONFIG)
           - --tsdb.path=${THANOS_RECEIVE_TSDB_PATH}
           - --tsdb.retention=4d
-          - --receive.local-endpoint=$(NAME).observatorium-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
           - --label=replica="$(NAME)"
           - --label=receive="true"
+          - --objstore.config=$(OBJSTORE_CONFIG)
+          - --receive.local-endpoint=$(NAME).observatorium-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
           - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
           - |-
             --tracing.config="config":
@@ -1378,15 +1400,15 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: OBJSTORE_CONFIG
             valueFrom:
               secretKeyRef:
                 key: thanos.yaml
                 name: ${THANOS_CONFIG_SECRET}
-          - name: HOST_IP_ADDRESS
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
           - name: DEBUG
             value: ${THANOS_RECEIVE_DEBUG_ENV}
           - name: AWS_ACCESS_KEY_ID
@@ -1402,6 +1424,7 @@ objects:
           - name: DEBUG
             value: ${THANOS_RECEIVE_DEBUG_ENV}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
             httpGet:
@@ -1474,7 +1497,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 900
@@ -1684,6 +1707,9 @@ objects:
     - name: http
       port: 10902
       targetPort: 10902
+    - name: reloader
+      port: 9533
+      targetPort: 9533
     selector:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: observatorium
@@ -1718,6 +1744,7 @@ objects:
         - namespace
         - pod
         targetLabel: instance
+    - port: reloader
     namespaceSelector:
       matchNames: ${{NAMESPACES}}
     selector:
@@ -1803,6 +1830,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 24
             httpGet:
@@ -1816,6 +1844,8 @@ objects:
             name: grpc
           - containerPort: 10902
             name: http
+          - containerPort: 9533
+            name: reloader
           readinessProbe:
             failureThreshold: 18
             httpGet:
@@ -1844,6 +1874,7 @@ objects:
           - -webhook-url=http://localhost:10902/-/reload
           - -volume-dir=/etc/thanos/rules/observatorium-rules
           image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: configmap-reloader
           volumeMounts:
           - mountPath: /etc/thanos/rules/observatorium-rules
@@ -1901,7 +1932,7 @@ objects:
           - mountPath: /etc/thanos-rule-syncer
             name: rule-syncer
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         volumes:
@@ -2326,6 +2357,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
             httpGet:
@@ -2394,7 +2426,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -2572,6 +2604,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
             httpGet:
@@ -2640,7 +2673,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -2818,6 +2851,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
             httpGet:
@@ -2886,7 +2920,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1689,6 +1689,36 @@ objects:
       app.kubernetes.io/part-of: observatorium
     name: observatorium-rules
 - apiVersion: v1
+  data:
+    rw-config.yaml: |-
+      "remote_write":
+      - "headers":
+          "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+        "name": "receive-rhobs"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+        "name": "receive-telemeter"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "source_labels":
+          - "tenant_id"
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/part-of: observatorium
+    name: remote-write-config
+- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -1805,6 +1835,7 @@ objects:
               "sampler_type": "ratelimiting"
               "service_name": "thanos-rule"
             "type": "JAEGER"
+          - --remote-write.config-file=/etc/thanos/config/remote-write-config/rw-config.yaml
           env:
           - name: NAME
             valueFrom:
@@ -1868,17 +1899,23 @@ objects:
             readOnly: false
           - mountPath: /etc/thanos/rules/observatorium-rules
             name: observatorium-rules
+          - mountPath: /etc/thanos/config/remote-write-config
+            name: remote-write-config
+            readOnly: true
           - mountPath: /etc/thanos/rules/rule-syncer
             name: rule-syncer
         - args:
           - -webhook-url=http://localhost:10902/-/reload
           - -volume-dir=/etc/thanos/rules/observatorium-rules
+          - -volume-dir=/etc/thanos/config/remote-write-config
           image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           name: configmap-reloader
           volumeMounts:
           - mountPath: /etc/thanos/rules/observatorium-rules
             name: observatorium-rules
+          - mountPath: /etc/thanos/config/remote-write-config
+            name: remote-write-config
         - args:
           - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
           - --reporter.type=grpc
@@ -1939,6 +1976,9 @@ objects:
         - configMap:
             name: observatorium-rules
           name: observatorium-rules
+        - configMap:
+            name: remote-write-config
+          name: remote-write-config
         - emptyDir: {}
           name: rule-syncer
     volumeClaimTemplates:

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1693,12 +1693,12 @@ objects:
     rw-config.yaml: |-
       "remote_write":
       - "headers":
-          "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "THANOS-TENANT": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
         "name": "receive-rhobs"
         "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
         "write_relabel_configs":
         - "action": "keep"
-          "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "regex": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
           "source_labels":
           - "tenant_id"
       - "headers":
@@ -1708,6 +1708,33 @@ objects:
         "write_relabel_configs":
         - "action": "keep"
           "regex": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+        "name": "receive-dptp"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+        "name": "receive-osd"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "63e320cd-622a-4d05-9585-ffd48342633e"
+        "name": "receive-managedkafka"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "63e320cd-622a-4d05-9585-ffd48342633e"
           "source_labels":
           - "tenant_id"
   kind: ConfigMap

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1695,7 +1695,7 @@ objects:
       - "headers":
           "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
         "name": "receive-rhobs"
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
         "write_relabel_configs":
         - "action": "keep"
           "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
@@ -1704,7 +1704,7 @@ objects:
       - "headers":
           "THANOS-TENANT": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
         "name": "receive-telemeter"
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
         "write_relabel_configs":
         - "action": "keep"
           "regex": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -163,7 +163,11 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         },
         data: {
           [statelessRulerKey]: std.manifestYamlDoc(remoteWriteConfig({
-            url: 'http://observatorium-thanos-receive.%s.svc.cluster.local:19291' % thanosSharedConfig.namespace,
+            url: 'http://%s.%s.svc.cluster.local:%d/api/v1/receive' % [
+              thanos.receiversService.metadata.name,
+              thanosSharedConfig.namespace,
+              thanos.receiversService.spec.ports[2].port,
+            ],
           })),
         },
       },
@@ -259,7 +263,11 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         },
         data: {
           [statelessRulerKey]: std.manifestYamlDoc(remoteWriteConfig({
-            url: 'http://observatorium-thanos-receive.%s.svc.cluster.local:19291' % '${THANOS_QUERIER_NAMESPACE}',
+            url: 'http://%s.%s.svc.cluster.local:%d/api/v1/receive' % [
+              thanos.receiversService.metadata.name,
+              thanosSharedConfig.namespace,
+              thanos.receiversService.spec.ports[2].port,
+            ],
           })),
         },
       },


### PR DESCRIPTION
This PR 

- Enables stateless Rulers for `observatorium-metrics` and `metric-federation-rule` templates
- Upgrades `kube-thanos` to latest

Addresses [MON-2128](https://issues.redhat.com/browse/MON-2128).

Note: These changes cannot be rolled out before Thanos v0.25, as support for specifying multiple remote_write targets was added after v0.24 ([thanos#4927](https://github.com/thanos-io/thanos/pull/4927)).