### PR TITLE
Revert "Remove stateful rulers (#184)"

### DIFF
--- a/observability/config.libsonnet
+++ b/observability/config.libsonnet
@@ -26,7 +26,7 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
       receiveSelector: t.receive.selector,
     },
     rule+:: {
-      selector: 'job=~"%s.*|%s.*"' % [thanos.rule.config.name, thanos.metricFederationStatelessRule.config.name],
+      selector: 'job=~"%s.*|%s.*|%s.*|%s.*"' % [thanos.rule.config.name, thanos.statelessRule.config.name, thanos.metricFederationRule.config.name, thanos.metricFederationStatelessRule.config.name],
     },
     compact+:: {
       selector: 'job="%s"' % thanos.compact.config.name,

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
@@ -2022,7 +2022,7 @@ data:
             "options": [
 
             ],
-            "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*\"}, job)",
+            "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*\"}, job)",
             "refresh": 1,
             "regex": "",
             "sort": 2,

--- a/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-custom-metrics-production.prometheusrules.yaml
@@ -32,7 +32,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumnorulesloaded
         summary: Observatorium Thanos Ruler has not any rule to evaluate. This should not have happened. Check out the configuration.
       expr: |
-        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) == 0
+        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) == 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-custom-metrics-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-custom-metrics-stage.prometheusrules.yaml
@@ -32,7 +32,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumnorulesloaded
         summary: Observatorium Thanos Ruler has not any rule to evaluate. This should not have happened. Check out the configuration.
       expr: |
-        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) == 0
+        sum by (namespace, job) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) == 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
@@ -58,7 +58,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleisdown
         summary: Thanos component has disappeared from {{$labels.namespace}}.
       expr: |
-        absent(up{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"} == 1)
+        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"} == 1)
       for: 5m
       labels:
         service: telemeter
@@ -444,7 +444,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulequeueisdroppingalerts
         summary: Thanos Rule is failing to queue alerts.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -457,7 +457,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulesenderisfailingalerts
         summary: Thanos Rule is failing to send alerts to alertmanager.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -471,9 +471,9 @@ spec:
         summary: Thanos Rule is failing to evaluate rules.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -488,7 +488,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulehighruleevaluationwarnings
         summary: Thanos Rule has high number of evaluation warnings.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
       for: 15m
       labels:
         service: telemeter
@@ -502,9 +502,9 @@ spec:
         summary: Thanos Rule has high rule evaluation latency.
       expr: |
         (
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
         >
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
         )
       for: 5m
       labels:
@@ -519,9 +519,9 @@ spec:
         summary: Thanos Rule is failing to handle grpc requests.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -535,7 +535,7 @@ spec:
         message: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has not been able to reload its configuration.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleconfigreloadfailure
         summary: Thanos Rule has not been able to reload configuration.
-      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) != 1
+      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) != 1
       for: 5m
       labels:
         service: telemeter
@@ -549,9 +549,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -567,9 +567,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -584,9 +584,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulenoevaluationfor10intervals
         summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
       expr: |
-        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
+        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
         >
-        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
+        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
       for: 5m
       labels:
         service: telemeter
@@ -599,9 +599,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosnoruleevaluations
         summary: Thanos Rule did not perform any rule evaluations.
       expr: |
-        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) <= 0
+        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) <= 0
           and
-        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) > 0
+        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) > 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
@@ -58,7 +58,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleisdown
         summary: Thanos component has disappeared from {{$labels.namespace}}.
       expr: |
