### PR TITLE
configuration/telemeter/metrics: Accept cluster_version_capability

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -43,6 +43,7 @@
   "{__name__=\"cluster_operator_up\"}",
   "{__name__=\"cluster_version\"}",
   "{__name__=\"cluster_version_available_updates\"}",
+  "{__name__=\"cluster_version_capability\"}",
   "{__name__=\"cluster_version_payload\"}",
   "{__name__=\"cnv:vmi_status_running:count\"}",
   "{__name__=\"code:apiserver_request_count:rate:sum\"}",

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -137,6 +137,7 @@ objects:
           - --whitelist={__name__="cluster_operator_up"}
           - --whitelist={__name__="cluster_version"}
           - --whitelist={__name__="cluster_version_available_updates"}
+          - --whitelist={__name__="cluster_version_capability"}
           - --whitelist={__name__="cluster_version_payload"}
           - --whitelist={__name__="cnv:vmi_status_running:count"}
           - --whitelist={__name__="code:apiserver_request_count:rate:sum"}
@@ -334,6 +335,7 @@ objects:
           - --whitelist={__name__="cluster_operator_up"}
           - --whitelist={__name__="cluster_version"}
           - --whitelist={__name__="cluster_version_available_updates"}
+          - --whitelist={__name__="cluster_version_capability"}
           - --whitelist={__name__="cluster_version_payload"}
           - --whitelist={__name__="cnv:vmi_status_running:count"}
           - --whitelist={__name__="code:apiserver_request_count:rate:sum"}


### PR DESCRIPTION
It was recently added to the metrics the Telemetry client submits in openshift/cluster-monitoring-operator#1607.