### PR TITLE
Add RHACS RBAC config

### DIFF
--- a/configuration/observatorium/rbac.libsonnet
+++ b/configuration/observatorium/rbac.libsonnet
@@ -1,6 +1,54 @@
 {
   roles: [
     {
+      name: 'rhacs-metrics-read',
+      resources: [
+        'metrics',
+      ],
+      tenants: [
+        'rhacs',
+      ],
+      permissions: [
+        'read',
+      ],
+    },
+    {
+      name: 'rhacs-metrics-write',
+      resources: [
+        'metrics',
+      ],
+      tenants: [
+        'rhacs',
+      ],
+      permissions: [
+        'write',
+      ],
+    },
+    {
+      name: 'rhacs-logs-write',
+      resources: [
+        'logs',
+      ],
+      tenants: [
+        'rhacs',
+      ],
+      permissions: [
+        'write',
+      ],
+    },
+    {
+      name: 'rhacs-logs-read',
+      resources: [
+        'logs',
+      ],
+      tenants: [
+        'rhacs',
+      ],
+      permissions: [
+        'read',
+      ],
+    },
+    {
       name: 'rhobs-read',
       resources: [
         'metrics',
@@ -52,6 +100,56 @@
     },
   ],
   roleBindings: [
+    {
+      name: 'rhacs-metrics',
+      roles: [
+        'rhacs-metrics-write',
+        'rhacs-metrics-read',
+      ],
+      subjects: [
+        {
+          name: 'service-account-observatorium-rhacs-metrics-staging',
+          kind: 'user',
+        },
+        {
+          name: 'service-account-observatorium-rhacs-metrics',
+          kind: 'user',
+        },
+      ],
+    },
+    {
+      name: 'rhacs-metrics-grafana',
+      roles: [
+        'rhacs-metrics-read',
+      ],
+      subjects: [
+        {
+          name: 'service-account-observatorium-rhacs-grafana-staging',
+          kind: 'user',
+        },
+        {
+          name: 'service-account-observatorium-rhacs-grafana',
+          kind: 'user',
+        },
+      ],
+    },
+    {
+      name: 'rhacs-logs',
+      roles: [
+        'rhacs-logs-read',
+        'rhacs-logs-write',
+      ],
+      subjects: [
+        {
+          name: 'service-account-observatorium-rhacs-logs-staging',
+          kind: 'user',
+        },
+        {
+          name: 'service-account-observatorium-rhacs-logs',
+          kind: 'user',
+        },
+      ],
+    },
     {
       name: 'rhobs',
       roles: [

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -7,6 +7,32 @@ objects:
   data:
     rbac.yaml: |-
       "roleBindings":
+      - "name": "rhacs-metrics"
+        "roles":
+        - "rhacs-metrics-write"
+        - "rhacs-metrics-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-rhacs-metrics-staging"
+        - "kind": "user"
+          "name": "service-account-observatorium-rhacs-metrics"
+      - "name": "rhacs-metrics-grafana"
+        "roles":
+        - "rhacs-metrics-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-rhacs-grafana-staging"
+        - "kind": "user"
+          "name": "service-account-observatorium-rhacs-grafana"
+      - "name": "rhacs-logs"
+        "roles":
+        - "rhacs-logs-read"
+        - "rhacs-logs-write"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-rhacs-logs-staging"
+        - "kind": "user"
+          "name": "service-account-observatorium-rhacs-logs"
       - "name": "rhobs"
         "roles":
         - "rhobs-write"
@@ -41,6 +67,34 @@ objects:
         - "kind": "user"
           "name": "service-account-observatorium-subwatch"
       "roles":
+      - "name": "rhacs-metrics-read"
+        "permissions":
+        - "read"
+        "resources":
+        - "metrics"
+        "tenants":
+        - "rhacs"
+      - "name": "rhacs-metrics-write"
+        "permissions":
+        - "write"
+        "resources":
+        - "metrics"
+        "tenants":
+        - "rhacs"
+      - "name": "rhacs-logs-write"
+        "permissions":
+        - "write"
+        "resources":
+        - "logs"
+        "tenants":
+        - "rhacs"
+      - "name": "rhacs-logs-read"
+        "permissions":
+        - "read"
+        "resources":
+        - "logs"
+        "tenants":
+        - "rhacs"
       - "name": "rhobs-read"
         "permissions":
         - "read"


### PR DESCRIPTION
This MR adds RBAC roles and role binding config for RHACS.

The RHACS onboarding ticket is [here](https://issues.redhat.com/browse/MON-2352) and the service account usernames created can be found [here](https://gitlab.cee.redhat.com/service/ocm-resources/-/merge_requests/2124/diffs).

Signed-off-by: Ian Billett <ibillett@redhat.com>