### PR TITLE
[observatorium-logs]: Bump loki to 2.4.2

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -100,8 +100,8 @@
           "subdir": "configuration"
         }
       },
-      "version": "2de7b74fb0ca1b62d2eeab8bc1eecfb8786cb282",
-      "sum": "dBeYY+hqNXb64b2x+HACcng7d6d6XyI1vVbTHKyN+GQ="
+      "version": "8dc8d05b966cc2ca08812c23e4aab899c5f8e549",
+      "sum": "dG8rtX9vCVD5rcLZkEykYz0uZMHw4o1BAZeaJ1W9p3A="
     },
     {
       "source": {

--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -92,6 +92,7 @@ objects:
           - -c 1024
           - -v
           image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: memcached
           ports:
           - containerPort: 11211
@@ -108,6 +109,7 @@ objects:
           - --memcached.address=localhost:11211
           - --web.listen-address=0.0.0.0:9150
           image: ${MEMCACHED_EXPORTER_IMAGE}:${MEMCACHED_EXPORTER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: exporter
           ports:
           - containerPort: 9150
@@ -204,6 +206,7 @@ objects:
           - -c 1024
           - -v
           image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: memcached
           ports:
           - containerPort: 11211
@@ -220,6 +223,7 @@ objects:
           - --memcached.address=localhost:11211
           - --web.listen-address=0.0.0.0:9150
           image: ${MEMCACHED_EXPORTER_IMAGE}:${MEMCACHED_EXPORTER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: exporter
           ports:
           - containerPort: 9150
@@ -316,6 +320,7 @@ objects:
           - -c 1024
           - -v
           image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: memcached
           ports:
           - containerPort: 11211
@@ -332,6 +337,7 @@ objects:
           - --memcached.address=localhost:11211
           - --web.listen-address=0.0.0.0:9150
           image: ${MEMCACHED_EXPORTER_IMAGE}:${MEMCACHED_EXPORTER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           name: exporter
           ports:
           - containerPort: 9150
@@ -440,7 +446,6 @@ objects:
           - -s3.access-key-id=$(AWS_ACCESS_KEY_ID)
           - -s3.secret-access-key=$(AWS_SECRET_ACCESS_KEY)
           - -distributor.replication-factor=${LOKI_REPLICATION_FACTOR}
-          - -querier.worker-parallelism=${LOKI_QUERY_PARALLELISM}
           env:
           - name: S3_BUCKETS
             valueFrom:
@@ -463,6 +468,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${LOKI_S3_SECRET}
           image: ${LOKI_IMAGE}:${LOKI_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10
             httpGet:
@@ -582,7 +588,7 @@ objects:
         "frontend_address": "observatorium-loki-query-frontend-grpc.${NAMESPACE}.svc.cluster.local:9095"
         "grpc_client_config":
           "max_send_msg_size": 104857600
-        "parallelism": 32
+        "match_max_concurrent": true
       "ingester":
         "chunk_block_size": 262144
         "chunk_encoding": "snappy"
@@ -600,6 +606,10 @@ objects:
             "kvstore":
               "store": "memberlist"
         "max_transfer_retries": 0
+        "wal":
+          "dir": "/data/loki/wal"
+          "enabled": true
+          "replay_memory_ceiling": "4GB"
       "ingester_client":
         "grpc_client_config":
           "max_recv_msg_size": 67108864
@@ -629,6 +639,7 @@ objects:
           "max_look_back_period": "5m"
           "timeout": "3m"
         "extra_query_delay": "0s"
+        "max_concurrent": 2
         "query_ingesters_within": "2h"
         "query_timeout": "1h"
         "tail_max_duration": "1h"
@@ -727,7 +738,6 @@ objects:
           - -s3.access-key-id=$(AWS_ACCESS_KEY_ID)
           - -s3.secret-access-key=$(AWS_SECRET_ACCESS_KEY)
           - -distributor.replication-factor=${LOKI_REPLICATION_FACTOR}
-          - -querier.worker-parallelism=${LOKI_QUERY_PARALLELISM}
           env:
           - name: S3_BUCKETS
             valueFrom:
@@ -750,6 +760,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${LOKI_S3_SECRET}
           image: ${LOKI_IMAGE}:${LOKI_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10
             httpGet:
@@ -1014,7 +1025,7 @@ objects:
           - -s3.access-key-id=$(AWS_ACCESS_KEY_ID)
           - -s3.secret-access-key=$(AWS_SECRET_ACCESS_KEY)
           - -distributor.replication-factor=${LOKI_REPLICATION_FACTOR}
-          - -querier.worker-parallelism=${LOKI_QUERY_PARALLELISM}
+          - -ingester.wal-replay-memory-ceiling=${LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING}
           env:
           - name: S3_BUCKETS
             valueFrom:
@@ -1037,6 +1048,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${LOKI_S3_SECRET}
           image: ${LOKI_IMAGE}:${LOKI_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10
             httpGet:
@@ -1230,7 +1242,8 @@ objects:
           - -s3.access-key-id=$(AWS_ACCESS_KEY_ID)
           - -s3.secret-access-key=$(AWS_SECRET_ACCESS_KEY)
           - -distributor.replication-factor=${LOKI_REPLICATION_FACTOR}
-          - -querier.worker-parallelism=${LOKI_QUERY_PARALLELISM}
+          - -querier.max-concurrent=${LOKI_QUERIER_MAX_CONCURRENCY}
+          - -querier.worker-match-max-concurrent
           env:
           - name: S3_BUCKETS
             valueFrom:
@@ -1253,6 +1266,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${LOKI_S3_SECRET}
           image: ${LOKI_IMAGE}:${LOKI_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10
             httpGet:
@@ -1381,7 +1395,6 @@ objects:
           - -s3.access-key-id=$(AWS_ACCESS_KEY_ID)
           - -s3.secret-access-key=$(AWS_SECRET_ACCESS_KEY)
           - -distributor.replication-factor=${LOKI_REPLICATION_FACTOR}
-          - -querier.worker-parallelism=${LOKI_QUERY_PARALLELISM}
           env:
           - name: S3_BUCKETS
             valueFrom:
@@ -1404,6 +1417,7 @@ objects:
                 key: aws_secret_access_key
                 name: ${LOKI_S3_SECRET}
           image: ${LOKI_IMAGE}:${LOKI_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10
             httpGet:
@@ -1541,7 +1555,7 @@ parameters:
 - name: STORAGE_CLASS
   value: gp2
 - name: LOKI_IMAGE_TAG
-  value: 2.2.1
+  value: 2.4.2
 - name: LOKI_IMAGE
   value: docker.io/grafana/loki
 - name: LOKI_S3_SECRET
@@ -1596,8 +1610,10 @@ parameters:
   value: 1200Mi
 - name: LOKI_REPLICATION_FACTOR
   value: "2"
-- name: LOKI_QUERY_PARALLELISM
+- name: LOKI_QUERIER_MAX_CONCURRENCY
   value: "2"
+- name: LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING
+  value: 5GB
 - name: LOKI_CHUNK_CACHE_REPLICAS
   value: "2"
 - name: LOKI_CHUNK_CACHE_CPU_REQUESTS

--- a/services/observatorium-logs-template.jsonnet
+++ b/services/observatorium-logs-template.jsonnet
@@ -23,7 +23,7 @@ local obs = import 'observatorium.libsonnet';
   parameters: [
     { name: 'NAMESPACE', value: 'observatorium-logs' },
     { name: 'STORAGE_CLASS', value: 'gp2' },
-    { name: 'LOKI_IMAGE_TAG', value: '2.2.1' },
+    { name: 'LOKI_IMAGE_TAG', value: '2.4.2' },
     { name: 'LOKI_IMAGE', value: 'docker.io/grafana/loki' },
     { name: 'LOKI_S3_SECRET', value: 'observatorium-logs-stage-s3' },
     { name: 'LOKI_COMPACTOR_CPU_REQUESTS', value: '500m' },
@@ -56,12 +56,9 @@ local obs = import 'observatorium.libsonnet';
     // The querier concurrency should be equal to (or less than) the CPU cores of the system the querier runs
     // A higher value will lead to a querier trying to process more requests than there are available
     // cores and will result in scheduling delays.
-    // This value should be set equal to:
-    //
-    // std.floor( querier-concurrency / LOKI_QUERY_FRONTEND_REPLICAS)
-    //
-    // e.g. limit to N/2 worker threads per frontend, as we have two frontends.
-    { name: 'LOKI_QUERY_PARALLELISM', value: '2' },
+    { name: 'LOKI_QUERIER_MAX_CONCURRENCY', value: '2' },
+    // The replay memory ceiling should be calculated as 50% of the ingester memory limit.
+    { name: 'LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING', value: '5GB' },
     { name: 'LOKI_CHUNK_CACHE_REPLICAS', value: '2' },
     { name: 'LOKI_CHUNK_CACHE_CPU_REQUESTS', value: '500m' },
     { name: 'LOKI_CHUNK_CACHE_CPU_LIMITS', value: '3' },

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -67,7 +67,7 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
     version: '${LOKI_IMAGE_TAG}',
     image: '%s:%s' % ['${LOKI_IMAGE}', cfg.version],
     commonLabels+: obs.config.commonLabels,
-    queryConcurrency: '${LOKI_QUERIER_MAX_CONCURRENCY}',
+    queryConcurrency: 2,  // overwritten in observatorium-logs-template-overwrites.libsonnet
     objectStorageConfig: {
       secretName: '${LOKI_S3_SECRET}',
       bucketsKey: 'bucket',
@@ -79,7 +79,7 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
       ringName: 'gossip-ring',
     },
     wal: {
-      replayMemoryCeiling: '${LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING}',
+      replayMemoryCeiling: '4GB',  // overwritten in observatorium-logs-template-overwrites.libsonnet
     },
     replicas: {
       compactor: 1,  // Loki supports only a single compactor instance.

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -67,6 +67,7 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
     version: '${LOKI_IMAGE_TAG}',
     image: '%s:%s' % ['${LOKI_IMAGE}', cfg.version],
     commonLabels+: obs.config.commonLabels,
+    queryConcurrency: '${LOKI_QUERIER_MAX_CONCURRENCY}',
     objectStorageConfig: {
       secretName: '${LOKI_S3_SECRET}',
       bucketsKey: 'bucket',
@@ -76,6 +77,9 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
     },
     memberlist: {
       ringName: 'gossip-ring',
+    },
+    wal: {
+      replayMemoryCeiling: '${LOKI_INGESTER_WAL_REPLAY_MEMORY_CEILING}',
     },
     replicas: {
       compactor: 1,  // Loki supports only a single compactor instance.


### PR DESCRIPTION
This PR bumps Loki to 2.4.2 and incorporates the new settings observatorium/observatorium/pull/462:
1. Introduce the work-ahead-log in ingesters that replaces the handover mechanism and makes rolling restarts without manual interventions smoother again.
2. Introduces the `max_concurrent` setting on queriers that replaces the old static `parallelism` setting.