### PR TITLE
Updating Query Latency SLOs 

### DIFF
--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -349,7 +349,7 @@ local renderAlerts(name, environment, mixin) = {
             alertMessage: 'API /query endpoint is burning too much error budget to guarantee latency SLOs',
             metric: 'up_custom_query_duration_seconds',
             selectors: ['query="query-path-sli-1M-samples"', upNamespaceSelector],
-            latencyTarget: 2.0113571874999994,
+            latencyTarget: 5,
             latencyBudget: 0.1,  // The budget is 1 - SLO
           }),
           slo.latencyburn({
@@ -357,7 +357,7 @@ local renderAlerts(name, environment, mixin) = {
             alertMessage: 'API /query endpoint is burning too much error budget to guarantee latency SLOs',
             metric: 'up_custom_query_duration_seconds',
             selectors: ['query="query-path-sli-10M-samples"', upNamespaceSelector],
-            latencyTarget: 10.761264004567169,
+            latencyTarget: 15,
             latencyBudget: 0.1,  // The budget is 1 - SLO
           }),
           slo.latencyburn({
@@ -366,7 +366,7 @@ local renderAlerts(name, environment, mixin) = {
             metric: 'up_custom_query_duration_seconds',
             // We can't use !~ operator in these selectors
             selectors: ['query="query-path-sli-100M-samples"', upNamespaceSelector],
-            latencyTarget: 21.6447457021712,
+            latencyTarget: 100,
             latencyBudget: 0.1,  // The budget is 1 - SLO
           }),
         ],

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -491,22 +491,22 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="5"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="5"} > (6*0.100000)
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: telemeter
@@ -514,122 +514,122 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-production,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="5"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="5"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="2.0113571874999994"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",latency="5"} > (0.100000)
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="5",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[5m]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="5",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[30m]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="5",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[1h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="5",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[2h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="5",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[6h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="5",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[1d]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="2.0113571874999994",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-production",le="5",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-production"}[3d]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=15 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="15"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="15"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="15"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="15"} > (6*0.100000)
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         service: telemeter
@@ -637,122 +637,122 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-production,latency=15 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="15"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="15"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="15"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="10.761264004567169"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",latency="15"} > (0.100000)
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="15",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[5m]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="15",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[30m]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="15",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[1h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="15",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[2h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="15",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[6h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="15",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[1d]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="10.761264004567169",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-production",le="15",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-production"}[3d]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=100 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="100"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="100"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="100"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="100"} > (6*0.100000)
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-production
         query: query-path-sli-100M-samples
         service: telemeter
@@ -760,100 +760,100 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-production,latency=100 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="100"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="100"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="100"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="21.6447457021712"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",latency="100"} > (0.100000)
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-production
         query: query-path-sli-100M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="100",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[5m]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="100",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[30m]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="100",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[1h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="100",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[2h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="100",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[6h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="100",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[1d]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="21.6447457021712",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-production",le="100",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-production"}[3d]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -491,22 +491,22 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-stage,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-stage,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="5"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="5"} > (6*0.100000)
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         service: telemeter
@@ -514,122 +514,122 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-stage,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-mst-stage,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="5"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="5"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="2.0113571874999994"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",latency="5"} > (0.100000)
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="5",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[5m]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="5",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[30m]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="5",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[1h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="5",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[2h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="5",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[6h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="5",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[1d]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="2.0113571874999994",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage",le="5",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-mst-stage"}[3d]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-stage,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-stage,latency=15 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="15"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="15"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="15"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="15"} > (6*0.100000)
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
         service: telemeter
@@ -637,122 +637,122 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-stage,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-mst-stage,latency=15 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="15"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="15"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="15"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="10.761264004567169"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",latency="15"} > (0.100000)
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="15",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[5m]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="15",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[30m]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="15",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[1h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="15",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[2h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="15",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[6h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="15",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[1d]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="10.761264004567169",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage",le="15",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-mst-stage"}[3d]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-stage,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-stage,latency=100 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="100"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="100"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="100"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="100"} > (6*0.100000)
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-stage
         query: query-path-sli-100M-samples
         service: telemeter
@@ -760,100 +760,100 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-stage,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-mst-stage,latency=100 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="100"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="100"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="100"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="21.6447457021712"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",latency="100"} > (0.100000)
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-stage
         query: query-path-sli-100M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="100",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[5m]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="100",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[30m]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="100",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[1h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="100",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[2h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="100",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[6h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="100",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[1d]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="21.6447457021712",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage",le="100",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-mst-stage"}[3d]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-mst-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -723,22 +723,22 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="5"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="5"} > (6*0.100000)
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         service: telemeter
@@ -746,122 +746,122 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-production,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="5"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="5"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="2.0113571874999994"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-production",latency="5"} > (0.100000)
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="5",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[5m]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="5",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[30m]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="5",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[1h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="5",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[2h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="5",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[6h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="5",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[1d]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="2.0113571874999994",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-production",le="5",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-production"}[3d]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=15 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="15"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="15"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="15"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="15"} > (6*0.100000)
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
         service: telemeter
@@ -869,122 +869,122 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-production,latency=15 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="15"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="15"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="15"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="10.761264004567169"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-production",latency="15"} > (0.100000)
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="15",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[5m]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="15",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[30m]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="15",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[1h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="15",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[2h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="15",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[6h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="15",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[1d]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="10.761264004567169",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-production",le="15",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-production"}[3d]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=100 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="100"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="100"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="100"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="100"} > (6*0.100000)
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-production
         query: query-path-sli-100M-samples
         service: telemeter
@@ -992,100 +992,100 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-production,latency=100 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="100"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="100"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="100"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="21.6447457021712"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-production",latency="100"} > (0.100000)
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-production
         query: query-path-sli-100M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="100",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[5m]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="100",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[30m]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="100",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[1h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="100",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[2h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="100",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[6h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="100",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[1d]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="21.6447457021712",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-production",le="100",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-production"}[3d]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -723,22 +723,22 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-stage,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-stage,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="5"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="5"} > (6*0.100000)
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         service: telemeter
@@ -746,122 +746,122 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-stage,latency=2.0113571874999994 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-1M-samples,namespace=observatorium-stage,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="5"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="5"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="2.0113571874999994"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-1M-samples",namespace="observatorium-stage",latency="5"} > (0.100000)
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="5",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[5m]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="5",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[30m]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="5",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[1h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="5",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[2h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="5",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[6h]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="5",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[1d]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="2.0113571874999994",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-1M-samples",namespace="observatorium-stage",le="5",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-1M-samples",namespace="observatorium-stage"}[3d]))
         )
       labels:
-        latency: "2.0113571874999994"
+        latency: "5"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-stage,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-stage,latency=15 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="15"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="15"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="15"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="15"} > (6*0.100000)
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
         service: telemeter
@@ -869,122 +869,122 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-stage,latency=10.761264004567169 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-10M-samples,namespace=observatorium-stage,latency=15 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="15"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="15"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="15"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="10.761264004567169"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-10M-samples",namespace="observatorium-stage",latency="15"} > (0.100000)
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="15",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[5m]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="15",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[30m]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="15",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[1h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="15",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[2h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="15",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[6h]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="15",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[1d]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="10.761264004567169",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-10M-samples",namespace="observatorium-stage",le="15",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-10M-samples",namespace="observatorium-stage"}[3d]))
         )
       labels:
-        latency: "10.761264004567169"
+        latency: "15"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-stage,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-stage,latency=100 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="100"} > (14.4*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (14.4*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate5m{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="100"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="100"} > (6*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (6*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate30m{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="100"} > (6*0.100000)
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-stage
         query: query-path-sli-100M-samples
         service: telemeter
@@ -992,100 +992,100 @@ spec:
     - alert: APIMetricsReadLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-read-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-stage,latency=21.6447457021712 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for query=query-path-sli-100M-samples,namespace=observatorium-stage,latency=100 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadlatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate1d{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="100"} > (3*0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (3*0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate2h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="100"} > (3*0.100000)
         )
         or
         (
-          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate3d{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="100"} > (0.100000)
           and
-          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="21.6447457021712"} > (0.100000)
+          latencytarget:up_custom_query_duration_seconds:rate6h{query="query-path-sli-100M-samples",namespace="observatorium-stage",latency="100"} > (0.100000)
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-stage
         query: query-path-sli-100M-samples
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[5m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="100",code!~"5.."}[5m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[5m]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[30m]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="100",code!~"5.."}[30m]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[30m]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[1h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="100",code!~"5.."}[1h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[1h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[2h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="100",code!~"5.."}[2h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[2h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[6h]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="100",code!~"5.."}[6h]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[6h]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[1d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="100",code!~"5.."}[1d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[1d]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="21.6447457021712",code!~"5.."}[3d]))
+          sum(rate(up_custom_query_duration_seconds_bucket{query="query-path-sli-100M-samples",namespace="observatorium-stage",le="100",code!~"5.."}[3d]))
           /
           sum(rate(up_custom_query_duration_seconds_count{query="query-path-sli-100M-samples",namespace="observatorium-stage"}[3d]))
         )
       labels:
-        latency: "21.6447457021712"
+        latency: "100"
         namespace: observatorium-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -551,7 +551,7 @@ objects:
           - --remote-write-interval=30s
           - --remote-requests-count=1000000
           - --value-interval=3600
-          - --series-interval=86400
+          - --series-interval=315360000
           - --metric-interval=315360000
           - --remote-tenant-header=THANOS-TENANT
           - --remote-tenant=0fc2b00e-201b-4c17-b9f2-19d91adc4fd2
@@ -820,7 +820,7 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: observatorium-up
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: master-2021-10-18-8943d73
+      app.kubernetes.io/version: master-2022-03-24-098c31a
     name: observatorium-observatorium-up
 - apiVersion: apps/v1
   kind: Deployment
@@ -830,7 +830,7 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: observatorium-up
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: master-2021-10-18-8943d73
+      app.kubernetes.io/version: master-2022-03-24-098c31a
     name: observatorium-observatorium-up
   spec:
     replicas: 1
@@ -847,7 +847,7 @@ objects:
           app.kubernetes.io/instance: observatorium
           app.kubernetes.io/name: observatorium-up
           app.kubernetes.io/part-of: observatorium
-          app.kubernetes.io/version: master-2021-10-18-8943d73
+          app.kubernetes.io/version: master-2022-03-24-098c31a
       spec:
         containers:
         - args:
@@ -856,7 +856,7 @@ objects:
           - --endpoint-type=metrics
           - --queries-file=/etc/up/queries.yaml
           - --endpoint-read=http://observatorium-thanos-query-frontend.${OBSERVATORIUM_METRICS_NAMESPACE}.svc:9090
-          image: quay.io/observatorium/up:master-2021-10-18-8943d73
+          image: quay.io/observatorium/up:master-2022-03-24-098c31a
           name: observatorium-up
           ports:
           - containerPort: 8080
@@ -884,7 +884,7 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: observatorium-up
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: master-2021-10-18-8943d73
+      app.kubernetes.io/version: master-2022-03-24-098c31a
     name: observatorium-observatorium-up
   spec:
     ports:

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -410,7 +410,7 @@ local rulesObjstore = (import 'github.com/observatorium/rules-objstore/jsonnet/l
     name: obs.config.name + '-' + cfg.commonLabels['app.kubernetes.io/name'],
     namespace: obs.config.namespaces.default,
     commonLabels+:: obs.config.commonLabels,
-    version: 'master-2021-10-18-8943d73',
+    version: 'master-2022-03-24-098c31a',
     image: 'quay.io/observatorium/up:' + cfg.version,
     replicas: 1,
     endpointType: 'metrics',
@@ -492,10 +492,10 @@ local rulesObjstore = (import 'github.com/observatorium/rules-objstore/jsonnet/l
                   obs.config.namespaces.metrics,
                   obs.thanos.receiversService.spec.ports[2].port,
                 ],  // this is the internal cluster url of the thanos receive service
-                '--remote-write-interval=30s',  // how frequenetly to remote_write data
+                '--remote-write-interval=30s',  // how frequently to remote_write data
                 '--remote-requests-count=1000000',  // how many requests we make before exiting - make it a big number
                 '--value-interval=3600',  // how often to update the metric values
-                '--series-interval=86400',  // 24h - how often to create new series names
+                '--series-interval=315360000',  // 10y - how often to create new series names
                 '--metric-interval=315360000',  // 10y - how often to create new metric names
                 '--remote-tenant-header=THANOS-TENANT',  // this is tenant header to set in remote write requests
                 '--remote-tenant=0fc2b00e-201b-4c17-b9f2-19d91adc4fd2',  // this is tenant we will write data to


### PR DESCRIPTION
* Amend Avalanche config to rotate series labels every `10y` instead of `1d` to reduce cardinality of 4d SLO query (8333 series * 4 instead of just 8333 in the other benchmarks)
* Update `up` binary version to include higher buckets for our more intensive benchmarks 
* 3s => 5s for 1m sample SLO
* 10s => 15s for 10m sample SLO
* 20s => 100s for 100m sample SLO