-        absent(up{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"} == 1)
+        absent(up{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"} == 1)
       for: 5m
       labels:
         service: telemeter
@@ -444,7 +444,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulequeueisdroppingalerts
         summary: Thanos Rule is failing to queue alerts.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -457,7 +457,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulesenderisfailingalerts
         summary: Thanos Rule is failing to send alerts to alertmanager.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
       for: 5m
       labels:
         service: telemeter
@@ -471,9 +471,9 @@ spec:
         summary: Thanos Rule is failing to evaluate rules.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -488,7 +488,7 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulehighruleevaluationwarnings
         summary: Thanos Rule has high number of evaluation warnings.
       expr: |
-        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
+        sum by (namespace, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) > 0
       for: 15m
       labels:
         service: telemeter
@@ -502,9 +502,9 @@ spec:
         summary: Thanos Rule has high rule evaluation latency.
       expr: |
         (
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
         >
-          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
+          sum by (namespace, job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
         )
       for: 5m
       labels:
@@ -519,9 +519,9 @@ spec:
         summary: Thanos Rule is failing to handle grpc requests.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         * 100 > 5
         )
       for: 5m
@@ -535,7 +535,7 @@ spec:
         message: Thanos Rule {{$labels.job}} in {{$labels.namespace}} has not been able to reload its configuration.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosruleconfigreloadfailure
         summary: Thanos Rule has not been able to reload configuration.
-      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) != 1
+      expr: avg by (namespace, job, instance) (thanos_rule_config_last_reload_successful{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) != 1
       for: 5m
       labels:
         service: telemeter
@@ -549,9 +549,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_query_apis_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -567,9 +567,9 @@ spec:
         summary: Thanos Rule is having high number of DNS failures.
       expr: |
         (
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         /
-          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
+          sum by (namespace, job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m]))
         * 100 > 1
         )
       for: 15m
@@ -584,9 +584,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosrulenoevaluationfor10intervals
         summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
       expr: |
-        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
+        time() -  max by (namespace, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
         >
-        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
+        10 * max by (namespace, job, instance, group) (prometheus_rule_group_interval_seconds{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"})
       for: 5m
       labels:
         service: telemeter
@@ -599,9 +599,9 @@ spec:
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosnoruleevaluations
         summary: Thanos Rule did not perform any rule evaluations.
       expr: |
-        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) <= 0
+        sum by (namespace, job, instance) (rate(prometheus_rule_evaluations_total{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}[5m])) <= 0
           and
-        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) > 0
+        sum by (namespace, job, instance) (thanos_rule_loaded_rules{job=~"observatorium-thanos-rule.*|observatorium-thanos-stateless-rule.*|observatorium-thanos-metric-federation-rule.*|observatorium-thanos-metric-fed-stateless-rule.*"}) > 0
       for: 5m
       labels:
         service: telemeter

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -4,6 +4,236 @@ metadata:
   name: metric-federation-rule
 objects:
 - apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-metric-federation-rule
+  spec:
+    clusterIP: None
+    ports:
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+    - name: http
+      port: 10902
+      targetPort: 10902
+    - name: reloader
+      port: 9533
+      targetPort: 9533
+    selector:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-metric-federation-rule
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      prometheus: app-sre
+    name: observatorium-thanos-metric-federation-rule
+  spec:
+    endpoints:
+    - port: http
+      relabelings:
+      - separator: /
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: instance
+    - port: reloader
+    namespaceSelector:
+      matchNames: ${{NAMESPACES}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: metric-federation
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: metric-federation
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-metric-federation-rule
+  spec:
+    replicas: ${{THANOS_RULER_REPLICAS}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: metric-federation
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+    serviceName: observatorium-thanos-metric-federation-rule
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: metric-federation
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+          app.kubernetes.io/tracing: jaeger-agent
+          app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      spec:
+        containers:
+        - args:
+          - rule
+          - --log.level=${THANOS_RULER_LOG_LEVEL}
+          - --log.format=logfmt
+          - --grpc-address=0.0.0.0:10901
+          - --http-address=0.0.0.0:10902
+          - --objstore.config=$(OBJSTORE_CONFIG)
+          - --data-dir=/var/thanos/rule
+          - --label=rule_replica="$(NAME)"
+          - --alert.label-drop=rule_replica
+          - --tsdb.retention=48h
+          - --tsdb.block-duration=2h
+          - --query=dnssrv+_http._tcp.observatorium-thanos-query.${THANOS_QUERIER_NAMESPACE}.svc.cluster.local
+          - |-
+            --tracing.config="config":
+              "sampler_param": 2
+              "sampler_type": "ratelimiting"
+              "service_name": "thanos-rule"
+            "type": "JAEGER"
+          env:
+          - name: NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OBJSTORE_CONFIG
+            valueFrom:
+              secretKeyRef:
+                key: thanos.yaml
+                name: ${THANOS_CONFIG_SECRET}
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: aws_access_key_id
+                name: ${THANOS_S3_SECRET}
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: aws_secret_access_key
+                name: ${THANOS_S3_SECRET}
+          image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 24
+            httpGet:
+              path: /-/healthy
+              port: 10902
+              scheme: HTTP
+            periodSeconds: 5
+          name: thanos-rule
+          ports:
+          - containerPort: 10901
+            name: grpc
+          - containerPort: 10902
+            name: http
+          - containerPort: 9533
+            name: reloader
+          readinessProbe:
+            failureThreshold: 18
+            httpGet:
+              path: /-/ready
+              port: 10902
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: ${THANOS_RULER_CPU_LIMIT}
+              memory: ${THANOS_RULER_MEMORY_LIMIT}
+            requests:
+              cpu: ${THANOS_RULER_CPU_REQUEST}
+              memory: ${THANOS_RULER_MEMORY_REQUEST}
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /var/thanos/rule
+            name: data
+            readOnly: false
+        - args:
+          - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+          - --reporter.type=grpc
+          - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+          env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14271
+              scheme: HTTP
+          name: jaeger-agent
+          ports:
+          - containerPort: 5778
+            name: configs
+          - containerPort: 6831
+            name: jaeger-thrift
+          - containerPort: 14271
+            name: metrics
+          resources:
+            limits:
+              cpu: 128m
+              memory: 128Mi
+            requests:
+              cpu: 32m
+              memory: 64Mi
+        nodeSelector:
+          kubernetes.io/os: linux
+        securityContext: {}
+        serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+        volumes: []
+    volumeClaimTemplates:
+    - metadata:
+        labels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: metric-federation
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+        name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: ${THANOS_RULER_PVC_REQUEST}
+        storageClassName: ${STORAGE_CLASS}
+- apiVersion: v1
   data:
     observatorium.yaml: |-
       "groups":

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -111,6 +111,7 @@ objects:
           - --tsdb.retention=48h
           - --tsdb.block-duration=2h
           - --query=dnssrv+_http._tcp.observatorium-thanos-query.${THANOS_QUERIER_NAMESPACE}.svc.cluster.local
+          - --rule-file=/etc/thanos/rules/metric-federation-rules/observatorium.yaml
           - |-
             --tracing.config="config":
               "sampler_param": 2
@@ -178,6 +179,17 @@ objects:
           - mountPath: /var/thanos/rule
             name: data
             readOnly: false
+          - mountPath: /etc/thanos/rules/metric-federation-rules
+            name: metric-federation-rules
+        - args:
+          - -webhook-url=http://localhost:10902/-/reload
+          - -volume-dir=/etc/thanos/rules/metric-federation-rules
+          image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          name: configmap-reloader
+          volumeMounts:
+          - mountPath: /etc/thanos/rules/metric-federation-rules
+            name: metric-federation-rules
         - args:
           - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
           - --reporter.type=grpc
@@ -217,7 +229,10 @@ objects:
           kubernetes.io/os: linux
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
-        volumes: []
+        volumes:
+        - configMap:
+            name: metric-federation-rules
+          name: metric-federation-rules
     volumeClaimTemplates:
     - metadata:
         labels:

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -437,6 +437,558 @@ objects:
         storage: 10Gi
 - apiVersion: v1
   data:
+    observatorium.yaml: |-
+      "groups":
+      - "interval": "1m"
+        "name": "telemeter-telemeter.rules"
+        "rules":
+        - "expr": |
+            count by (name,reason) (cluster_operator_conditions{condition="Degraded"} == 1)
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "name_reason:cluster_operator_degraded:count"
+        - "expr": |
+            count by (name,reason) (cluster_operator_conditions{condition="Available"} == 0)
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "name_reason:cluster_operator_unavailable:count"
+        - "expr": |
+            sort_desc(max by (_id,code) (code:apiserver_request_count:rate:sum{code=~"(4|5)\\d\\d"}) > 0.5)
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_code:apiserver_request_error_rate_sum:max"
+        - "expr": |
+            bottomk by (_id) (1, max by (_id, version) (0 * cluster_version{type="failure"}) or max by (_id, version) (1 + 0 * cluster_version{type="current"}))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_version:cluster_available"
+        - "expr": |
+            topk by (_id) (1, max by (_id, managed, ebs_account, internal) (label_replace(label_replace((subscription_labels{support=~"Standard|Premium|Layered"} * 0 + 1) or subscription_labels * 0, "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com"), "managed", "", "managed", "false")) + on(_id) group_left(version) (topk by (_id) (1, id_version*0)) + on(_id) group_left(install_type) (topk by (_id) (1, id_install_type*0)) + on(_id) group_left(host_type) (topk by (_id) (1, id_primary_host_type*0)) + on(_id) group_left(provider) (topk by (_id) (1, id_provider*0)))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_version_ebs_account_internal:cluster_subscribed"
+        - "expr": |
+            0 * (max by (_id,host_type) (topk by (_id) (1, label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(cluster:virt_platform_nodes:sum, "host_type", "$1", "type", "(aws|ibm_.*|ovirt|none|rhev|gcp|openstack|hyperv|vmware)"), "host_type", "virt-unknown", "host_type", ""), "host_type", "kvm-unknown", "type", "kvm"), "host_type", "xen-unknown", "type", "xen.*"), "host_type", "metal", "host_type", "none"), "host_type", "ibm-$1", "host_type", "ibm[_-](power|systemz).*"))) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}), "host_type", "", "host_type", ""))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_primary_host_type"
+        - "expr": |
+            0 * topk by (_id) (1, count by (_id, provider) (label_replace(cluster_infrastructure_provider * 0 + 2, "provider", "$1", "type", "(.*)")) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}*0+1), "provider", "", "provider", "") or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "provider", "hypershift-unknown", "provider", ""))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_provider"
+        - "expr": |
+            0 * (max by (_id,version) (topk by (_id) (1, cluster_version{type="current"})) or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "version", "", "unknown", ""))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_version"
+        - "expr": |
+            (
+              count by (_id, install_type) (
+                label_replace(
+                  label_replace(
+                    label_replace(
+                      label_replace(
+                        label_replace(
+                          topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"
+                        ), "install_type", "ipi", "type", "openshift-install"
+                      ), "install_type", "hive", "invoker", "hive"
+                    ), "install_type", "assisted-installer", "invoker", "assisted-installer"
+                  ), "install_type", "infrastructure-operator", "invoker", "assisted-installer-operator"
+                )
+              ) or on(_id) (
+                label_replace(
+                  count by (_id) (
+                    cluster:virt_platform_nodes:sum
+                  ), "install_type", "hypershift-unknown", "install_type", ""
+                )
+              ) * 0
+            ) * 0
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_install_type"
+        - "expr": |
+            0 * (max by (_id,cloudpak_type) (topk by (_id) (1, count by (_id,cloudpak_type) (label_replace(subscription_sync_total{installed=~"ibm-((licensing|common-service)-operator).*"}, "cloudpak_type", "unknown", "", ".*")))))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_cloudpak_type"
+        - "expr": |
+            topk by(_id) (1,
+              (label_replace(7+0*count by (_id) (cluster:usage:resources:sum{resource="netnamespaces.network.openshift.io"}), "network_type", "OpenshiftSDN", "", "") > 0) or
+              (label_replace(6+0*count by (_id) (cluster:usage:resources:sum{resource="clusterinformations.crd.projectcalico.org"}), "network_type", "Calico", "", "") > 0) or
+              (label_replace(5+0*count by (_id) (cluster:usage:resources:sum{resource="acicontainersoperators.aci.ctrl"}), "network_type", "ACI", "", "") > 0) or
+              (label_replace(4+0*count by (_id) (cluster:usage:resources:sum{resource="kuryrnetworks.openstack.org"}), "network_type", "Kuryr", "", "") > 0) or
+              (label_replace(3+0*count by (_id) (cluster:usage:resources:sum{resource="ciliumendpoints.cilium.io"}), "network_type", "Cilium", "", "") > 0) or
+              (label_replace(2+0*count by (_id) (cluster:usage:resources:sum{resource="ncpconfigs.nsx.vmware.com"}), "network_type", "VMWareNSX", "", "") > 0) or
+              (label_replace(1+0*count by (_id) (cluster:usage:resources:sum{resource="egressips.k8s.ovn.org"}), "network_type", "OVNKube", "", "")) or
+              (label_replace(0+0*max by (_id) (cluster:node_instance_type_count:sum*0), "network_type", "unknown", "", ""))
+            )
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "id_network_type"
+        - "expr": |
+            0 * topk by (ebs_account) (1, max by (ebs_account,account_type,internal,email_domain) (label_replace(label_replace(label_replace(subscription_labels{email_domain="redhat.com"}*0+5, "class", "Internal", "class", ".*") or label_replace(subscription_labels{class!="Customer",email_domain=~"(.*\\.|^)ibm.com"}*0+4, "class", "Internal", "class", ".*") or (subscription_labels{class="Customer"}*0+3) or (subscription_labels{class="Partner"}*0+2) or (subscription_labels{class="Evaluation"}*0+1) or label_replace(subscription_labels{class!~"Evaluation|Customer|Partner"}*0+0, "class", "", "class", ".*"), "account_type", "$1", "class", "(.+)"), "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com") ))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "ebs_account_account_type_email_domain_internal"
+        - "expr": |
+            topk(500, sum (acm_managed_cluster_info) by (managed_cluster_id, cloud, created_via, endpoint, instance, job, namespace, pod, service, vendor, version))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "acm_top500_mcs:acm_managed_cluster_info"
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/part-of: observatorium
+    name: observatorium-rules
+- apiVersion: v1
+  data:
+    rw-config.yaml: |-
+      "remote_write":
+      - "headers":
+          "THANOS-TENANT": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
+        "name": "receive-rhobs"
+        "queue_config":
+          "batch_send_deadline": "5s"
+          "capacity": 120000
+          "max_backoff": "5m"
+          "max_samples_per_send": 40000
+          "max_shards": 50
+          "min_backoff": "5s"
+          "min_shards": 1
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+        "name": "receive-telemeter"
+        "queue_config":
+          "batch_send_deadline": "5s"
+          "capacity": 120000
+          "max_backoff": "5m"
+          "max_samples_per_send": 40000
+          "max_shards": 50
+          "min_backoff": "5s"
+          "min_shards": 1
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+        "name": "receive-dptp"
+        "queue_config":
+          "batch_send_deadline": "5s"
+          "capacity": 120000
+          "max_backoff": "5m"
+          "max_samples_per_send": 40000
+          "max_shards": 50
+          "min_backoff": "5s"
+          "min_shards": 1
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+        "name": "receive-osd"
+        "queue_config":
+          "batch_send_deadline": "5s"
+          "capacity": 120000
+          "max_backoff": "5m"
+          "max_samples_per_send": 40000
+          "max_shards": 50
+          "min_backoff": "5s"
+          "min_shards": 1
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "63e320cd-622a-4d05-9585-ffd48342633e"
+        "name": "receive-managedkafka"
+        "queue_config":
+          "batch_send_deadline": "5s"
+          "capacity": 120000
+          "max_backoff": "5m"
+          "max_samples_per_send": 40000
+          "max_shards": 50
+          "min_backoff": "5s"
+          "min_shards": 1
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "63e320cd-622a-4d05-9585-ffd48342633e"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "1b9b6e43-9128-4bbf-bfff-3c120bbe6f11"
+        "name": "receive-rhacs"
+        "queue_config":
+          "batch_send_deadline": "5s"
+          "capacity": 120000
+          "max_backoff": "5m"
+          "max_samples_per_send": 40000
+          "max_shards": 50
+          "min_backoff": "5s"
+          "min_shards": 1
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "1b9b6e43-9128-4bbf-bfff-3c120bbe6f11"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "9ca26972-4328-4fe3-92db-31302013d03f"
+        "name": "receive-cnvqe"
+        "queue_config":
+          "batch_send_deadline": "5s"
+          "capacity": 120000
+          "max_backoff": "5m"
+          "max_samples_per_send": 40000
+          "max_shards": 50
+          "min_backoff": "5s"
+          "min_shards": 1
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "9ca26972-4328-4fe3-92db-31302013d03f"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "37b8fd3f-56ff-4b64-8272-917c9b0d1623"
+        "name": "receive-psiocp"
+        "queue_config":
+          "batch_send_deadline": "5s"
+          "capacity": 120000
+          "max_backoff": "5m"
+          "max_samples_per_send": 40000
+          "max_shards": 50
+          "min_backoff": "5s"
+          "min_shards": 1
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "37b8fd3f-56ff-4b64-8272-917c9b0d1623"
+          "source_labels":
+          - "tenant_id"
+      - "headers":
+          "THANOS-TENANT": "8ace13a2-1c72-4559-b43d-ab43e32a255a"
+        "name": "receive-rhods"
+        "queue_config":
+          "batch_send_deadline": "5s"
+          "capacity": 120000
+          "max_backoff": "5m"
+          "max_samples_per_send": 40000
+          "max_shards": 50
+          "min_backoff": "5s"
+          "min_shards": 1
+        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
+        "write_relabel_configs":
+        - "action": "keep"
+          "regex": "8ace13a2-1c72-4559-b43d-ab43e32a255a"
+          "source_labels":
+          - "tenant_id"
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/part-of: observatorium
+    name: remote-write-config
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-stateless-rule
+  spec:
+    clusterIP: None
+    ports:
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+    - name: http
+      port: 10902
+      targetPort: 10902
+    - name: reloader
+      port: 9533
+      targetPort: 9533
+    selector:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-stateless-rule
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      prometheus: app-sre
+    name: observatorium-thanos-stateless-rule
+  spec:
+    endpoints:
+    - port: http
+      relabelings:
+      - separator: /
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: instance
+    - port: reloader
+    namespaceSelector:
+      matchNames: ${{NAMESPACES}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app.kubernetes.io/component: rule-evaluation-engine
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-rule
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+    name: observatorium-thanos-stateless-rule
+  spec:
+    replicas: ${{THANOS_RULER_REPLICAS}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+    serviceName: observatorium-thanos-stateless-rule
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+          app.kubernetes.io/tracing: jaeger-agent
+          app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      spec:
+        containers:
+        - args:
+          - rule
+          - --log.level=${THANOS_RULER_LOG_LEVEL}
+          - --log.format=logfmt
+          - --grpc-address=0.0.0.0:10901
+          - --http-address=0.0.0.0:10902
+          - --objstore.config=$(OBJSTORE_CONFIG)
+          - --data-dir=/var/thanos/rule
+          - --label=rule_replica="$(NAME)"
+          - --alert.label-drop=rule_replica
+          - --tsdb.retention=48h
+          - --tsdb.block-duration=2h
+          - --query=dnssrv+_http._tcp.observatorium-thanos-query.${NAMESPACE}.svc.cluster.local
+          - --rule-file=/etc/thanos/rules/rule-syncer/observatorium.yaml
+          - --alertmanagers.url=dnssrv+http://observatorium-alertmanager.${NAMESPACE}.svc.cluster.local:9093
+          - --rule-file=/etc/thanos/rules/observatorium-rules/observatorium.yaml
+          - |-
+            --tracing.config="config":
+              "sampler_param": 2
+              "sampler_type": "ratelimiting"
+              "service_name": "thanos-rule"
+            "type": "JAEGER"
+          - --remote-write.config-file=/etc/thanos/config/remote-write-config/rw-config.yaml
+          env:
+          - name: NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OBJSTORE_CONFIG
+            valueFrom:
+              secretKeyRef:
+                key: thanos.yaml
+                name: ${THANOS_CONFIG_SECRET}
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: aws_access_key_id
+                name: ${THANOS_S3_SECRET}
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: aws_secret_access_key
+                name: ${THANOS_S3_SECRET}
+          image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 24
+            httpGet:
+              path: /-/healthy
+              port: 10902
+              scheme: HTTP
+            periodSeconds: 5
+          name: thanos-rule
+          ports:
+          - containerPort: 10901
+            name: grpc
+          - containerPort: 10902
+            name: http
+          - containerPort: 9533
+            name: reloader
+          readinessProbe:
+            failureThreshold: 18
+            httpGet:
+              path: /-/ready
+              port: 10902
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: ${THANOS_RULER_CPU_LIMIT}
+              memory: ${THANOS_RULER_MEMORY_LIMIT}
+            requests:
+              cpu: ${THANOS_RULER_CPU_REQUEST}
+              memory: ${THANOS_RULER_MEMORY_REQUEST}
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /var/thanos/rule
+            name: data
+            readOnly: false
+          - mountPath: /etc/thanos/rules/observatorium-rules
+            name: observatorium-rules
+          - mountPath: /etc/thanos/config/remote-write-config
+            name: remote-write-config
+            readOnly: true
+          - mountPath: /etc/thanos/rules/rule-syncer
+            name: rule-syncer
+        - args:
+          - -webhook-url=http://localhost:10902/-/reload
+          - -volume-dir=/etc/thanos/rules/observatorium-rules
+          - -volume-dir=/etc/thanos/config/remote-write-config
+          image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          name: configmap-reloader
+          volumeMounts:
+          - mountPath: /etc/thanos/rules/observatorium-rules
+            name: observatorium-rules
+          - mountPath: /etc/thanos/config/remote-write-config
+            name: remote-write-config
+        - args:
+          - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+          - --reporter.type=grpc
+          - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+          env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14271
+              scheme: HTTP
+          name: jaeger-agent
+          ports:
+          - containerPort: 5778
+            name: configs
+          - containerPort: 6831
+            name: jaeger-thrift
+          - containerPort: 14271
+            name: metrics
+          resources:
+            limits:
+              cpu: 128m
+              memory: 128Mi
+            requests:
+              cpu: 32m
+              memory: 64Mi
+        - args:
+          - -file=/etc/thanos-rule-syncer/observatorium.yaml
+          - -interval=60
+          - -rules-backend-url=http://rules-objstore.${OBSERVATORIUM_NAMESPACE}.svc:8080
+          - -thanos-rule-url=http://localhost:10902
+          image: ${THANOS_RULE_SYNCER_IMAGE}:${THANOS_RULE_SYNCER_IMAGE_TAG}
+          name: thanos-rule-syncer
+          resources:
+            limits:
+              cpu: 128m
+              memory: 128Mi
+            requests:
+              cpu: 32m
+              memory: 64Mi
+          volumeMounts:
+          - mountPath: /etc/thanos-rule-syncer
+            name: rule-syncer
+        nodeSelector:
+          kubernetes.io/os: linux
+        securityContext: {}
+        serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+        volumes:
+        - configMap:
+            name: observatorium-rules
+          name: observatorium-rules
+        - configMap:
+            name: remote-write-config
+          name: remote-write-config
+        - emptyDir: {}
+          name: rule-syncer
+    volumeClaimTemplates:
+    - metadata:
+        labels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+        name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: ${THANOS_RULER_PVC_REQUEST}
+        storageClassName: ${STORAGE_CLASS}
+- apiVersion: v1
+  data:
     file_sd.yaml: '- targets: ${THANOS_QUERIER_FILE_SD_TARGETS}'
   kind: ConfigMap
   metadata:
@@ -503,6 +1055,7 @@ objects:
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-1.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-2.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-receive-default.${NAMESPACE}.svc.cluster.local
+          - --rule=dnssrv+_grpc._tcp.observatorium-thanos-rule.${NAMESPACE}.svc.cluster.local
           - --rule=dnssrv+_grpc._tcp.observatorium-thanos-stateless-rule.${NAMESPACE}.svc.cluster.local
           - --rule=dnssrv+_grpc._tcp.observatorium-thanos-metric-fed-stateless-rule.${NAMESPACE}.svc.cluster.local
           - --web.prefix-header=X-Forwarded-Prefix
@@ -1588,280 +2141,6 @@ objects:
         app.kubernetes.io/name: thanos-receive
         app.kubernetes.io/part-of: observatorium
 - apiVersion: v1
-  data:
-    observatorium.yaml: |-
-      "groups":
-      - "interval": "1m"
-        "name": "telemeter-telemeter.rules"
-        "rules":
-        - "expr": |
-            count by (name,reason) (cluster_operator_conditions{condition="Degraded"} == 1)
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "name_reason:cluster_operator_degraded:count"
-        - "expr": |
-            count by (name,reason) (cluster_operator_conditions{condition="Available"} == 0)
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "name_reason:cluster_operator_unavailable:count"
-        - "expr": |
-            sort_desc(max by (_id,code) (code:apiserver_request_count:rate:sum{code=~"(4|5)\\d\\d"}) > 0.5)
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_code:apiserver_request_error_rate_sum:max"
-        - "expr": |
-            bottomk by (_id) (1, max by (_id, version) (0 * cluster_version{type="failure"}) or max by (_id, version) (1 + 0 * cluster_version{type="current"}))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_version:cluster_available"
-        - "expr": |
-            topk by (_id) (1, max by (_id, managed, ebs_account, internal) (label_replace(label_replace((subscription_labels{support=~"Standard|Premium|Layered"} * 0 + 1) or subscription_labels * 0, "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com"), "managed", "", "managed", "false")) + on(_id) group_left(version) (topk by (_id) (1, id_version*0)) + on(_id) group_left(install_type) (topk by (_id) (1, id_install_type*0)) + on(_id) group_left(host_type) (topk by (_id) (1, id_primary_host_type*0)) + on(_id) group_left(provider) (topk by (_id) (1, id_provider*0)))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_version_ebs_account_internal:cluster_subscribed"
-        - "expr": |
-            0 * (max by (_id,host_type) (topk by (_id) (1, label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(cluster:virt_platform_nodes:sum, "host_type", "$1", "type", "(aws|ibm_.*|ovirt|none|rhev|gcp|openstack|hyperv|vmware)"), "host_type", "virt-unknown", "host_type", ""), "host_type", "kvm-unknown", "type", "kvm"), "host_type", "xen-unknown", "type", "xen.*"), "host_type", "metal", "host_type", "none"), "host_type", "ibm-$1", "host_type", "ibm[_-](power|systemz).*"))) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}), "host_type", "", "host_type", ""))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_primary_host_type"
-        - "expr": |
-            0 * topk by (_id) (1, count by (_id, provider) (label_replace(cluster_infrastructure_provider * 0 + 2, "provider", "$1", "type", "(.*)")) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}*0+1), "provider", "", "provider", "") or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "provider", "hypershift-unknown", "provider", ""))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_provider"
-        - "expr": |
-            0 * (max by (_id,version) (topk by (_id) (1, cluster_version{type="current"})) or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "version", "", "unknown", ""))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_version"
-        - "expr": |
-            (
-              count by (_id, install_type) (
-                label_replace(
-                  label_replace(
-                    label_replace(
-                      label_replace(
-                        label_replace(
-                          topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"
-                        ), "install_type", "ipi", "type", "openshift-install"
-                      ), "install_type", "hive", "invoker", "hive"
-                    ), "install_type", "assisted-installer", "invoker", "assisted-installer"
-                  ), "install_type", "infrastructure-operator", "invoker", "assisted-installer-operator"
-                )
-              ) or on(_id) (
-                label_replace(
-                  count by (_id) (
-                    cluster:virt_platform_nodes:sum
-                  ), "install_type", "hypershift-unknown", "install_type", ""
-                )
-              ) * 0
-            ) * 0
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_install_type"
-        - "expr": |
-            0 * (max by (_id,cloudpak_type) (topk by (_id) (1, count by (_id,cloudpak_type) (label_replace(subscription_sync_total{installed=~"ibm-((licensing|common-service)-operator).*"}, "cloudpak_type", "unknown", "", ".*")))))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_cloudpak_type"
-        - "expr": |
-            topk by(_id) (1,
-              (label_replace(7+0*count by (_id) (cluster:usage:resources:sum{resource="netnamespaces.network.openshift.io"}), "network_type", "OpenshiftSDN", "", "") > 0) or
-              (label_replace(6+0*count by (_id) (cluster:usage:resources:sum{resource="clusterinformations.crd.projectcalico.org"}), "network_type", "Calico", "", "") > 0) or
-              (label_replace(5+0*count by (_id) (cluster:usage:resources:sum{resource="acicontainersoperators.aci.ctrl"}), "network_type", "ACI", "", "") > 0) or
-              (label_replace(4+0*count by (_id) (cluster:usage:resources:sum{resource="kuryrnetworks.openstack.org"}), "network_type", "Kuryr", "", "") > 0) or
-              (label_replace(3+0*count by (_id) (cluster:usage:resources:sum{resource="ciliumendpoints.cilium.io"}), "network_type", "Cilium", "", "") > 0) or
-              (label_replace(2+0*count by (_id) (cluster:usage:resources:sum{resource="ncpconfigs.nsx.vmware.com"}), "network_type", "VMWareNSX", "", "") > 0) or
-              (label_replace(1+0*count by (_id) (cluster:usage:resources:sum{resource="egressips.k8s.ovn.org"}), "network_type", "OVNKube", "", "")) or
-              (label_replace(0+0*max by (_id) (cluster:node_instance_type_count:sum*0), "network_type", "unknown", "", ""))
-            )
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "id_network_type"
-        - "expr": |
-            0 * topk by (ebs_account) (1, max by (ebs_account,account_type,internal,email_domain) (label_replace(label_replace(label_replace(subscription_labels{email_domain="redhat.com"}*0+5, "class", "Internal", "class", ".*") or label_replace(subscription_labels{class!="Customer",email_domain=~"(.*\\.|^)ibm.com"}*0+4, "class", "Internal", "class", ".*") or (subscription_labels{class="Customer"}*0+3) or (subscription_labels{class="Partner"}*0+2) or (subscription_labels{class="Evaluation"}*0+1) or label_replace(subscription_labels{class!~"Evaluation|Customer|Partner"}*0+0, "class", "", "class", ".*"), "account_type", "$1", "class", "(.+)"), "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com") ))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "ebs_account_account_type_email_domain_internal"
-        - "expr": |
-            topk(500, sum (acm_managed_cluster_info) by (managed_cluster_id, cloud, created_via, endpoint, instance, job, namespace, pod, service, vendor, version))
-          "labels":
-            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "acm_top500_mcs:acm_managed_cluster_info"
-  kind: ConfigMap
-  metadata:
-    annotations:
-      qontract.recycle: "true"
-    labels:
-      app.kubernetes.io/instance: observatorium
-      app.kubernetes.io/part-of: observatorium
-    name: observatorium-rules
-- apiVersion: v1
-  data:
-    rw-config.yaml: |-
-      "remote_write":
-      - "headers":
-          "THANOS-TENANT": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
-        "name": "receive-rhobs"
-        "queue_config":
-          "batch_send_deadline": "5s"
-          "capacity": 120000
-          "max_backoff": "5m"
-          "max_samples_per_send": 40000
-          "max_shards": 50
-          "min_backoff": "5s"
-          "min_shards": 1
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
-        "write_relabel_configs":
-        - "action": "keep"
-          "regex": "0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"
-          "source_labels":
-          - "tenant_id"
-      - "headers":
-          "THANOS-TENANT": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-        "name": "receive-telemeter"
-        "queue_config":
-          "batch_send_deadline": "5s"
-          "capacity": 120000
-          "max_backoff": "5m"
-          "max_samples_per_send": 40000
-          "max_shards": 50
-          "min_backoff": "5s"
-          "min_shards": 1
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
-        "write_relabel_configs":
-        - "action": "keep"
-          "regex": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "source_labels":
-          - "tenant_id"
-      - "headers":
-          "THANOS-TENANT": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
-        "name": "receive-dptp"
-        "queue_config":
-          "batch_send_deadline": "5s"
-          "capacity": 120000
-          "max_backoff": "5m"
-          "max_samples_per_send": 40000
-          "max_shards": 50
-          "min_backoff": "5s"
-          "min_shards": 1
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
-        "write_relabel_configs":
-        - "action": "keep"
-          "regex": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
-          "source_labels":
-          - "tenant_id"
-      - "headers":
-          "THANOS-TENANT": "770c1124-6ae8-4324-a9d4-9ce08590094b"
-        "name": "receive-osd"
-        "queue_config":
-          "batch_send_deadline": "5s"
-          "capacity": 120000
-          "max_backoff": "5m"
-          "max_samples_per_send": 40000
-          "max_shards": 50
-          "min_backoff": "5s"
-          "min_shards": 1
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
-        "write_relabel_configs":
-        - "action": "keep"
-          "regex": "770c1124-6ae8-4324-a9d4-9ce08590094b"
-          "source_labels":
-          - "tenant_id"
-      - "headers":
-          "THANOS-TENANT": "63e320cd-622a-4d05-9585-ffd48342633e"
-        "name": "receive-managedkafka"
-        "queue_config":
-          "batch_send_deadline": "5s"
-          "capacity": 120000
-          "max_backoff": "5m"
-          "max_samples_per_send": 40000
-          "max_shards": 50
-          "min_backoff": "5s"
-          "min_shards": 1
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
-        "write_relabel_configs":
-        - "action": "keep"
-          "regex": "63e320cd-622a-4d05-9585-ffd48342633e"
-          "source_labels":
-          - "tenant_id"
-      - "headers":
-          "THANOS-TENANT": "1b9b6e43-9128-4bbf-bfff-3c120bbe6f11"
-        "name": "receive-rhacs"
-        "queue_config":
-          "batch_send_deadline": "5s"
-          "capacity": 120000
-          "max_backoff": "5m"
-          "max_samples_per_send": 40000
-          "max_shards": 50
-          "min_backoff": "5s"
-          "min_shards": 1
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
-        "write_relabel_configs":
-        - "action": "keep"
-          "regex": "1b9b6e43-9128-4bbf-bfff-3c120bbe6f11"
-          "source_labels":
-          - "tenant_id"
-      - "headers":
-          "THANOS-TENANT": "9ca26972-4328-4fe3-92db-31302013d03f"
-        "name": "receive-cnvqe"
-        "queue_config":
-          "batch_send_deadline": "5s"
-          "capacity": 120000
-          "max_backoff": "5m"
-          "max_samples_per_send": 40000
-          "max_shards": 50
-          "min_backoff": "5s"
-          "min_shards": 1
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
-        "write_relabel_configs":
-        - "action": "keep"
-          "regex": "9ca26972-4328-4fe3-92db-31302013d03f"
-          "source_labels":
-          - "tenant_id"
-      - "headers":
-          "THANOS-TENANT": "37b8fd3f-56ff-4b64-8272-917c9b0d1623"
-        "name": "receive-psiocp"
-        "queue_config":
-          "batch_send_deadline": "5s"
-          "capacity": 120000
-          "max_backoff": "5m"
-          "max_samples_per_send": 40000
-          "max_shards": 50
-          "min_backoff": "5s"
-          "min_shards": 1
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
-        "write_relabel_configs":
-        - "action": "keep"
-          "regex": "37b8fd3f-56ff-4b64-8272-917c9b0d1623"
-          "source_labels":
-          - "tenant_id"
-      - "headers":
-          "THANOS-TENANT": "8ace13a2-1c72-4559-b43d-ab43e32a255a"
-        "name": "receive-rhods"
-        "queue_config":
-          "batch_send_deadline": "5s"
-          "capacity": 120000
-          "max_backoff": "5m"
-          "max_samples_per_send": 40000
-          "max_shards": 50
-          "min_backoff": "5s"
-          "min_shards": 1
-        "url": "http://observatorium-thanos-receive.${NAMESPACE}.svc.cluster.local:19291/api/v1/receive"
-        "write_relabel_configs":
-        - "action": "keep"
-          "regex": "8ace13a2-1c72-4559-b43d-ab43e32a255a"
-          "source_labels":
-          - "tenant_id"
-  kind: ConfigMap
-  metadata:
-    annotations:
-      qontract.recycle: "true"
-    labels:
-      app.kubernetes.io/instance: observatorium
-      app.kubernetes.io/part-of: observatorium
-    name: remote-write-config
-- apiVersion: v1
   kind: Service
   metadata:
     labels:
