### PR TITLE
Fix alertmanagers.url to contain scheme

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1770,7 +1770,7 @@ objects:
           - --tsdb.block-duration=2h
           - --query=dnssrv+_http._tcp.observatorium-thanos-query.${NAMESPACE}.svc.cluster.local
           - --rule-file=/etc/thanos/rules/rule-syncer/observatorium.yaml
-          - --alertmanagers.url=dnssrv+_http._tcp.observatorium-alertmanager.${NAMESPACE}.svc.cluster.local
+          - --alertmanagers.url=dnssrv+http://observatorium-alertmanager.${NAMESPACE}.svc.cluster.local
           - --rule-file=/etc/thanos/rules/observatorium-rules/observatorium.yaml
           - |-
             --tracing.config="config":

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -77,7 +77,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       replicas: 1,  // overwritten in observatorium-metrics-template.libsonnet
       logLevel: '${THANOS_RULER_LOG_LEVEL}',
       serviceMonitor: true,
-      alertmanagersURLs: ['dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanosSharedConfig.alertmanagerName, thanosSharedConfig.namespace]],
+      alertmanagersURLs: ['dnssrv+http://%s.%s.svc.cluster.local' % [thanosSharedConfig.alertmanagerName, thanosSharedConfig.namespace]],
       queriers: [
         'dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, thanos.query.service.metadata.namespace],
       ],


### PR DESCRIPTION
The previous format was not being parsed correctly by Thanos, resulting in an empty scheme (according to [tests](https://github.com/thanos-io/thanos/blob/main/pkg/alert/config_test.go#L85)) causing Thanos Rule to have a misconfigured `--alertmanagers.url` (with an extra `/` at the beginning) and not being able to forward alerts to the configured Alertmanager url.

This was the error we got in Thanos Rule logs:
```bash
"send request to \"/dnssrv+_http._tcp.observatorium-alertmanager.observatorium-metrics-stage.svc.cluster.local/api/v1/alerts\": Post \"/dnssrv+_http._tcp.observatorium-alertmanager.observatorium-metrics-stage.svc.cluster.local/api/v1/alerts\": unsupported protocol scheme \"\""
```

As a follow up we can open an issue about this in Thanos, but for now we can change the URL to be in a format that is accepted.

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>