### PR TITLE
Add cnvqe tenanat to the OPA-AMS mappings

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -234,6 +234,7 @@ objects:
           - --opa.package=observatorium
           - --memcached=observatorium-api-cache-memcached.${NAMESPACE}.svc.cluster.local:11211
           - --memcached.expire=${OPA_AMS_MEMCACHED_EXPIRE}
+          - --ams.mappings=cnvqe=${CNVQE_ORGANIZATION_ID}
           - --ams.mappings=dptp=${DPTP_ORGANIZATION_ID}
           - --ams.mappings=managedkafka=${MANAGEDKAFKA_ORGANIZATION_ID}
           - --ams.mappings=osd=${OSD_ORGANIZATION_ID}
@@ -981,6 +982,8 @@ parameters:
   value: observatorium-logs
 - name: AMS_URL
   value: https://api.openshift.com
+- name: CNVQE_ORGANIZATION_ID
+  value: ""
 - name: DPTP_ORGANIZATION_ID
   value: ""
 - name: GUBERNATOR_CPU_LIMIT

--- a/services/observatorium-template.jsonnet
+++ b/services/observatorium-template.jsonnet
@@ -22,6 +22,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'OBSERVATORIUM_METRICS_NAMESPACE', value: 'observatorium-metrics' },
     { name: 'OBSERVATORIUM_LOGS_NAMESPACE', value: 'observatorium-logs' },
     { name: 'AMS_URL', value: 'https://api.openshift.com' },
+    { name: 'CNVQE_ORGANIZATION_ID', value: '' },
     { name: 'DPTP_ORGANIZATION_ID', value: '' },
     { name: 'GUBERNATOR_CPU_LIMIT', value: '200m' },
     { name: 'GUBERNATOR_CPU_REQUEST', value: '100m' },

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -328,6 +328,7 @@ local rulesObjstore = (import 'github.com/observatorium/rules-objstore/jsonnet/l
         osd: '${OSD_ORGANIZATION_ID}',
         dptp: '${DPTP_ORGANIZATION_ID}',
         managedkafka: '${MANAGEDKAFKA_ORGANIZATION_ID}',
+        cnvqe: '${CNVQE_ORGANIZATION_ID}',
       },
       memcached: '%s.%s.svc.cluster.local:%d' % [
         obs.memcached.service.metadata.name,


### PR DESCRIPTION
As part of onboarding the CNV-QE team, the PR adds a new `cnvqe` tenant to OPA-AMS mappings. The actual organisation id will be added via App-Interface.