@@ -1870,7 +2149,7 @@ objects:
       app.kubernetes.io/name: thanos-rule
       app.kubernetes.io/part-of: observatorium
       app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
-    name: observatorium-thanos-stateless-rule
+    name: observatorium-thanos-rule
   spec:
     clusterIP: None
     ports:
@@ -1897,7 +2176,7 @@ objects:
       app.kubernetes.io/name: thanos-rule
       app.kubernetes.io/part-of: observatorium
       app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
-    name: observatorium-thanos-stateless-rule
+    name: observatorium-thanos-rule
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
@@ -1907,7 +2186,7 @@ objects:
       app.kubernetes.io/name: thanos-rule
       app.kubernetes.io/part-of: observatorium
       prometheus: app-sre
-    name: observatorium-thanos-stateless-rule
+    name: observatorium-thanos-rule
   spec:
     endpoints:
     - port: http
@@ -1935,7 +2214,7 @@ objects:
       app.kubernetes.io/name: thanos-rule
       app.kubernetes.io/part-of: observatorium
       app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
-    name: observatorium-thanos-stateless-rule
+    name: observatorium-thanos-rule
   spec:
     replicas: ${{THANOS_RULER_REPLICAS}}
     selector:
@@ -1944,7 +2223,7 @@ objects:
         app.kubernetes.io/instance: observatorium
         app.kubernetes.io/name: thanos-rule
         app.kubernetes.io/part-of: observatorium
