### PR TITLE
Bump rules-objstore version and add labels

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -737,8 +737,9 @@ objects:
   metadata:
     labels:
       app.kubernetes.io/component: rules-storage
-      app.kubernetes.io/instance: rules-objstore
+      app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
+      app.kubernetes.io/part-of: observatorium
       app.kubernetes.io/version: ${RULES_OBJSTORE_IMAGE_TAG}
     name: rules-objstore
   spec:
@@ -746,8 +747,9 @@ objects:
     selector:
       matchLabels:
         app.kubernetes.io/component: rules-storage
-        app.kubernetes.io/instance: rules-objstore
+        app.kubernetes.io/instance: observatorium
         app.kubernetes.io/name: rules-objstore
+        app.kubernetes.io/part-of: observatorium
     strategy:
       rollingUpdate:
         maxSurge: 0
@@ -756,8 +758,9 @@ objects:
       metadata:
         labels:
           app.kubernetes.io/component: rules-storage
-          app.kubernetes.io/instance: rules-objstore
+          app.kubernetes.io/instance: observatorium
           app.kubernetes.io/name: rules-objstore
+          app.kubernetes.io/part-of: observatorium
           app.kubernetes.io/version: ${RULES_OBJSTORE_IMAGE_TAG}
       spec:
         containers:
@@ -818,8 +821,9 @@ objects:
   metadata:
     labels:
       app.kubernetes.io/component: rules-storage
-      app.kubernetes.io/instance: rules-objstore
+      app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
+      app.kubernetes.io/part-of: observatorium
       app.kubernetes.io/version: ${RULES_OBJSTORE_IMAGE_TAG}
     name: rules-objstore
   spec:
@@ -832,15 +836,17 @@ objects:
       targetPort: 8080
     selector:
       app.kubernetes.io/component: rules-storage
-      app.kubernetes.io/instance: rules-objstore
+      app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
+      app.kubernetes.io/part-of: observatorium
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
     labels:
       app.kubernetes.io/component: rules-storage
-      app.kubernetes.io/instance: rules-objstore
+      app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
+      app.kubernetes.io/part-of: observatorium
       app.kubernetes.io/version: ${RULES_OBJSTORE_IMAGE_TAG}
     name: rules-objstore
 - apiVersion: monitoring.coreos.com/v1
@@ -857,8 +863,9 @@ objects:
     selector:
       matchLabels:
         app.kubernetes.io/component: rules-storage
-        app.kubernetes.io/instance: rules-objstore
+        app.kubernetes.io/instance: observatorium
         app.kubernetes.io/name: rules-objstore
+        app.kubernetes.io/part-of: observatorium
 - apiVersion: v1
   data:
     queries.yaml: |-
@@ -1085,7 +1092,7 @@ parameters:
 - name: RULES_OBJSTORE_IMAGE
   value: quay.io/observatorium/rules-objstore
 - name: RULES_OBJSTORE_IMAGE_TAG
-  value: main-2022-01-31-4a4394f
+  value: main-2022-04-01-64cd17e
 - name: RULES_OBJSTORE_S3_SECRET
   value: rules-objstore-stage-s3
 - name: RULES_OBJSTORE_SECRET

--- a/services/observatorium-template.jsonnet
+++ b/services/observatorium-template.jsonnet
@@ -73,7 +73,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'OPA_AMS_MEMORY_REQUEST', value: '100Mi' },
     { name: 'OSD_ORGANIZATION_ID', value: '' },
     { name: 'RULES_OBJSTORE_IMAGE', value: 'quay.io/observatorium/rules-objstore' },
-    { name: 'RULES_OBJSTORE_IMAGE_TAG', value: 'main-2022-01-31-4a4394f' },
+    { name: 'RULES_OBJSTORE_IMAGE_TAG', value: 'main-2022-04-01-64cd17e' },
     { name: 'RULES_OBJSTORE_S3_SECRET', value: 'rules-objstore-stage-s3' },
     { name: 'RULES_OBJSTORE_SECRET', value: 'rules-objstore' },
     { name: 'SERVICE_ACCOUNT_NAME', value: 'prometheus-telemeter' },

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -157,6 +157,7 @@ local rulesObjstore = (import 'github.com/observatorium/rules-objstore/jsonnet/l
       name: '${RULES_OBJSTORE_SECRET}',
       key: 'objstore.yaml',
     },
+    commonLabels+:: obs.config.commonLabels,
     serviceMonitor: true,
   }) + {
     deployment+: {


### PR DESCRIPTION
This PR bumps the rules-objstore version to the latest to get the newly added metrics in https://github.com/observatorium/rules-objstore/pull/9.

Exisiting rules-objstore was also instrumented with Go metrics and object store Thanos metrics. But it isn't listed in Prometheus AppSRE targets, so adding labels too, to see if that fixes it.