### PR TITLE
Bumping readiness probe for stateless rulers to account for WAL replay

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -867,13 +867,13 @@ objects:
           - containerPort: 9533
             name: reloader
           readinessProbe:
-            failureThreshold: 18
+            failureThreshold: 3
             httpGet:
               path: /-/ready
               port: 10902
               scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: 60
+            periodSeconds: 180
           resources:
             limits:
               cpu: ${THANOS_RULER_CPU_LIMIT}
@@ -2290,13 +2290,13 @@ objects:
           - containerPort: 9533
             name: reloader
           readinessProbe:
-            failureThreshold: 18
+            failureThreshold: 3
             httpGet:
               path: /-/ready
               port: 10902
               scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: 60
+            periodSeconds: 180
           resources:
             limits:
               cpu: ${THANOS_RULER_CPU_LIMIT}

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -116,6 +116,11 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                     name: ruleSyncerVolume,
                     mountPath: '/etc/thanos/rules/rule-syncer',
                   }],
+                  readinessProbe+: {
+                    failureThreshold: 3,
+                    periodSeconds: 180,
+                    initialDelaySeconds: 60,
+                  },
                 } else c
                 for c in super.containers
               ],
@@ -139,6 +144,11 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                     name: ruleSyncerVolume,
                     mountPath: '/etc/thanos/rules/rule-syncer',
                   }],
+                  readinessProbe+: {
+                    failureThreshold: 3,
+                    periodSeconds: 180,
+                    initialDelaySeconds: 60,
+                  },
                 } else c
                 for c in super.containers
               ],


### PR DESCRIPTION
Moving from 180s with delay of 60s. This will delay all rollouts as readiness probe is less-frequent after a longer elapsed time. We can revisit this if it mitigates ruler crashloop

Signed-off-by: mzardab <mzardab@redhat.com>