-    serviceName: observatorium-thanos-stateless-rule
+    serviceName: observatorium-thanos-rule
     template:
       metadata:
         labels:
@@ -1969,16 +2248,13 @@ objects:
           - --tsdb.retention=48h
           - --tsdb.block-duration=2h
           - --query=dnssrv+_http._tcp.observatorium-thanos-query.${NAMESPACE}.svc.cluster.local
-          - --rule-file=/etc/thanos/rules/rule-syncer/observatorium.yaml
           - --alertmanagers.url=dnssrv+http://observatorium-alertmanager.${NAMESPACE}.svc.cluster.local:9093
-          - --rule-file=/etc/thanos/rules/observatorium-rules/observatorium.yaml
           - |-
             --tracing.config="config":
               "sampler_param": 2
               "sampler_type": "ratelimiting"
               "service_name": "thanos-rule"
             "type": "JAEGER"
-          - --remote-write.config-file=/etc/thanos/config/remote-write-config/rw-config.yaml
           env:
           - name: NAME
             valueFrom:
@@ -2040,25 +2316,8 @@ objects:
           - mountPath: /var/thanos/rule
             name: data
             readOnly: false
-          - mountPath: /etc/thanos/rules/observatorium-rules
-            name: observatorium-rules
-          - mountPath: /etc/thanos/config/remote-write-config
-            name: remote-write-config
-            readOnly: true
           - mountPath: /etc/thanos/rules/rule-syncer
             name: rule-syncer
