### PR TITLE
Add parallel stateless Ruler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ $(VENDOR_DIR): $(JB) jsonnetfile.json jsonnetfile.lock.json
 
 JSONNET_SRC = $(shell find . -type f -not -path './*vendor/*' \( -name '*.libsonnet' -o -name '*.jsonnet' \))
 
+.PHONY: update
+update: $(JB) jsonnetfile.json jsonnetfile.lock.json
+	@$(JB) update https://github.com/thanos-io/kube-thanos/jsonnet/kube-thanos@main
+
 .PHONY: format
 format: $(JSONNET_SRC) $(JSONNETFMT)
 	@echo ">>>>> Running format"

--- a/configuration/observatorium/ruler-remote-write.libsonnet
+++ b/configuration/observatorium/ruler-remote-write.libsonnet
@@ -1,0 +1,76 @@
+function(params) {
+  assert std.isString(params.url),
+
+  remote_write: [
+    {
+      url: params.url,
+      name: 'receive-rhobs',
+      headers: {
+        'THANOS-TENANT': '0fc2b00e-201b-4c17-b9f2-19d91adc4fd2',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: '0fc2b00e-201b-4c17-b9f2-19d91adc4fd2',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-telemeter',
+      headers: {
+        'THANOS-TENANT': 'FB870BF3-9F3A-44FF-9BF7-D7A047A52F43',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: 'FB870BF3-9F3A-44FF-9BF7-D7A047A52F43',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-dptp',
+      headers: {
+        'THANOS-TENANT': 'AC879303-C60F-4D0D-A6D5-A485CFD638B8',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: 'AC879303-C60F-4D0D-A6D5-A485CFD638B8',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-osd',
+      headers: {
+        'THANOS-TENANT': '770c1124-6ae8-4324-a9d4-9ce08590094b',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: '770c1124-6ae8-4324-a9d4-9ce08590094b',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-managedkafka',
+      headers: {
+        'THANOS-TENANT': '63e320cd-622a-4d05-9585-ffd48342633e',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: '63e320cd-622a-4d05-9585-ffd48342633e',
+          action: 'keep',
+        },
+      ],
+    },
+  ],
+}

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -183,8 +183,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "e1a68590f56034ca1a43d59401f03e72fd01ac5f",
-      "sum": "9g4HwpZ8Vpi950O6x92HNM47Yqa0+Nfv+7YbwwKpt3o="
+      "version": "6328583a623765ed6ebf18064a301104def57420",
+      "sum": "9XtRX02CoqEIb2BHJ0nDhuV6VvncFBanwQRFd60qYGg="
     },
     {
       "source": {

--- a/observability/config.libsonnet
+++ b/observability/config.libsonnet
@@ -26,7 +26,7 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
       receiveSelector: t.receive.selector,
     },
     rule+:: {
-      selector: 'job=~"%s.*|%s.*|%s.*"' % [thanos.rule.config.name, thanos.statelessRule.config.name, thanos.metricFederationRule.config.name],
+      selector: 'job=~"%s.*|%s.*|%s.*|%s.*"' % [thanos.rule.config.name, thanos.statelessRule.config.name, thanos.metricFederationRule.config.name, thanos.metricFederationStatelessRule.config.name],
     },
     compact+:: {
       selector: 'job="%s"' % thanos.compact.config.name,

--- a/observability/config.libsonnet
+++ b/observability/config.libsonnet
@@ -26,7 +26,7 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
       receiveSelector: t.receive.selector,
     },
     rule+:: {
-      selector: 'job=~"%s.*|%s.*"' % [thanos.rule.config.name, thanos.metricFederationRule.config.name],
+      selector: 'job=~"%s.*|%s.*|%s.*"' % [thanos.rule.config.name, thanos.statelessRule.config.name, thanos.metricFederationRule.config.name],
     },
     compact+:: {
       selector: 'job="%s"' % thanos.compact.config.name,

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
@@ -2022,7 +2022,7 @@ data:
             "options": [
 
             ],
-            "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*\"}, job)",
+            "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
@@ -2022,7 +2022,7 @@ data:
             "options": [
 
             ],
-            "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*\"}, job)",
+            "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
@@ -2022,7 +2022,7 @@ data:
             "options": [
 
             ],
-            "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*\"}, job)",
+            "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml
@@ -32,7 +32,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumnorulesloaded
         summary: Observatorium Thanos Ruler has not any rule to evaluate. This should not have happened. Check out the configuration.
       expr: |
-        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}) == 0
+        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) == 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml
@@ -32,7 +32,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumnorulesloaded
         summary: Observatorium Thanos Ruler has not any rule to evaluate. This should not have happened. Check out the configuration.
       expr: |
-        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) == 0
+        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) == 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml
@@ -32,7 +32,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumnorulesloaded
         summary: Observatorium Thanos Ruler has not any rule to evaluate. This should not have happened. Check out the configuration.
       expr: |
-        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) == 0
+        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}) == 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-custom-metrics-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-custom-metrics-stage.prometheusrules.yaml
@@ -32,7 +32,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumnorulesloaded
         summary: Observatorium Thanos Ruler has not any rule to evaluate. This should not have happened. Check out the configuration.
       expr: |
-        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}) == 0
+        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) == 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-custom-metrics-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-custom-metrics-stage.prometheusrules.yaml
@@ -32,7 +32,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumnorulesloaded
         summary: Observatorium Thanos Ruler has not any rule to evaluate. This should not have happened. Check out the configuration.
       expr: |
-        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) == 0
+        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) == 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-custom-metrics-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-custom-metrics-stage.prometheusrules.yaml
@@ -32,7 +32,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumnorulesloaded
         summary: Observatorium Thanos Ruler has not any rule to evaluate. This should not have happened. Check out the configuration.
       expr: |
-        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) == 0
+        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}) == 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
@@ -58,7 +58,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleisdown
         summary: Thanos component has disappeared from {{$labels.namespace}}.
       expr: |
-        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"} == 1)
+        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"} == 1)
       for: 5m
       labels:
         service: telemeter
@@ -444,7 +444,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulequeueisdroppingalerts
         summary: Thanos Rule is failing to queue alerts.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -457,7 +457,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulesenderisfailingalerts
         summary: Thanos Rule is failing to send alerts to alertmanager.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -471,9 +471,9 @@ spec:
         summary: Thanos Rule is failing to evaluate rules.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -488,7 +488,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulehighruleevaluationwarnings
         summary: Thanos Rule has high number of evaluation warnings.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
       for: 15m
       labels:
         service: telemeter
@@ -502,9 +502,9 @@ spec:
         summary: Thanos Rule has high rule evaluation latency.
       expr: |
         (
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
         >
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
         )
       for: 5m
       labels:
@@ -519,9 +519,9 @@ spec:
         summary: Thanos Rule is failing to handle grpc requests.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -535,7 +535,7 @@ spec:
         message: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has not been able to reload its configuration.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleconfigreloadfailure
         summary: Thanos Rule has not been able to reload configuration.
-      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) != 1
+      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) != 1
       for: 5m
       labels:
         service: telemeter
@@ -549,9 +549,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -567,9 +567,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -584,9 +584,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulenoevaluationfor10intervals
         summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
       expr: |
-        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
+        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
         >
-        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
+        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
       for: 5m
       labels:
         service: telemeter
@@ -599,9 +599,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosnoruleevaluations
         summary: Thanos Rule did not perform any rule evaluations.
       expr: |
-        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) <= 0
+        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) <= 0
           and
-        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) > 0
+        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) > 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
@@ -58,7 +58,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleisdown
         summary: Thanos component has disappeared from {{$labels.namespace}}.
       expr: |
-        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"} == 1)
+        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"} == 1)
       for: 5m
       labels:
         service: telemeter
