### PR TITLE
Fix metric-federation ruler ConfigMap name

### DIFF
--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -329,7 +329,7 @@ objects:
     labels:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/part-of: observatorium
-    name: remote-write-config
+    name: metric-federation-ruler-remote-write-config
 - apiVersion: v1
   kind: Service
   metadata:

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -298,7 +298,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         apiVersion: 'v1',
         kind: 'ConfigMap',
         metadata: {
-          name: statelessRuler,
+          name: metricFederationStatelessRuler,
           annotations: {
             'qontract.recycle': 'true',
           },


### PR DESCRIPTION
Fixes the name of the stateless metric federation ruler remote-write ConfigMap.