-        - args:
-          - -webhook-url=http://localhost:10902/-/reload
-          - -volume-dir=/etc/thanos/rules/observatorium-rules
-          - -volume-dir=/etc/thanos/config/remote-write-config
-          image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
-          imagePullPolicy: IfNotPresent
-          name: configmap-reloader
-          volumeMounts:
-          - mountPath: /etc/thanos/rules/observatorium-rules
-            name: observatorium-rules
-          - mountPath: /etc/thanos/config/remote-write-config
-            name: remote-write-config
         - args:
           - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
           - --reporter.type=grpc
@@ -2116,12 +2375,6 @@ objects:
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         volumes:
-        - configMap:
-            name: observatorium-rules
-          name: observatorium-rules
-        - configMap:
-            name: remote-write-config
-          name: remote-write-config
         - emptyDir: {}
           name: rule-syncer
     volumeClaimTemplates:

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1057,6 +1057,7 @@ objects:
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-receive-default.${NAMESPACE}.svc.cluster.local
           - --rule=dnssrv+_grpc._tcp.observatorium-thanos-rule.${NAMESPACE}.svc.cluster.local
           - --rule=dnssrv+_grpc._tcp.observatorium-thanos-stateless-rule.${NAMESPACE}.svc.cluster.local
+          - --rule=dnssrv+_grpc._tcp.observatorium-thanos-metric-federation-rule.${NAMESPACE}.svc.cluster.local
           - --rule=dnssrv+_grpc._tcp.observatorium-thanos-metric-fed-stateless-rule.${NAMESPACE}.svc.cluster.local
           - --web.prefix-header=X-Forwarded-Prefix
           - --query.timeout=15m

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2248,7 +2248,9 @@ objects:
           - --tsdb.retention=48h
           - --tsdb.block-duration=2h
           - --query=dnssrv+_http._tcp.observatorium-thanos-query.${NAMESPACE}.svc.cluster.local