@@ -444,7 +444,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulequeueisdroppingalerts
         summary: Thanos Rule is failing to queue alerts.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -457,7 +457,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulesenderisfailingalerts
         summary: Thanos Rule is failing to send alerts to alertmanager.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -471,9 +471,9 @@ spec:
         summary: Thanos Rule is failing to evaluate rules.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -488,7 +488,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulehighruleevaluationwarnings
         summary: Thanos Rule has high number of evaluation warnings.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
       for: 15m
       labels:
         service: telemeter
@@ -502,9 +502,9 @@ spec:
         summary: Thanos Rule has high rule evaluation latency.
       expr: |
         (
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
         >
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
         )
       for: 5m
       labels:
@@ -519,9 +519,9 @@ spec:
         summary: Thanos Rule is failing to handle grpc requests.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -535,7 +535,7 @@ spec:
         message: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has not been able to reload its configuration.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleconfigreloadfailure
         summary: Thanos Rule has not been able to reload configuration.
-      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}) != 1
+      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) != 1
       for: 5m
       labels:
         service: telemeter
@@ -549,9 +549,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -567,9 +567,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -584,9 +584,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulenoevaluationfor10intervals
         summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
       expr: |
-        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"})
+        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
         >
-        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"})
+        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
       for: 5m
       labels:
         service: telemeter
@@ -599,9 +599,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosnoruleevaluations
         summary: Thanos Rule did not perform any rule evaluations.
       expr: |
-        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) <= 0
+        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) <= 0
           and
-        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}) > 0
+        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) > 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
@@ -58,7 +58,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleisdown
         summary: Thanos component has disappeared from {{$labels.namespace}}.
       expr: |
-        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"} == 1)
+        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"} == 1)
       for: 5m
       labels:
         service: telemeter
@@ -444,7 +444,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulequeueisdroppingalerts
         summary: Thanos Rule is failing to queue alerts.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -457,7 +457,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulesenderisfailingalerts
         summary: Thanos Rule is failing to send alerts to alertmanager.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -471,9 +471,9 @@ spec:
         summary: Thanos Rule is failing to evaluate rules.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -488,7 +488,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulehighruleevaluationwarnings
         summary: Thanos Rule has high number of evaluation warnings.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m])) > 0
       for: 15m
       labels:
         service: telemeter
@@ -502,9 +502,9 @@ spec:
         summary: Thanos Rule has high rule evaluation latency.
       expr: |
         (
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"})
         >
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"})
         )
       for: 5m
       labels:
@@ -519,9 +519,9 @@ spec:
         summary: Thanos Rule is failing to handle grpc requests.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -535,7 +535,7 @@ spec:
         message: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has not been able to reload its configuration.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleconfigreloadfailure
         summary: Thanos Rule has not been able to reload configuration.
-      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) != 1
+      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}) != 1
       for: 5m
       labels:
         service: telemeter
@@ -549,9 +549,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -567,9 +567,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -584,9 +584,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulenoevaluationfor10intervals
         summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
       expr: |
-        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
+        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"})
         >
-        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
+        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"})
       for: 5m
       labels:
         service: telemeter
@@ -599,9 +599,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosnoruleevaluations
         summary: Thanos Rule did not perform any rule evaluations.
       expr: |
-        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) <= 0
+        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m])) <= 0
           and
-        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) > 0
+        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}) > 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
@@ -58,7 +58,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleisdown
         summary: Thanos component has disappeared from {{$labels.namespace}}.
       expr: |
-        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"} == 1)
+        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"} == 1)
       for: 5m
       labels:
         service: telemeter
@@ -444,7 +444,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulequeueisdroppingalerts
         summary: Thanos Rule is failing to queue alerts.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -457,7 +457,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulesenderisfailingalerts
         summary: Thanos Rule is failing to send alerts to alertmanager.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -471,9 +471,9 @@ spec:
         summary: Thanos Rule is failing to evaluate rules.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -488,7 +488,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulehighruleevaluationwarnings
         summary: Thanos Rule has high number of evaluation warnings.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
       for: 15m
       labels:
         service: telemeter
@@ -502,9 +502,9 @@ spec:
         summary: Thanos Rule has high rule evaluation latency.
       expr: |
         (
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
         >
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
         )
       for: 5m
       labels:
@@ -519,9 +519,9 @@ spec:
         summary: Thanos Rule is failing to handle grpc requests.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -535,7 +535,7 @@ spec:
         message: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has not been able to reload its configuration.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleconfigreloadfailure
         summary: Thanos Rule has not been able to reload configuration.
-      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) != 1
+      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) != 1
       for: 5m
       labels:
         service: telemeter
@@ -549,9 +549,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -567,9 +567,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -584,9 +584,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulenoevaluationfor10intervals
         summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
       expr: |
-        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
+        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
         >
-        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
+        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
       for: 5m
       labels:
         service: telemeter
@@ -599,9 +599,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosnoruleevaluations
         summary: Thanos Rule did not perform any rule evaluations.
       expr: |
-        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) <= 0
+        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) <= 0
           and
-        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) > 0
+        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) > 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
@@ -58,7 +58,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleisdown
         summary: Thanos component has disappeared from {{$labels.namespace}}.
       expr: |
-        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"} == 1)
+        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"} == 1)
       for: 5m
       labels:
         service: telemeter
@@ -444,7 +444,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulequeueisdroppingalerts
         summary: Thanos Rule is failing to queue alerts.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -457,7 +457,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulesenderisfailingalerts
         summary: Thanos Rule is failing to send alerts to alertmanager.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -471,9 +471,9 @@ spec:
         summary: Thanos Rule is failing to evaluate rules.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -488,7 +488,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulehighruleevaluationwarnings
         summary: Thanos Rule has high number of evaluation warnings.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) > 0
       for: 15m
       labels:
         service: telemeter
@@ -502,9 +502,9 @@ spec:
         summary: Thanos Rule has high rule evaluation latency.
       expr: |
         (
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
         >
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
         )
       for: 5m
       labels:
@@ -519,9 +519,9 @@ spec:
         summary: Thanos Rule is failing to handle grpc requests.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -535,7 +535,7 @@ spec:
         message: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has not been able to reload its configuration.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleconfigreloadfailure
         summary: Thanos Rule has not been able to reload configuration.
-      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}) != 1
+      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) != 1
       for: 5m
       labels:
         service: telemeter
@@ -549,9 +549,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -567,9 +567,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -584,9 +584,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulenoevaluationfor10intervals
         summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
       expr: |
-        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"})
+        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
         >
-        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"})
+        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"})
       for: 5m
       labels:
         service: telemeter
@@ -599,9 +599,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosnoruleevaluations
         summary: Thanos Rule did not perform any rule evaluations.
       expr: |
-        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) <= 0
+        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}[5m])) <= 0
           and
-        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-metric-federation-rule.*"}) > 0
+        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*"}) > 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
@@ -58,7 +58,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleisdown
         summary: Thanos component has disappeared from {{$labels.namespace}}.
       expr: |
-        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"} == 1)
+        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"} == 1)
       for: 5m
       labels:
         service: telemeter
@@ -444,7 +444,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulequeueisdroppingalerts
         summary: Thanos Rule is failing to queue alerts.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -457,7 +457,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulesenderisfailingalerts
         summary: Thanos Rule is failing to send alerts to alertmanager.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -471,9 +471,9 @@ spec:
         summary: Thanos Rule is failing to evaluate rules.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -488,7 +488,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulehighruleevaluationwarnings
         summary: Thanos Rule has high number of evaluation warnings.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m])) > 0
       for: 15m
       labels:
         service: telemeter
@@ -502,9 +502,9 @@ spec:
         summary: Thanos Rule has high rule evaluation latency.
       expr: |
         (
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"})
         >
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"})
         )
       for: 5m
       labels:
@@ -519,9 +519,9 @@ spec:
         summary: Thanos Rule is failing to handle grpc requests.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -535,7 +535,7 @@ spec:
         message: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has not been able to reload its configuration.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleconfigreloadfailure
         summary: Thanos Rule has not been able to reload configuration.
-      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) != 1
+      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}) != 1
       for: 5m
       labels:
         service: telemeter
