### PR TITLE
Lowering indexCach max_async_buffer_size from 10_000_000 => 2_500_000

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2261,7 +2261,7 @@ objects:
               "addresses":
               - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
               "dns_provider_update_interval": "10s"
-              "max_async_buffer_size": 10000000
+              "max_async_buffer_size": 2500000
               "max_async_concurrency": 1000
               "max_get_multi_batch_size": 100000
               "max_get_multi_concurrency": 1000
@@ -2507,7 +2507,7 @@ objects:
               "addresses":
               - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
               "dns_provider_update_interval": "10s"
-              "max_async_buffer_size": 10000000
+              "max_async_buffer_size": 2500000
               "max_async_concurrency": 1000
               "max_get_multi_batch_size": 100000
               "max_get_multi_concurrency": 1000
@@ -2753,7 +2753,7 @@ objects:
               "addresses":
               - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
               "dns_provider_update_interval": "10s"
-              "max_async_buffer_size": 10000000
+              "max_async_buffer_size": 2500000
               "max_async_concurrency": 1000
               "max_get_multi_batch_size": 100000
               "max_get_multi_concurrency": 1000

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -250,7 +250,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
           // Default Memcached Max Connection Limit is '3072', this is related to concurrency.
           max_idle_connections: 2500,  // default: 100 - For better performances, this should be set to a number higher than your peak parallel requests.
           timeout: '2s',  // default: 500ms
-          max_async_buffer_size: 10000000,  // default: 10_000
+          max_async_buffer_size: 2500000,  // default: 10_000
           max_async_concurrency: 1000,  // default: 20
           max_get_multi_batch_size: 100000,  // default: 0 - No batching.
           max_get_multi_concurrency: 1000,  // default: 100


### PR DESCRIPTION
We have run into some Thanos Store memory issues in production. Through some profiling I have determined the following: 

![image](https://user-images.githubusercontent.com/50833398/156758243-6974a387-7780-4aba-a753-fac067ad17bc.png)

Of the ~20GB limit for a given store-gw partition I determined that: 
* ~17GB was allocated for the `SetAsync` buffer
* ~4GB of that was allocated for `cacheKey`'s associated with buffered memcahed sets
* ~9GB of that was allocated for loglines

I will be: 
* Lowering async pool size
* Disabling debug logging in production 


Signed-off-by: mzardab <mzardab@redhat.com>