+          - --rule-file=/etc/thanos/rules/rule-syncer/observatorium.yaml
           - --alertmanagers.url=dnssrv+http://observatorium-alertmanager.${NAMESPACE}.svc.cluster.local:9093
+          - --rule-file=/etc/thanos/rules/observatorium-rules/observatorium.yaml
           - |-
             --tracing.config="config":
               "sampler_param": 2
@@ -2316,8 +2318,19 @@ objects:
           - mountPath: /var/thanos/rule
             name: data
             readOnly: false
+          - mountPath: /etc/thanos/rules/observatorium-rules
+            name: observatorium-rules
           - mountPath: /etc/thanos/rules/rule-syncer
             name: rule-syncer
+        - args:
+          - -webhook-url=http://localhost:10902/-/reload
+          - -volume-dir=/etc/thanos/rules/observatorium-rules
+          image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          name: configmap-reloader
+          volumeMounts:
+          - mountPath: /etc/thanos/rules/observatorium-rules
+            name: observatorium-rules
         - args:
           - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
           - --reporter.type=grpc
@@ -2375,6 +2388,9 @@ objects:
         securityContext: {}
         serviceAccountName: ${SERVICE_ACCOUNT_NAME}
         volumes:
+        - configMap:
+            name: observatorium-rules
+          name: observatorium-rules
         - emptyDir: {}
           name: rule-syncer
     volumeClaimTemplates:

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -125,6 +125,29 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
       },
     },
 