@@ -549,9 +549,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -567,9 +567,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -584,9 +584,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulenoevaluationfor10intervals
         summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
       expr: |
-        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
+        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"})
         >
-        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"})
+        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"})
       for: 5m
       labels:
         service: telemeter
@@ -599,9 +599,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosnoruleevaluations
         summary: Thanos Rule did not perform any rule evaluations.
       expr: |
-        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}[5m])) <= 0
+        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}[5m])) <= 0
           and
-        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-statless-rule.*"}) > 0
+        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-federation-stateless-rule.*"}) > 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -339,7 +339,7 @@ objects:
       app.kubernetes.io/name: thanos-rule
       app.kubernetes.io/part-of: observatorium
       app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
-    name: observatorium-thanos-metric-federation-statless-rule
+    name: observatorium-thanos-metric-federation-stateless-rule
   spec:
     clusterIP: None
     ports:
@@ -366,7 +366,7 @@ objects:
       app.kubernetes.io/name: thanos-rule
       app.kubernetes.io/part-of: observatorium
       app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
-    name: observatorium-thanos-metric-federation-statless-rule
+    name: observatorium-thanos-metric-federation-stateless-rule
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
@@ -376,7 +376,7 @@ objects:
       app.kubernetes.io/name: thanos-rule
       app.kubernetes.io/part-of: observatorium
       prometheus: app-sre
-    name: observatorium-thanos-metric-federation-statless-rule
+    name: observatorium-thanos-metric-federation-stateless-rule
   spec:
     endpoints:
     - port: http
@@ -404,7 +404,7 @@ objects:
       app.kubernetes.io/name: thanos-rule
       app.kubernetes.io/part-of: observatorium
       app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
-    name: observatorium-thanos-metric-federation-statless-rule
+    name: observatorium-thanos-metric-federation-stateless-rule
   spec:
     replicas: ${{THANOS_RULER_REPLICAS}}
     selector:
@@ -413,7 +413,7 @@ objects:
         app.kubernetes.io/instance: metric-federation
         app.kubernetes.io/name: thanos-rule
         app.kubernetes.io/part-of: observatorium
-    serviceName: observatorium-thanos-metric-federation-statless-rule
+    serviceName: observatorium-thanos-metric-federation-stateless-rule
     template:
       metadata:
         labels:

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -288,6 +288,318 @@ objects:
           requests:
             storage: ${THANOS_RULER_PVC_REQUEST}
         storageClassName: ${STORAGE_CLASS}
