### PR TITLE
rbac: Add rhob testing SA

### DIFF
--- a/configuration/observatorium/rbac.libsonnet
+++ b/configuration/observatorium/rbac.libsonnet
@@ -182,6 +182,10 @@
       ],
       subjects: [
         {
+          name: 'service-account-observatorium-rhobs-testing',
+          kind: 'user',
+        },
+        {
           name: 'service-account-observatorium-rhobs-staging',
           kind: 'user',
         },

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -39,6 +39,8 @@ objects:
         - "rhobs-read"
         "subjects":
         - "kind": "user"
+          "name": "service-account-observatorium-rhobs-testing"
+        - "kind": "user"
           "name": "service-account-observatorium-rhobs-staging"
         - "kind": "user"
           "name": "service-account-observatorium-rhobs"


### PR DESCRIPTION
Adds the new SA created in external SSO for testing to RBAC config.