+    statelessRule+:: {
+      statefulSet+: jaegerAgentSidecar.statefulSet + ruleSyncerSidecar.statefulSet {
+        spec+: {
+          replicas: '${{THANOS_RULER_REPLICAS}}',
+          template+: {
+            spec+: {
+              securityContext: {},
+              containers: [
+                if c.name == 'thanos-rule' then c {
+                  env+: s3EnvVars,
+                  volumeMounts+: [{
+                    name: ruleSyncerVolume,
+                    mountPath: '/etc/thanos/rules/rule-syncer',
+                  }],
+                } else c
+                for c in super.containers
+              ],
+            },
+          },
+        },
+      },
+    },
+
     metricFederationRule+:: {
       statefulSet+: jaegerAgentSidecar.statefulSet {
         spec+: {

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -83,6 +83,15 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       queriers: [
         'dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, thanos.query.service.metadata.namespace],
       ],
+      ruleFiles: [
+        '/etc/thanos/rules/rule-syncer/observatorium.yaml',
+      ],
+      rulesConfig: [
+        {
+          name: observatoriumRules,
+          key: observatoriumRulesKey,
+        },
+      ],
       reloaderImage: '${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}',
       resources: {
         limits: {

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -70,9 +70,46 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
 
     local observatoriumRules = 'observatorium-rules',
     local observatoriumRulesKey = 'observatorium.yaml',
+    rule:: t.rule(thanosSharedConfig {
+      name: 'observatorium-thanos-rule',
+      commonLabels+:: {
+        'app.kubernetes.io/part-of': 'observatorium',
+        'app.kubernetes.io/instance': 'observatorium',
+      },
+      replicas: 1,  // overwritten in observatorium-metrics-template.libsonnet
+      logLevel: '${THANOS_RULER_LOG_LEVEL}',
+      serviceMonitor: true,
+      alertmanagersURLs: ['dnssrv+http://%s.%s.svc.cluster.local:%s' % [thanosSharedConfig.alertmanagerName, thanosSharedConfig.namespace, thanosSharedConfig.alertmanagerPort]],
+      queriers: [
+        'dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, thanos.query.service.metadata.namespace],
+      ],
+      reloaderImage: '${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}',
+      resources: {
+        limits: {
+          cpu: '${THANOS_RULER_CPU_LIMIT}',
+          memory: '${THANOS_RULER_MEMORY_LIMIT}',
+        },
+        requests: {
+          cpu: '${THANOS_RULER_CPU_REQUEST}',
+          memory: '${THANOS_RULER_MEMORY_REQUEST}',
+        },
+      },
+      volumeClaimTemplate: {
+        spec: {
+          accessModes: ['ReadWriteOnce'],
+          storageClassName: '${STORAGE_CLASS}',
+          resources: {
+            requests: {
+              storage: '${THANOS_RULER_PVC_REQUEST}',
+            },
+          },
+        },
+      },
+    }),
+
     local statelessRuler = 'remote-write-config',
     local statelessRulerKey = 'rw-config.yaml',
-    rule:: t.rule(thanosSharedConfig {
+    statelessRule:: t.rule(thanosSharedConfig {
       name: 'observatorium-thanos-stateless-rule',
       commonLabels+:: {
         'app.kubernetes.io/part-of': 'observatorium',
@@ -175,6 +212,42 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
     },
 
     local metricFederationRulesName = 'metric-federation-rules',
+    metricFederationRule:: t.rule(thanosSharedConfig {
+      name: 'observatorium-thanos-metric-federation-rule',
+      commonLabels+:: {
+        'app.kubernetes.io/part-of': 'observatorium',
+        'app.kubernetes.io/instance': 'metric-federation',
+      },
+      replicas: 1,  // overwritten in observatorium-metrics-template.libsonnet
+      logLevel: '${THANOS_RULER_LOG_LEVEL}',
+      serviceMonitor: true,
+      queriers: [
+        'dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, '${THANOS_QUERIER_NAMESPACE}'],
+      ],
+      reloaderImage: '${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}',
+      resources: {
+        limits: {
+          cpu: '${THANOS_RULER_CPU_LIMIT}',
+          memory: '${THANOS_RULER_MEMORY_LIMIT}',
+        },
+        requests: {
+          cpu: '${THANOS_RULER_CPU_REQUEST}',
+          memory: '${THANOS_RULER_MEMORY_REQUEST}',
+        },
+      },
+      volumeClaimTemplate: {
+        spec: {
+          accessModes: ['ReadWriteOnce'],
+          storageClassName: '${STORAGE_CLASS}',
+          resources: {
+            requests: {
+              storage: '${THANOS_RULER_PVC_REQUEST}',
+            },
+          },
+        },
+      },
+    }),
+
     local metricFederationStatelessRuler = 'metric-federation-ruler-remote-write-config',
     metricFederationStatelessRule:: t.rule(thanosSharedConfig {
       name: 'observatorium-thanos-metric-fed-stateless-rule',
@@ -498,6 +571,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
         for service in
           [thanos.rule.service] +
+          [thanos.statelessRule.service] +
           [thanos.metricFederationStatelessRule.service]
       ],
       serviceMonitor: true,
@@ -930,8 +1004,14 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       ['store-bucket-cache-' + name]: thanos.storeBucketCache[name]
       for name in std.objectFields(thanos.storeBucketCache)
     } + {
+      ['metric-federation-rule-' + name]: thanos.metricFederationRule[name]
+      for name in std.objectFields(thanos.metricFederationRule)
+    } + {
       ['metric-federation-stateless-rule-' + name]: thanos.metricFederationStatelessRule[name]
       for name in std.objectFields(thanos.metricFederationStatelessRule)
+    } + {
+      ['observatorium-thanos-stateless-rule' + name]: thanos.statelessRule[name]
+      for name in std.objectFields(thanos.statelessRule)
     } + {
       ['observatorium-alertmanager-' + name]: thanos.alertmanager[name]
       for name in std.objectFields(thanos.alertmanager)

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -234,6 +234,12 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         'dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [thanos.query.service.metadata.name, '${THANOS_QUERIER_NAMESPACE}'],
       ],
       reloaderImage: '${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}',
+      rulesConfig: [
+        {
+          name: metricFederationRulesName,
+          key: observatoriumRulesKey,
+        },
+      ],
       resources: {
         limits: {
           cpu: '${THANOS_RULER_CPU_LIMIT}',
@@ -581,6 +587,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         for service in
           [thanos.rule.service] +
           [thanos.statelessRule.service] +
+          [thanos.metricFederationRule.service] +
           [thanos.metricFederationStatelessRule.service]
       ],
       serviceMonitor: true,


### PR DESCRIPTION
This reverts commit 04b0c0bc

The plan now is to keep running stateless-ruler in parallel, continue to gather data and understanding of performance over time. Before completing the migration completely, we should have a set of SOP's/Alerts that tell us when things are going wrong. 

cc: @saswatamcode for review

Signed-off-by: mzardab <mzardab@redhat.com>