+- apiVersion: v1
+  data:
+    rw-config.yaml: |-
+      "remote_write":
+      - "headers":
+          "THANOS-TENANT": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
+        "name": "receive-rhobs"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+        "name": "receive-telemeter"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+        "name": "receive-dptp"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+        "name": "receive-osd"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "63e320cd-622a-4d05-9585-ffd48342633e"
+        "name": "receive-managedkafka"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "63e320cd-622a-4d05-9585-ffd48342633e"
+          "source_labels":
+          - "tenant_id"
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/part-of: observatorium
+    name: remote-write-config
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-metric-federation-statless-rule
+  spec:
+    clusterIP: None
+    ports:
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+    - name: http
+      port: 10902
+      targetPort: 10902
+    - name: reloader
+      port: 9533
+      targetPort: 9533
+    selector:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-metric-federation-statless-rule
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      prometheus: app-sre
+    name: observatorium-thanos-metric-federation-statless-rule
+  spec:
+    endpoints:
+    - port: http
+      relabelings:
+      - separator: /
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: instance
+    - port: reloader
+    namespaceSelector:
+      matchNames: ${{NAMESPACES}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: metric-federation
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-metric-federation-statless-rule
+  spec:
+    replicas: ${{THANOS_RULER_REPLICAS}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: metric-federation
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+    serviceName: observatorium-thanos-metric-federation-statless-rule
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: metric-federation
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+          app.kubernetes.io/tracing: jaeger-agent
+          app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      spec:
+        containers:
+        - args:
+          - rule
+          - --log.level=${THANOS_RULER_LOG_LEVEL}
+          - --log.format=logfmt
+          - --grpc-address=0.0.0.0:10901
+          - --http-address=0.0.0.0:10902
+          - --objstore.config=$(OBJSTORE_CONFIG)
+          - --data-dir=/var/thanos/rule
+          - --label=rule_replica="$(NAME)"
+          - --alert.label-drop=rule_replica
+          - --tsdb.retention=48h
+          - --tsdb.block-duration=2h
+          - --query=dnssrv+_http._tcp.observatorium-thanos-query.${THANOS_QUERIER_NAMESPACE}.svc.cluster.local
+          - --rule-file=/etc/thanos/rules/metric-federation-rules/observatorium.yaml
+          - |-
+            --tracing.config="config":
+              "sampler_param": 2
+              "sampler_type": "ratelimiting"
+              "service_name": "thanos-rule"
+            "type": "JAEGER"
+          - --remote-write.config-file=/etc/thanos/config/metric-federation-ruler-remote-write-config/rw-config.yaml
+          env:
+          - name: NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OBJSTORE_CONFIG
+            valueFrom:
+              secretKeyRef:
+                key: thanos.yaml
+                name: ${THANOS_CONFIG_SECRET}
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: aws_access_key_id
+                name: ${THANOS_S3_SECRET}
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: aws_secret_access_key
+                name: ${THANOS_S3_SECRET}
+          image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 24
+            httpGet:
+              path: /-/healthy
+              port: 10902
+              scheme: HTTP
+            periodSeconds: 5
+          name: thanos-rule
+          ports:
+          - containerPort: 10901
+            name: grpc
+          - containerPort: 10902
+            name: http
+          - containerPort: 9533
+            name: reloader
+          readinessProbe:
+            failureThreshold: 18
+            httpGet:
+              path: /-/ready
+              port: 10902
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: ${THANOS_RULER_CPU_LIMIT}
+              memory: ${THANOS_RULER_MEMORY_LIMIT}
+            requests:
+              cpu: ${THANOS_RULER_CPU_REQUEST}
+              memory: ${THANOS_RULER_MEMORY_REQUEST}
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /var/thanos/rule
+            name: data
+            readOnly: false
+          - mountPath: /etc/thanos/rules/metric-federation-rules
+            name: metric-federation-rules
+          - mountPath: /etc/thanos/config/metric-federation-ruler-remote-write-config
+            name: metric-federation-ruler-remote-write-config
+            readOnly: true
+        - args:
+          - -webhook-url=http://localhost:10902/-/reload
+          - -volume-dir=/etc/thanos/rules/metric-federation-rules
+          - -volume-dir=/etc/thanos/config/metric-federation-ruler-remote-write-config
+          image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          name: configmap-reloader
+          volumeMounts:
+          - mountPath: /etc/thanos/rules/metric-federation-rules
+            name: metric-federation-rules
+          - mountPath: /etc/thanos/config/metric-federation-ruler-remote-write-config
+            name: metric-federation-ruler-remote-write-config
+        - args:
+          - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+          - --reporter.type=grpc
+          - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+          env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14271
+              scheme: HTTP
+          name: jaeger-agent
+          ports:
+          - containerPort: 5778
+            name: configs
+          - containerPort: 6831
+            name: jaeger-thrift
+          - containerPort: 14271
+            name: metrics
+          resources:
+            limits:
+              cpu: 128m
+              memory: 128Mi
+            requests:
+              cpu: 32m
+              memory: 64Mi
+        nodeSelector:
+          kubernetes.io/os: linux
+        securityContext: {}
+        serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+        volumes:
+        - configMap:
+            name: metric-federation-rules
+          name: metric-federation-rules
+        - configMap:
+            name: metric-federation-ruler-remote-write-config
+          name: metric-federation-ruler-remote-write-config
+    volumeClaimTemplates:
+    - metadata:
+        labels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: metric-federation
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+        name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: ${THANOS_RULER_PVC_REQUEST}
+        storageClassName: ${STORAGE_CLASS}
 parameters:
 - name: NAMESPACE
   value: observatorium-metrics

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -4,46 +4,6 @@ metadata:
   name: metric-federation-rule
 objects:
 - apiVersion: v1
-  data:
-    observatorium.yaml: |-
-      "groups":
-      - "interval": "1m"
-        "name": "telemeter-kafka.rules"
-        "rules":
-        - "expr": |
-            kafka_id:strimzi_resource_state:max_over_time1h
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "kafka_id:strimzi_resource_state:max_over_time1h"
-        - "expr": |
-            kafka_id:haproxy_server_bytes_in_total:rate1h_gibibytes
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "kafka_id:haproxy_server_bytes_in_total:rate1h_gibibytes"
-        - "expr": |
-            kafka_id:haproxy_server_bytes_out_total:rate1h_gibibytes
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "kafka_id:haproxy_server_bytes_out_total:rate1h_gibibytes"
-        - "expr": |
-            kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes"
-        - "expr": |
-            kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes"
-  kind: ConfigMap
-  metadata:
-    annotations:
-      qontract.recycle: "true"
-    labels:
-      app.kubernetes.io/instance: observatorium
-      app.kubernetes.io/part-of: observatorium
-    name: metric-federation-rules
-- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -151,7 +111,6 @@ objects:
           - --tsdb.retention=48h
           - --tsdb.block-duration=2h
           - --query=dnssrv+_http._tcp.observatorium-thanos-query.${THANOS_QUERIER_NAMESPACE}.svc.cluster.local
-          - --rule-file=/etc/thanos/rules/metric-federation-rules/observatorium.yaml
           - |-
             --tracing.config="config":
               "sampler_param": 2
@@ -219,17 +178,6 @@ objects:
           - mountPath: /var/thanos/rule
             name: data
             readOnly: false
-          - mountPath: /etc/thanos/rules/metric-federation-rules
-            name: metric-federation-rules
-        - args:
-          - -webhook-url=http://localhost:10902/-/reload
-          - -volume-dir=/etc/thanos/rules/metric-federation-rules
-          image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
-          imagePullPolicy: IfNotPresent
-          name: configmap-reloader
-          volumeMounts:
-          - mountPath: /etc/thanos/rules/metric-federation-rules
-            name: metric-federation-rules
         - args:
           - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
           - --reporter.type=grpc
@@ -269,10 +217,7 @@ objects:
           kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
-        volumes:
-        - configMap:
-            name: metric-federation-rules
-          name: metric-federation-rules
+        volumes: []
     volumeClaimTemplates:
     - metadata:
         labels:
@@ -288,6 +233,46 @@ objects:
           requests:
             storage: ${THANOS_RULER_PVC_REQUEST}
         storageClassName: ${STORAGE_CLASS}
+- apiVersion: v1
+  data:
+    observatorium.yaml: |-
+      "groups":
+      - "interval": "1m"
+        "name": "telemeter-kafka.rules"
+        "rules":
+        - "expr": |
+            kafka_id:strimzi_resource_state:max_over_time1h
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "kafka_id:strimzi_resource_state:max_over_time1h"
+        - "expr": |
+            kafka_id:haproxy_server_bytes_in_total:rate1h_gibibytes
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "kafka_id:haproxy_server_bytes_in_total:rate1h_gibibytes"
+        - "expr": |
+            kafka_id:haproxy_server_bytes_out_total:rate1h_gibibytes
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "kafka_id:haproxy_server_bytes_out_total:rate1h_gibibytes"
+        - "expr": |
+            kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibytes"
+        - "expr": |
+            kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes"
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/part-of: observatorium
+    name: metric-federation-rules
 - apiVersion: v1
   data:
     rw-config.yaml: |-

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -62,6 +62,9 @@ objects:
     - name: http
       port: 10902
       targetPort: 10902
+    - name: reloader
+      port: 9533
+      targetPort: 9533
     selector:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: metric-federation
@@ -96,6 +99,7 @@ objects:
         - namespace
         - pod
         targetLabel: instance
+    - port: reloader
     namespaceSelector:
       matchNames: ${{NAMESPACES}}
     selector:
@@ -179,6 +183,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 24
             httpGet:
@@ -192,6 +197,8 @@ objects:
             name: grpc
           - containerPort: 10902
             name: http
+          - containerPort: 9533
+            name: reloader
           readinessProbe:
             failureThreshold: 18
             httpGet:
@@ -218,6 +225,7 @@ objects:
           - -webhook-url=http://localhost:10902/-/reload
           - -volume-dir=/etc/thanos/rules/metric-federation-rules
           image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: configmap-reloader
           volumeMounts:
           - mountPath: /etc/thanos/rules/metric-federation-rules
@@ -258,7 +266,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         volumes:

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2135,7 +2135,6 @@ objects:
           - --tsdb.retention=48h
           - --tsdb.block-duration=2h
           - --query=dnssrv+_http._tcp.observatorium-thanos-query.${NAMESPACE}.svc.cluster.local
-          - --rule-file=/etc/thanos/rules/rule-syncer/observatorium.yaml
           - --alertmanagers.url=dnssrv+http://observatorium-alertmanager.${NAMESPACE}.svc.cluster.local:9093
           - |-
             --tracing.config="config":

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -435,6 +435,115 @@ objects:
         storage: 10Gi
 - apiVersion: v1
   data:
+    observatorium.yaml: |-
+      "groups":
+      - "interval": "1m"
+        "name": "telemeter-telemeter.rules"
+        "rules":
+        - "expr": |
+            count by (name,reason) (cluster_operator_conditions{condition="Degraded"} == 1)
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "name_reason:cluster_operator_degraded:count"
+        - "expr": |
+            count by (name,reason) (cluster_operator_conditions{condition="Available"} == 0)
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "name_reason:cluster_operator_unavailable:count"
+        - "expr": |
+            sort_desc(max by (_id,code) (code:apiserver_request_count:rate:sum{code=~"(4|5)\\d\\d"}) > 0.5)
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_code:apiserver_request_error_rate_sum:max"
+        - "expr": |
+            bottomk by (_id) (1, max by (_id, version) (0 * cluster_version{type="failure"}) or max by (_id, version) (1 + 0 * cluster_version{type="current"}))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_version:cluster_available"
+        - "expr": |
+            topk by (_id) (1, max by (_id, managed, ebs_account, internal) (label_replace(label_replace((subscription_labels{support=~"Standard|Premium|Layered"} * 0 + 1) or subscription_labels * 0, "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com"), "managed", "", "managed", "false")) + on(_id) group_left(version) (topk by (_id) (1, id_version*0)) + on(_id) group_left(install_type) (topk by (_id) (1, id_install_type*0)) + on(_id) group_left(host_type) (topk by (_id) (1, id_primary_host_type*0)) + on(_id) group_left(provider) (topk by (_id) (1, id_provider*0)))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_version_ebs_account_internal:cluster_subscribed"
+        - "expr": |
+            0 * (max by (_id,host_type) (topk by (_id) (1, label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(cluster:virt_platform_nodes:sum, "host_type", "$1", "type", "(aws|ibm_.*|ovirt|none|rhev|gcp|openstack|hyperv|vmware)"), "host_type", "virt-unknown", "host_type", ""), "host_type", "kvm-unknown", "type", "kvm"), "host_type", "xen-unknown", "type", "xen.*"), "host_type", "metal", "host_type", "none"), "host_type", "ibm-$1", "host_type", "ibm[_-](power|systemz).*"))) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}), "host_type", "", "host_type", ""))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_primary_host_type"
+        - "expr": |
+            0 * topk by (_id) (1, count by (_id, provider) (label_replace(cluster_infrastructure_provider * 0 + 2, "provider", "$1", "type", "(.*)")) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}*0+1), "provider", "", "provider", "") or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "provider", "hypershift-unknown", "provider", ""))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_provider"
+        - "expr": |
+            0 * (max by (_id,version) (topk by (_id) (1, cluster_version{type="current"})) or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "version", "", "unknown", ""))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_version"
+        - "expr": |
+            (
+              count by (_id, install_type) (
+                label_replace(
+                  label_replace(
+                    label_replace(
+                      label_replace(
+                        label_replace(
+                          topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"
+                        ), "install_type", "ipi", "type", "openshift-install"
+                      ), "install_type", "hive", "invoker", "hive"
+                    ), "install_type", "assisted-installer", "invoker", "assisted-installer"
+                  ), "install_type", "infrastructure-operator", "invoker", "assisted-installer-operator"
+                )
+              ) or on(_id) (
+                label_replace(
+                  count by (_id) (
+                    cluster:virt_platform_nodes:sum
+                  ), "install_type", "hypershift-unknown", "install_type", ""
+                )
+              ) * 0
+            ) * 0
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_install_type"
+        - "expr": |
+            0 * (max by (_id,cloudpak_type) (topk by (_id) (1, count by (_id,cloudpak_type) (label_replace(subscription_sync_total{installed=~"ibm-((licensing|common-service)-operator).*"}, "cloudpak_type", "unknown", "", ".*")))))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_cloudpak_type"
+        - "expr": |
+            topk by(_id) (1,
+              (label_replace(7+0*count by (_id) (cluster:usage:resources:sum{resource="netnamespaces.network.openshift.io"}), "network_type", "OpenshiftSDN", "", "") > 0) or
+              (label_replace(6+0*count by (_id) (cluster:usage:resources:sum{resource="clusterinformations.crd.projectcalico.org"}), "network_type", "Calico", "", "") > 0) or
+              (label_replace(5+0*count by (_id) (cluster:usage:resources:sum{resource="acicontainersoperators.aci.ctrl"}), "network_type", "ACI", "", "") > 0) or
+              (label_replace(4+0*count by (_id) (cluster:usage:resources:sum{resource="kuryrnetworks.openstack.org"}), "network_type", "Kuryr", "", "") > 0) or
+              (label_replace(3+0*count by (_id) (cluster:usage:resources:sum{resource="ciliumendpoints.cilium.io"}), "network_type", "Cilium", "", "") > 0) or
+              (label_replace(2+0*count by (_id) (cluster:usage:resources:sum{resource="ncpconfigs.nsx.vmware.com"}), "network_type", "VMWareNSX", "", "") > 0) or
+              (label_replace(1+0*count by (_id) (cluster:usage:resources:sum{resource="egressips.k8s.ovn.org"}), "network_type", "OVNKube", "", "")) or
+              (label_replace(0+0*max by (_id) (cluster:node_instance_type_count:sum*0), "network_type", "unknown", "", ""))
+            )
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_network_type"
+        - "expr": |
+            0 * topk by (ebs_account) (1, max by (ebs_account,account_type,internal,email_domain) (label_replace(label_replace(label_replace(subscription_labels{email_domain="redhat.com"}*0+5, "class", "Internal", "class", ".*") or label_replace(subscription_labels{class!="Customer",email_domain=~"(.*\\.|^)ibm.com"}*0+4, "class", "Internal", "class", ".*") or (subscription_labels{class="Customer"}*0+3) or (subscription_labels{class="Partner"}*0+2) or (subscription_labels{class="Evaluation"}*0+1) or label_replace(subscription_labels{class!~"Evaluation|Customer|Partner"}*0+0, "class", "", "class", ".*"), "account_type", "$1", "class", "(.+)"), "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com") ))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "ebs_account_account_type_email_domain_internal"
+        - "expr": |
+            topk(500, sum (acm_managed_cluster_info) by (managed_cluster_id, cloud, created_via, endpoint, instance, job, namespace, pod, service, vendor, version))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "acm_top500_mcs:acm_managed_cluster_info"
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/part-of: observatorium
+    name: observatorium-rules
+- apiVersion: v1
+  data:
     rw-config.yaml: |-
       "remote_write":
       - "headers":
