### PR TITLE
Add new tenants to Ruler remote-write config

### DIFF
--- a/configuration/observatorium/ruler-remote-write.libsonnet
+++ b/configuration/observatorium/ruler-remote-write.libsonnet
@@ -72,5 +72,61 @@ function(params) {
         },
       ],
     },
+    {
+      url: params.url,
+      name: 'receive-rhacs',
+      headers: {
+        'THANOS-TENANT': '1b9b6e43-9128-4bbf-bfff-3c120bbe6f11',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: '1b9b6e43-9128-4bbf-bfff-3c120bbe6f11',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-cnvqe',
+      headers: {
+        'THANOS-TENANT': '9ca26972-4328-4fe3-92db-31302013d03f',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: '9ca26972-4328-4fe3-92db-31302013d03f',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-psiocp',
+      headers: {
+        'THANOS-TENANT': '37b8fd3f-56ff-4b64-8272-917c9b0d1623',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: '37b8fd3f-56ff-4b64-8272-917c9b0d1623',
+          action: 'keep',
+        },
+      ],
+    },
+    {
+      url: params.url,
+      name: 'receive-rhods',
+      headers: {
+        'THANOS-TENANT': '8ace13a2-1c72-4559-b43d-ab43e32a255a',
+      },
+      write_relabel_configs: [
+        {
+          source_labels: ['tenant_id'],
+          regex: '8ace13a2-1c72-4559-b43d-ab43e32a255a',
+          action: 'keep',
+        },
+      ],
+    },
   ],
 }

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -92,6 +92,42 @@ objects:
           "regex": "63e320cd-622a-4d05-9585-ffd48342633e"
           "source_labels":
           - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "1b9b6e43-9128-4bbf-bfff-3c120bbe6f11"
+        "name": "receive-rhacs"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "1b9b6e43-9128-4bbf-bfff-3c120bbe6f11"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "9ca26972-4328-4fe3-92db-31302013d03f"
+        "name": "receive-cnvqe"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "9ca26972-4328-4fe3-92db-31302013d03f"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "37b8fd3f-56ff-4b64-8272-917c9b0d1623"
+        "name": "receive-psiocp"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "37b8fd3f-56ff-4b64-8272-917c9b0d1623"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "8ace13a2-1c72-4559-b43d-ab43e32a255a"
+        "name": "receive-rhods"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "8ace13a2-1c72-4559-b43d-ab43e32a255a"
+          "source_labels":
+          - "tenant_id"
   kind: ConfigMap
   metadata:
     annotations:

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1745,6 +1745,42 @@ objects:
           "regex": "63e320cd-622a-4d05-9585-ffd48342633e"
           "source_labels":
           - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "1b9b6e43-9128-4bbf-bfff-3c120bbe6f11"
+        "name": "receive-rhacs"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "1b9b6e43-9128-4bbf-bfff-3c120bbe6f11"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "9ca26972-4328-4fe3-92db-31302013d03f"
+        "name": "receive-cnvqe"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "9ca26972-4328-4fe3-92db-31302013d03f"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "37b8fd3f-56ff-4b64-8272-917c9b0d1623"
+        "name": "receive-psiocp"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "37b8fd3f-56ff-4b64-8272-917c9b0d1623"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "8ace13a2-1c72-4559-b43d-ab43e32a255a"
+        "name": "receive-rhods"
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "8ace13a2-1c72-4559-b43d-ab43e32a255a"
+          "source_labels":
+          - "tenant_id"
   kind: ConfigMap
   metadata:
     annotations:


### PR DESCRIPTION
This PR adds the Ruler remote write config for the newly added tenant i.e, rhacs, cnvqe, psiocp and rhods.
Without this, tenants can write Rules but not query them.