### PR TITLE
Bumping max_idle_connections on index-cache 1300 => 2500

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2264,7 +2264,7 @@ objects:
               "max_async_concurrency": 1000
               "max_get_multi_batch_size": 100000
               "max_get_multi_concurrency": 1000
-              "max_idle_connections": 1300
+              "max_idle_connections": 2500
               "max_item_size": "5MiB"
               "timeout": "2s"
             "type": "memcached"
@@ -2510,7 +2510,7 @@ objects:
               "max_async_concurrency": 1000
               "max_get_multi_batch_size": 100000
               "max_get_multi_concurrency": 1000
-              "max_idle_connections": 1300
+              "max_idle_connections": 2500
               "max_item_size": "5MiB"
               "timeout": "2s"
             "type": "memcached"
@@ -2756,7 +2756,7 @@ objects:
               "max_async_concurrency": 1000
               "max_get_multi_batch_size": 100000
               "max_get_multi_concurrency": 1000
-              "max_idle_connections": 1300
+              "max_idle_connections": 2500
               "max_item_size": "5MiB"
               "timeout": "2s"
             "type": "memcached"

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -248,7 +248,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         config+: memcachedDefaults {
           addresses: ['dnssrv+_client._tcp.%s.%s.svc' % [thanos.storeIndexCache.service.metadata.name, thanos.storeIndexCache.service.metadata.namespace]],
           // Default Memcached Max Connection Limit is '3072', this is related to concurrency.
-          max_idle_connections: 1300,  // default: 100 - For better performances, this should be set to a number higher than your peak parallel requests.
+          max_idle_connections: 2500,  // default: 100 - For better performances, this should be set to a number higher than your peak parallel requests.
           timeout: '2s',  // default: 500ms
           max_async_buffer_size: 10000000,  // default: 10_000
           max_async_concurrency: 1000,  // default: 20


### PR DESCRIPTION
So after bumping index-cache partitions from 3-6 we have fixed OOMKill issues but connections still timing out. 

I noticed this only happens during peak connection events, after some perusing of gomemcache. The `max_idle_conns` flag. In gomemcache it states:
```
   // DefaultMaxIdleConns is the default maximum number of idle connections
   // kept for any single address.
```
Given: 
* All of our connections from the indexCache memcached client are to the same host, the service address for the index-cache, this connection limiting applies to any/all connections to memcached from storegateway
* Currently we have a concurrency of `1000` for `max_async_concurrency` and `max_get_multi_concurrency`, a theoretical maximum of `2000` concurrent requests for async ops + getMulti ops
* Our `max_idle_conns` is 1300, less than the peak concurrency load 
* When gomemcache relinquishes a connection, it checks if it has exceeded the `maxIdleConn` flag, closing it if it has. 
* I 'believe' that this is causing active requests to abort and generate 'broken pipe' errors in Memcached as TCP connections are closed 

Hopefully bumping this will help resolve that issue. 

Signed-off-by: mzardab <mzardab@redhat.com>