@@ -1919,115 +2028,6 @@ objects:
         app.kubernetes.io/name: thanos-receive
         app.kubernetes.io/part-of: observatorium
 - apiVersion: v1
-  data:
-    observatorium.yaml: |-
-      "groups":
-      - "interval": "1m"
-        "name": "telemeter-telemeter.rules"
-        "rules":
-        - "expr": |
-            count by (name,reason) (cluster_operator_conditions{condition="Degraded"} == 1)
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "name_reason:cluster_operator_degraded:count"
-        - "expr": |
-            count by (name,reason) (cluster_operator_conditions{condition="Available"} == 0)
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "name_reason:cluster_operator_unavailable:count"
-        - "expr": |
-            sort_desc(max by (_id,code) (code:apiserver_request_count:rate:sum{code=~"(4|5)\\d\\d"}) > 0.5)
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_code:apiserver_request_error_rate_sum:max"
-        - "expr": |
-            bottomk by (_id) (1, max by (_id, version) (0 * cluster_version{type="failure"}) or max by (_id, version) (1 + 0 * cluster_version{type="current"}))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_version:cluster_available"
-        - "expr": |
-            topk by (_id) (1, max by (_id, managed, ebs_account, internal) (label_replace(label_replace((subscription_labels{support=~"Standard|Premium|Layered"} * 0 + 1) or subscription_labels * 0, "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com"), "managed", "", "managed", "false")) + on(_id) group_left(version) (topk by (_id) (1, id_version*0)) + on(_id) group_left(install_type) (topk by (_id) (1, id_install_type*0)) + on(_id) group_left(host_type) (topk by (_id) (1, id_primary_host_type*0)) + on(_id) group_left(provider) (topk by (_id) (1, id_provider*0)))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_version_ebs_account_internal:cluster_subscribed"
-        - "expr": |
-            0 * (max by (_id,host_type) (topk by (_id) (1, label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(cluster:virt_platform_nodes:sum, "host_type", "$1", "type", "(aws|ibm_.*|ovirt|none|rhev|gcp|openstack|hyperv|vmware)"), "host_type", "virt-unknown", "host_type", ""), "host_type", "kvm-unknown", "type", "kvm"), "host_type", "xen-unknown", "type", "xen.*"), "host_type", "metal", "host_type", "none"), "host_type", "ibm-$1", "host_type", "ibm[_-](power|systemz).*"))) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}), "host_type", "", "host_type", ""))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_primary_host_type"
-        - "expr": |
-            0 * topk by (_id) (1, count by (_id, provider) (label_replace(cluster_infrastructure_provider * 0 + 2, "provider", "$1", "type", "(.*)")) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}*0+1), "provider", "", "provider", "") or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "provider", "hypershift-unknown", "provider", ""))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_provider"
-        - "expr": |
-            0 * (max by (_id,version) (topk by (_id) (1, cluster_version{type="current"})) or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "version", "", "unknown", ""))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_version"
-        - "expr": |
-            (
-              count by (_id, install_type) (
-                label_replace(
-                  label_replace(
-                    label_replace(
-                      label_replace(
-                        label_replace(
-                          topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"
-                        ), "install_type", "ipi", "type", "openshift-install"
-                      ), "install_type", "hive", "invoker", "hive"
-                    ), "install_type", "assisted-installer", "invoker", "assisted-installer"
-                  ), "install_type", "infrastructure-operator", "invoker", "assisted-installer-operator"
-                )
-              ) or on(_id) (
-                label_replace(
-                  count by (_id) (
-                    cluster:virt_platform_nodes:sum
-                  ), "install_type", "hypershift-unknown", "install_type", ""
-                )
-              ) * 0
-            ) * 0
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_install_type"
-        - "expr": |
-            0 * (max by (_id,cloudpak_type) (topk by (_id) (1, count by (_id,cloudpak_type) (label_replace(subscription_sync_total{installed=~"ibm-((licensing|common-service)-operator).*"}, "cloudpak_type", "unknown", "", ".*")))))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_cloudpak_type"
-        - "expr": |
-            topk by(_id) (1,
-              (label_replace(7+0*count by (_id) (cluster:usage:resources:sum{resource="netnamespaces.network.openshift.io"}), "network_type", "OpenshiftSDN", "", "") > 0) or
-              (label_replace(6+0*count by (_id) (cluster:usage:resources:sum{resource="clusterinformations.crd.projectcalico.org"}), "network_type", "Calico", "", "") > 0) or
-              (label_replace(5+0*count by (_id) (cluster:usage:resources:sum{resource="acicontainersoperators.aci.ctrl"}), "network_type", "ACI", "", "") > 0) or
-              (label_replace(4+0*count by (_id) (cluster:usage:resources:sum{resource="kuryrnetworks.openstack.org"}), "network_type", "Kuryr", "", "") > 0) or
-              (label_replace(3+0*count by (_id) (cluster:usage:resources:sum{resource="ciliumendpoints.cilium.io"}), "network_type", "Cilium", "", "") > 0) or
-              (label_replace(2+0*count by (_id) (cluster:usage:resources:sum{resource="ncpconfigs.nsx.vmware.com"}), "network_type", "VMWareNSX", "", "") > 0) or
-              (label_replace(1+0*count by (_id) (cluster:usage:resources:sum{resource="egressips.k8s.ovn.org"}), "network_type", "OVNKube", "", "")) or
-              (label_replace(0+0*max by (_id) (cluster:node_instance_type_count:sum*0), "network_type", "unknown", "", ""))
-            )
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_network_type"
-        - "expr": |
-            0 * topk by (ebs_account) (1, max by (ebs_account,account_type,internal,email_domain) (label_replace(label_replace(label_replace(subscription_labels{email_domain="redhat.com"}*0+5, "class", "Internal", "class", ".*") or label_replace(subscription_labels{class!="Customer",email_domain=~"(.*\\.|^)ibm.com"}*0+4, "class", "Internal", "class", ".*") or (subscription_labels{class="Customer"}*0+3) or (subscription_labels{class="Partner"}*0+2) or (subscription_labels{class="Evaluation"}*0+1) or label_replace(subscription_labels{class!~"Evaluation|Customer|Partner"}*0+0, "class", "", "class", ".*"), "account_type", "$1", "class", "(.+)"), "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com") ))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "ebs_account_account_type_email_domain_internal"
-        - "expr": |
-            topk(500, sum (acm_managed_cluster_info) by (managed_cluster_id, cloud, created_via, endpoint, instance, job, namespace, pod, service, vendor, version))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "acm_top500_mcs:acm_managed_cluster_info"
-  kind: ConfigMap
-  metadata:
-    annotations:
-      qontract.recycle: "true"
-    labels:
-      app.kubernetes.io/instance: observatorium
-      app.kubernetes.io/part-of: observatorium
-    name: observatorium-rules
-- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -2137,7 +2137,6 @@ objects:
           - --query=dnssrv+_http._tcp.observatorium-thanos-query.${NAMESPACE}.svc.cluster.local
           - --rule-file=/etc/thanos/rules/rule-syncer/observatorium.yaml
           - --alertmanagers.url=dnssrv+http://observatorium-alertmanager.${NAMESPACE}.svc.cluster.local:9093
