### PR TITLE
Add rhobs-mst role binding

### DIFF
--- a/configuration/observatorium/rbac.libsonnet
+++ b/configuration/observatorium/rbac.libsonnet
@@ -168,6 +168,23 @@
       ],
     },
     {
+      name: 'rhobs-mst',
+      roles: [
+        'rhobs-write',
+        'rhobs-read',
+      ],
+      subjects: [
+        {
+          name: 'service-account-observatorium-rhobs-mst-staging',
+          kind: 'user',
+        },
+        {
+          name: 'service-account-observatorium-rhobs-mst',
+          kind: 'user',
+        },
+      ],
+    },
+    {
       name: 'rhobs-admin',
       roles: [
         'telemeter-read',

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -42,6 +42,15 @@ objects:
           "name": "service-account-observatorium-rhobs-staging"
         - "kind": "user"
           "name": "service-account-observatorium-rhobs"
+      - "name": "rhobs-mst"
+        "roles":
+        - "rhobs-write"
+        - "rhobs-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-rhobs-mst-staging"
+        - "kind": "user"
+          "name": "service-account-observatorium-rhobs-mst"
       - "name": "rhobs-admin"
         "roles":
         - "telemeter-read"


### PR DESCRIPTION
* Adds `service-account-observatorium-rhobs-mst-staging` and `service-account-observatorium-rhobs-mst`, so that the RHOBS tenant in MST can have proper access
* I've used the same `rhobs-write` and `rhobs-read` roles, since the tenant is the same (`rhobs`)