### PR TITLE
Set Observatorium Alertmanager to v0.21.0 and parametrize image

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -337,7 +337,7 @@ objects:
           - --web.listen-address=:9093
           - --cluster.listen-address=
           - --log.level=${OBSERVATORIUM_ALERTMANAGER_LOG_LEVEL}
-          image: quay.io/prometheus/alertmanager:main
+          image: ${OBSERVATORIUM_ALERTMANAGER_IMAGE}:${OBSERVATORIUM_ALERTMANAGER_IMAGE_TAG}
           livenessProbe:
             failureThreshold: 4
             httpGet:
@@ -3087,6 +3087,10 @@ parameters:
   value: 100Mi
 - name: OBSERVATORIUM_ALERTMANAGER_LOG_LEVEL
   value: info
+- name: OBSERVATORIUM_ALERTMANAGER_IMAGE
+  value: quay.io/prometheus/alertmanager
+- name: OBSERVATORIUM_ALERTMANAGER_IMAGE_TAG
+  value: v0.21.0
 - name: SERVICE_ACCOUNT_NAME
   value: prometheus-telemeter
 - name: STORAGE_CLASS

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -39,6 +39,8 @@ local obs = import 'observatorium.libsonnet';
     { name: 'OAUTH_PROXY_MEMORY_LIMITS', value: '200Mi' },
     { name: 'OAUTH_PROXY_MEMORY_REQUEST', value: '100Mi' },
     { name: 'OBSERVATORIUM_ALERTMANAGER_LOG_LEVEL', value: 'info' },
+    { name: 'OBSERVATORIUM_ALERTMANAGER_IMAGE', value: 'quay.io/prometheus/alertmanager' },
+    { name: 'OBSERVATORIUM_ALERTMANAGER_IMAGE_TAG', value: 'v0.21.0' },
     { name: 'SERVICE_ACCOUNT_NAME', value: 'prometheus-telemeter' },
     { name: 'STORAGE_CLASS', value: 'gp2' },
     { name: 'THANOS_COMPACTOR_CPU_LIMIT', value: '1' },

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -760,7 +760,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       local cfg = {
         name: 'observatorium-alertmanager',
         namespace: thanosSharedConfig.namespace,
-        image: 'quay.io/prometheus/alertmanager:main',
+        image: '${OBSERVATORIUM_ALERTMANAGER_IMAGE}:${OBSERVATORIUM_ALERTMANAGER_IMAGE_TAG}',
         persistentVolumeClaimName: 'alertmanager-data',
         dataMountPath: '/data',
         configMountPath: '/etc/config',


### PR DESCRIPTION
Since we use [version](https://github.com/app-sre/container-images/blob/master/qontract-reconcile-base/Dockerfile#L16) 0.21.0 in `app-interface`, as discussed we can align the Observatorium Alertmanager to that same version, which will make it possible for us to use the `validate_alertmanager_config` option in the openshift resource definitions.

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>