-          - --rule-file=/etc/thanos/rules/observatorium-rules/observatorium.yaml
           - |-
             --tracing.config="config":
               "sampler_param": 2
@@ -2205,19 +2204,8 @@ objects:
           - mountPath: /var/thanos/rule
             name: data
             readOnly: false
-          - mountPath: /etc/thanos/rules/observatorium-rules
-            name: observatorium-rules
           - mountPath: /etc/thanos/rules/rule-syncer
             name: rule-syncer
-        - args:
-          - -webhook-url=http://localhost:10902/-/reload
-          - -volume-dir=/etc/thanos/rules/observatorium-rules
-          image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
-          imagePullPolicy: IfNotPresent
-          name: configmap-reloader
-          volumeMounts:
-          - mountPath: /etc/thanos/rules/observatorium-rules
-            name: observatorium-rules
         - args:
           - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
           - --reporter.type=grpc
@@ -2275,9 +2263,6 @@ objects:
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         volumes:
-        - configMap:
-            name: observatorium-rules
-          name: observatorium-rules
         - emptyDir: {}
           name: rule-syncer
     volumeClaimTemplates:

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -29,6 +29,7 @@ objects:
       app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
     name: observatorium-thanos-compact
   spec:
+    clusterIP: None
     ports:
     - name: http
       port: 10902
@@ -106,6 +107,24 @@ objects:
           app.kubernetes.io/part-of: observatorium
           app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - thanos-compact
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                    - observatorium
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - compact
@@ -119,6 +138,8 @@ objects:
           - --retention.resolution-5m=${THANOS_COMPACTOR_RETENTION_RESOLUTION_FIVE_MINUTES}
           - --retention.resolution-1h=${THANOS_COMPACTOR_RETENTION_RESOLUTION_ONE_HOUR}
           - --delete-delay=48h
+          - --compact.concurrency=1
+          - --downsample.concurrency=1
           - --deduplication.replica-label=replica
           - --debug.max-compaction-level=3
           - ${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}
@@ -143,6 +164,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 4
             httpGet:
@@ -208,7 +230,7 @@ objects:
             name: compact-proxy
             readOnly: false
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -497,6 +519,7 @@ objects:
               fieldRef:
                 fieldPath: status.hostIP
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 4
             httpGet:
@@ -600,7 +623,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -812,6 +835,7 @@ objects:
               fieldRef:
                 fieldPath: status.hostIP
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 4
             httpGet:
@@ -908,7 +932,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -1356,12 +1380,12 @@ objects:
           - --http-address=0.0.0.0:10902
           - --remote-write.address=0.0.0.0:19291
           - --receive.replication-factor=3
-          - --objstore.config=$(OBJSTORE_CONFIG)
           - --tsdb.path=${THANOS_RECEIVE_TSDB_PATH}
           - --tsdb.retention=4d
-          - --receive.local-endpoint=$(NAME).observatorium-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
           - --label=replica="$(NAME)"
           - --label=receive="true"
+          - --objstore.config=$(OBJSTORE_CONFIG)
+          - --receive.local-endpoint=$(NAME).observatorium-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
           - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
           - |-
             --tracing.config="config":
@@ -1379,15 +1403,15 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: OBJSTORE_CONFIG
             valueFrom:
               secretKeyRef:
                 key: thanos.yaml
                 name: ${THANOS_CONFIG_SECRET}
-          - name: HOST_IP_ADDRESS
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
           - name: DEBUG
             value: ${THANOS_RECEIVE_DEBUG_ENV}
           - name: AWS_ACCESS_KEY_ID
@@ -1403,6 +1427,7 @@ objects:
           - name: DEBUG
             value: ${THANOS_RECEIVE_DEBUG_ENV}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
             httpGet:
@@ -1475,7 +1500,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 900
@@ -1685,6 +1710,9 @@ objects:
     - name: http
       port: 10902
       targetPort: 10902
+    - name: reloader
+      port: 9533
+      targetPort: 9533
     selector:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: observatorium
@@ -1719,6 +1747,7 @@ objects:
         - namespace
         - pod
         targetLabel: instance
+    - port: reloader
     namespaceSelector:
       matchNames: ${{NAMESPACES}}
     selector:
@@ -1804,6 +1833,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 24
             httpGet:
@@ -1817,6 +1847,8 @@ objects:
             name: grpc
           - containerPort: 10902
             name: http
+          - containerPort: 9533
+            name: reloader
           readinessProbe:
             failureThreshold: 18
             httpGet:
@@ -1845,6 +1877,7 @@ objects:
           - -webhook-url=http://localhost:10902/-/reload
           - -volume-dir=/etc/thanos/rules/observatorium-rules
           image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: configmap-reloader
           volumeMounts:
           - mountPath: /etc/thanos/rules/observatorium-rules
@@ -1902,7 +1935,7 @@ objects:
           - mountPath: /etc/thanos-rule-syncer
             name: rule-syncer
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         volumes:
@@ -2327,6 +2360,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
             httpGet:
