### PR TITLE
Add port number to alertmanager.url

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1771,7 +1771,7 @@ objects:
           - --tsdb.block-duration=2h
           - --query=dnssrv+_http._tcp.observatorium-thanos-query.${NAMESPACE}.svc.cluster.local
           - --rule-file=/etc/thanos/rules/rule-syncer/observatorium.yaml
-          - --alertmanagers.url=dnssrv+http://observatorium-alertmanager.${NAMESPACE}.svc.cluster.local
+          - --alertmanagers.url=dnssrv+http://observatorium-alertmanager.${NAMESPACE}.svc.cluster.local:9093
           - --rule-file=/etc/thanos/rules/observatorium-rules/observatorium.yaml
           - |-
             --tracing.config="config":

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -27,6 +27,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         },
       },
       alertmanagerName: 'observatorium-alertmanager',
+      alertmanagerPort: 9093,
     },
 
     compact:: t.compact(thanosSharedConfig {
@@ -77,7 +78,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       replicas: 1,  // overwritten in observatorium-metrics-template.libsonnet
       logLevel: '${THANOS_RULER_LOG_LEVEL}',
       serviceMonitor: true,
-      alertmanagersURLs: ['dnssrv+http://%s.%s.svc.cluster.local' % [thanosSharedConfig.alertmanagerName, thanosSharedConfig.namespace]],
+      alertmanagersURLs: ['dnssrv+http://%s.%s.svc.cluster.local:%s' % [thanosSharedConfig.alertmanagerName, thanosSharedConfig.namespace, thanosSharedConfig.alertmanagerPort]],
       queriers: [
         'dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, thanos.query.service.metadata.namespace],
       ],


### PR DESCRIPTION
This PR specifies the port number for the Alertmanager in Thanos Ruler so that it only sends alerts to AM and not to both AM and oauth-proxy. 

Prior to https://github.com/rhobs/configuration/pull/156 we used [SRV record](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#srv-records) for the headless service where the port name was specified via `_http`, but in order to fix scheme, it was changed. 
As the port was not specified, that resolves to both ports in the service and causes errors as Thanos tries to send alerts to both.

Further context in [MON-2261](https://issues.redhat.com/browse/MON-2261).