### PR TITLE
Add gateway-mode-telemetry to allowlist

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -23,6 +23,7 @@
   "{__name__=\"cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum\"}",
   "{__name__=\"cluster:kubelet_volume_stats_used_bytes:provisioner:sum\"}",
   "{__name__=\"cluster:memory_usage_bytes:sum\"}",
+  "{__name__=\"cluster:ovnkube_master_egress_routing_via_host:max\"}",
   "{__name__=\"cluster:network_attachment_definition_enabled_instance_up:max\"}",
   "{__name__=\"cluster:network_attachment_definition_instances:max\"}",
   "{__name__=\"cluster:node_instance_type_count:sum\"}",

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -117,6 +117,7 @@ objects:
           - --whitelist={__name__="cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum"}
           - --whitelist={__name__="cluster:kubelet_volume_stats_used_bytes:provisioner:sum"}
           - --whitelist={__name__="cluster:memory_usage_bytes:sum"}
+          - --whitelist={__name__="cluster:ovnkube_master_egress_routing_via_host:max"}
           - --whitelist={__name__="cluster:network_attachment_definition_enabled_instance_up:max"}
           - --whitelist={__name__="cluster:network_attachment_definition_instances:max"}
           - --whitelist={__name__="cluster:node_instance_type_count:sum"}
@@ -315,6 +316,7 @@ objects:
           - --whitelist={__name__="cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum"}
           - --whitelist={__name__="cluster:kubelet_volume_stats_used_bytes:provisioner:sum"}
           - --whitelist={__name__="cluster:memory_usage_bytes:sum"}
+          - --whitelist={__name__="cluster:ovnkube_master_egress_routing_via_host:max"}
           - --whitelist={__name__="cluster:network_attachment_definition_enabled_instance_up:max"}
           - --whitelist={__name__="cluster:network_attachment_definition_instances:max"}
           - --whitelist={__name__="cluster:node_instance_type_count:sum"}


### PR DESCRIPTION
This PR adds the metric added in https://github.com/openshift/cluster-monitoring-operator/pull/1635 to telemetry allowlist.