@@ -2395,7 +2429,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -2573,6 +2607,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
             httpGet:
@@ -2641,7 +2676,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120
@@ -2819,6 +2854,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${THANOS_S3_SECRET}
           image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
             httpGet:
@@ -2887,7 +2923,7 @@ objects:
               cpu: 32m
               memory: 64Mi
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         terminationGracePeriodSeconds: 120

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -435,6 +435,341 @@ objects:
         storage: 10Gi
 - apiVersion: v1
   data:
+    rw-config.yaml: |-
+      "remote_write":
+      - "headers":
+          "THANOS-TENANT": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
+        "name": "receive-rhobs"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+        "name": "receive-telemeter"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+        "name": "receive-dptp"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+        "name": "receive-osd"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "63e320cd-622a-4d05-9585-ffd48342633e"
+        "name": "receive-managedkafka"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "63e320cd-622a-4d05-9585-ffd48342633e"
+          "source_labels":
+          - "tenant_id"
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/part-of: observatorium
+    name: remote-write-config
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-stateless-rule
+  spec:
+    clusterIP: None
+    ports:
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+    - name: http
+      port: 10902
+      targetPort: 10902
+    - name: reloader
+      port: 9533
+      targetPort: 9533
+    selector:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-stateless-rule
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      prometheus: app-sre
+    name: observatorium-thanos-stateless-rule
+  spec:
+    endpoints:
+    - port: http
+      relabelings:
+      - separator: /
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: instance
+    - port: reloader
+    namespaceSelector:
+      matchNames: ${{NAMESPACES}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-stateless-rule
+  spec:
+    replicas: ${{THANOS_RULER_REPLICAS}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+    serviceName: observatorium-thanos-stateless-rule
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+          app.kubernetes.io/tracing: jaeger-agent
+          app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      spec:
+        containers:
+        - args:
+          - rule
+          - --log.level=${THANOS_RULER_LOG_LEVEL}
+          - --log.format=logfmt
+          - --grpc-address=0.0.0.0:10901
+          - --http-address=0.0.0.0:10902
+          - --objstore.config=$(OBJSTORE_CONFIG)
+          - --data-dir=/var/thanos/rule
+          - --label=rule_replica="$(NAME)"
+          - --alert.label-drop=rule_replica
+          - --tsdb.retention=48h
+          - --tsdb.block-duration=2h
+          - --query=dnssrv+_http._tcp.observatorium-thanos-query.${NAMESPACE}.svc.cluster.local
+          - --rule-file=/etc/thanos/rules/rule-syncer/observatorium.yaml
+          - --alertmanagers.url=dnssrv+http://observatorium-alertmanager.${NAMESPACE}.svc.cluster.local:9093
+          - --rule-file=/etc/thanos/rules/observatorium-rules/observatorium.yaml
+          - |-
+            --tracing.config="config":
+              "sampler_param": 2
+              "sampler_type": "ratelimiting"
+              "service_name": "thanos-rule"
+            "type": "JAEGER"
+          - --remote-write.config-file=/etc/thanos/config/remote-write-config/rw-config.yaml
+          env:
+          - name: NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OBJSTORE_CONFIG
+            valueFrom:
+              secretKeyRef:
+                key: thanos.yaml
+                name: ${THANOS_CONFIG_SECRET}
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: aws_access_key_id
+                name: ${THANOS_S3_SECRET}
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: aws_secret_access_key
+                name: ${THANOS_S3_SECRET}
+          image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 24
+            httpGet:
+              path: /-/healthy
+              port: 10902
+              scheme: HTTP
+            periodSeconds: 5
+          name: thanos-rule
+          ports:
+          - containerPort: 10901
+            name: grpc
+          - containerPort: 10902
+            name: http
+          - containerPort: 9533
+            name: reloader
+          readinessProbe:
+            failureThreshold: 18
+            httpGet:
+              path: /-/ready
+              port: 10902
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: ${THANOS_RULER_CPU_LIMIT}
+              memory: ${THANOS_RULER_MEMORY_LIMIT}
+            requests:
+              cpu: ${THANOS_RULER_CPU_REQUEST}
+              memory: ${THANOS_RULER_MEMORY_REQUEST}
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /var/thanos/rule
+            name: data
+            readOnly: false
+          - mountPath: /etc/thanos/rules/observatorium-rules
+            name: observatorium-rules
+          - mountPath: /etc/thanos/config/remote-write-config
+            name: remote-write-config
+            readOnly: true
+          - mountPath: /etc/thanos/rules/rule-syncer
+            name: rule-syncer
+        - args:
+          - -webhook-url=http://localhost:10902/-/reload
+          - -volume-dir=/etc/thanos/rules/observatorium-rules
+          - -volume-dir=/etc/thanos/config/remote-write-config
+          image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          name: configmap-reloader
+          volumeMounts:
+          - mountPath: /etc/thanos/rules/observatorium-rules
+            name: observatorium-rules
+          - mountPath: /etc/thanos/config/remote-write-config
+            name: remote-write-config
+        - args:
+          - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+          - --reporter.type=grpc
+          - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+          env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14271
+              scheme: HTTP
+          name: jaeger-agent
+          ports:
+          - containerPort: 5778
+            name: configs
+          - containerPort: 6831
+            name: jaeger-thrift
+          - containerPort: 14271
+            name: metrics
+          resources:
+            limits:
+              cpu: 128m
+              memory: 128Mi
+            requests:
+              cpu: 32m
+              memory: 64Mi
+        - args:
+          - -file=/etc/thanos-rule-syncer/observatorium.yaml
+          - -interval=60
+          - -rules-backend-url=http://rules-objstore.${OBSERVATORIUM_NAMESPACE}.svc:8080
+          - -thanos-rule-url=http://localhost:10902
+          image: ${THANOS_RULE_SYNCER_IMAGE}:${THANOS_RULE_SYNCER_IMAGE_TAG}
+          name: thanos-rule-syncer
+          resources:
+            limits:
+              cpu: 128m
+              memory: 128Mi
+            requests:
+              cpu: 32m
+              memory: 64Mi
+          volumeMounts:
+          - mountPath: /etc/thanos-rule-syncer
+            name: rule-syncer
+        nodeSelector:
+          kubernetes.io/os: linux
+        securityContext: {}
+        serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+        volumes:
+        - configMap:
+            name: observatorium-rules
+          name: observatorium-rules
+        - configMap:
+            name: remote-write-config
+          name: remote-write-config
+        - emptyDir: {}
+          name: rule-syncer
+    volumeClaimTemplates:
+    - metadata:
+        labels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+        name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: ${THANOS_RULER_PVC_REQUEST}
+        storageClassName: ${STORAGE_CLASS}
+- apiVersion: v1
+  data:
     file_sd.yaml: '- targets: ${THANOS_QUERIER_FILE_SD_TARGETS}'
   kind: ConfigMap
   metadata:
@@ -498,6 +833,7 @@ objects:
           - --query.replica-label=rule_replica
           - --query.replica-label=prometheus_replica
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-rule.${NAMESPACE}.svc.cluster.local
+          - --store=dnssrv+_grpc._tcp.observatorium-thanos-stateless-rule.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-0.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-1.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-2.${NAMESPACE}.svc.cluster.local

--- a/services/metric-federation-rule-template.jsonnet
+++ b/services/metric-federation-rule-template.jsonnet
@@ -8,7 +8,7 @@ local obs = import 'observatorium.libsonnet';
       metadata+: { namespace:: 'hidden' },
     }
     for name in std.objectFields(obs.thanos.manifests)
-    if obs.thanos.manifests[name] != null && std.startsWith(name, 'metric-federation-rule')
+    if obs.thanos.manifests[name] != null && std.startsWith(name, 'metric-federation')
   ],
   parameters: [
     { name: 'NAMESPACE', value: 'observatorium-metrics' },

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -167,6 +167,25 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
       },
     },
 
+    metricFederationStatelessRule+:: {
+      statefulSet+: jaegerAgentSidecar.statefulSet {
+        spec+: {
+          replicas: '${{THANOS_RULER_REPLICAS}}',
+          template+: {
+            spec+: {
+              securityContext: {},
+              containers: [
+                if c.name == 'thanos-rule' then c {
+                  env+: s3EnvVars,
+                } else c
+                for c in super.containers
+              ],
+            },
+          },
+        },
+      },
+    },
+
     stores+:: {
       shards:
         std.mapWithKey(function(shard, obj) obj {  // loops over each [shard-n]:obj

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -125,6 +125,29 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
       },
     },
 
+    statelessRule+:: {
+      statefulSet+: jaegerAgentSidecar.statefulSet + ruleSyncerSidecar.statefulSet {
+        spec+: {
+          replicas: '${{THANOS_RULER_REPLICAS}}',
+          template+: {
+            spec+: {
+              securityContext: {},
+              containers: [
+                if c.name == 'thanos-rule' then c {
+                  env+: s3EnvVars,
+                  volumeMounts+: [{
+                    name: ruleSyncerVolume,
+                    mountPath: '/etc/thanos/rules/rule-syncer',
+                  }],
+                } else c
+                for c in super.containers
+              ],
+            },
+          },
+        },
+      },
+    },
+
     metricFederationRule+:: {
       statefulSet+: jaegerAgentSidecar.statefulSet {
         spec+: {

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -8,7 +8,7 @@ local obs = import 'observatorium.libsonnet';
       metadata+: { namespace:: 'hidden' },
     }
     for name in std.objectFields(obs.thanos.manifests)
-    if obs.thanos.manifests[name] != null && !std.startsWith(name, 'metric-federation-rule')
+    if obs.thanos.manifests[name] != null && !std.startsWith(name, 'metric-federation')
   ],
   parameters: [
     { name: 'NAMESPACE', value: 'observatorium-metrics' },

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -250,7 +250,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
 
     local metricFederationStatelessRuler = 'metric-federation-ruler-remote-write-config',
     metricFederationStatelessRule:: t.rule(thanosSharedConfig {
-      name: 'observatorium-thanos-metric-federation-statless-rule',
+      name: 'observatorium-thanos-metric-federation-stateless-rule',
       commonLabels+:: {
         'app.kubernetes.io/part-of': 'observatorium',
         'app.kubernetes.io/instance': 'metric-federation',

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -84,12 +84,6 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         'dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, thanos.query.service.metadata.namespace],
       ],
       reloaderImage: '${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}',
-      rulesConfig: [
-        {
-          name: observatoriumRules,
-          key: observatoriumRulesKey,
-        },
-      ],
       ruleFiles: [
         '/etc/thanos/rules/rule-syncer/observatorium.yaml',
       ],
@@ -114,36 +108,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
           },
         },
       },
-    }) + {
-      // TODO: Move configmap either to upstream (best) or as overwrite.
-      configmap: {
-        apiVersion: 'v1',
-        kind: 'ConfigMap',
-        metadata: {
-          name: observatoriumRules,
-          annotations: {
-            'qontract.recycle': 'true',
-          },
-          labels: {
-            'app.kubernetes.io/instance': 'observatorium',
-            'app.kubernetes.io/part-of': 'observatorium',
-          },
-        },
-        data: {
-          [observatoriumRulesKey]: std.manifestYamlDoc({
-            groups: std.map(function(group) {
-              name: 'telemeter-' + group.name,
-              interval: group.interval,
-              rules: std.map(function(rule) rule {
-                labels+: {
-                  tenant_id: tenants.map.telemeter.id,
-                },
-              }, group.rules),
-            }, telemeterRules.prometheus.recordingrules.groups),
-          }),
-        },
-      },
-    },
+    }),
 
     local statelessRuler = 'remote-write-config',
     local statelessRulerKey = 'rw-config.yaml',
@@ -219,6 +184,34 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
           })),
         },
       },
+      // TODO: Move configmap either to upstream (best) or as overwrite.
+      configmap: {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: {
+          name: observatoriumRules,
+          annotations: {
+            'qontract.recycle': 'true',
+          },
+          labels: {
+            'app.kubernetes.io/instance': 'observatorium',
+            'app.kubernetes.io/part-of': 'observatorium',
+          },
+        },
+        data: {
+          [observatoriumRulesKey]: std.manifestYamlDoc({
+            groups: std.map(function(group) {
+              name: 'telemeter-' + group.name,
+              interval: group.interval,
+              rules: std.map(function(rule) rule {
+                labels+: {
+                  tenant_id: tenants.map.telemeter.id,
+                },
+              }, group.rules),
+            }, telemeterRules.prometheus.recordingrules.groups),
+          }),
+        },
+      },
     },
 
     local metricFederationRulesName = 'metric-federation-rules',
@@ -235,12 +228,6 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         'dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, '${THANOS_QUERIER_NAMESPACE}'],
       ],
       reloaderImage: '${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}',
-      rulesConfig: [
-        {
-          name: metricFederationRulesName,
-          key: observatoriumRulesKey,
-        },
-      ],
       resources: {
         limits: {
           cpu: '${THANOS_RULER_CPU_LIMIT}',
@@ -262,36 +249,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
           },
         },
       },
-    }) + {
-      // TODO: Move configmap either to upstream (best) or as overwrite.
-      configmap: {
-        apiVersion: 'v1',
-        kind: 'ConfigMap',
-        metadata: {
-          name: metricFederationRulesName,
-          annotations: {
-            'qontract.recycle': 'true',
-          },
-          labels: {
-            'app.kubernetes.io/instance': 'observatorium',
-            'app.kubernetes.io/part-of': 'observatorium',
-          },
-        },
-        data: {
-          [observatoriumRulesKey]: std.manifestYamlDoc({
-            groups: std.map(function(group) {
-              name: 'telemeter-' + group.name,
-              interval: group.interval,
-              rules: std.map(function(rule) rule {
-                labels+: {
-                  tenant_id: tenants.map.telemeter.id,
-                },
-              }, group.rules),
-            }, metricFederationRules.prometheus.recordingrules.groups),
-          }),
-        },
-      },
-    },
+    }),
 
     local metricFederationStatelessRuler = 'metric-federation-ruler-remote-write-config',
     metricFederationStatelessRule:: t.rule(thanosSharedConfig {
@@ -360,6 +318,34 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
               thanos.receiversService.spec.ports[2].port,
             ],
           })),
+        },
+      },
+      // TODO: Move configmap either to upstream (best) or as overwrite.
+      configmap: {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: {
+          name: metricFederationRulesName,
+          annotations: {
+            'qontract.recycle': 'true',
+          },
+          labels: {
+            'app.kubernetes.io/instance': 'observatorium',
+            'app.kubernetes.io/part-of': 'observatorium',
+          },
+        },
+        data: {
+          [observatoriumRulesKey]: std.manifestYamlDoc({
+            groups: std.map(function(group) {
+              name: 'telemeter-' + group.name,
+              interval: group.interval,
+              rules: std.map(function(rule) rule {
+                labels+: {
+                  tenant_id: tenants.map.telemeter.id,
+                },
+              }, group.rules),
+            }, metricFederationRules.prometheus.recordingrules.groups),
+          }),
         },
       },
     },

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -84,9 +84,6 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         'dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, thanos.query.service.metadata.namespace],
       ],
       reloaderImage: '${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}',
-      ruleFiles: [
-        '/etc/thanos/rules/rule-syncer/observatorium.yaml',
-      ],
       resources: {
         limits: {
           cpu: '${THANOS_RULER_CPU_LIMIT}',


### PR DESCRIPTION
This PR,

- Upgrades `kube-thanos` to latest
- Adds stateless Ruler StatefulSet alongside the existing one (uses the same ConfigMap for rules and adds one for remote write config)
- Adds new ruler to dashboard queries

Open question: Should we configure all the same rules on both Rulers, as this PR does? Or try this out with one rule first?
cc: @matej-g 