### PR TITLE
IR-254: Collecting registry and image stream usage

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -99,5 +99,7 @@
   "{__name__=\"visual_web_terminal_sessions_total\"}",
   "{__name__=\"workload:cpu_usage_cores:sum\"}",
   "{__name__=\"workload:memory_usage_bytes:sum\"}",
-  "{__name__=~\"cluster:usage:.*\"}"
+  "{__name__=~\"cluster:usage:.*\"}",
+  "{__name__=\"imageregistry:imagestreamtags_count:sum\"}",
+  "{__name__=\"imageregistry:operations_count:sum\"}"
 ]

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -194,6 +194,8 @@ objects:
           - --whitelist={__name__="workload:cpu_usage_cores:sum"}
           - --whitelist={__name__="workload:memory_usage_bytes:sum"}
           - --whitelist={__name__=~"cluster:usage:.*"}
+          - --whitelist={__name__="imageregistry:imagestreamtags_count:sum"}
+          - --whitelist={__name__="imageregistry:operations_count:sum"}
           - --elide-label=prometheus_replica
           - --log-level=${TELEMETER_LOG_LEVEL}
           - --token-expire-seconds=${TELEMETER_SERVER_TOKEN_EXPIRE_SECONDS}
@@ -392,6 +394,8 @@ objects:
           - --whitelist={__name__="workload:cpu_usage_cores:sum"}
           - --whitelist={__name__="workload:memory_usage_bytes:sum"}
           - --whitelist={__name__=~"cluster:usage:.*"}
+          - --whitelist={__name__="imageregistry:imagestreamtags_count:sum"}
+          - --whitelist={__name__="imageregistry:operations_count:sum"}
           - --elide-label=prometheus_replica
           - --log-level=${TELEMETER_LOG_LEVEL}
           - --token-expire-seconds=${TELEMETER_SERVER_TOKEN_EXPIRE_SECONDS}


### PR DESCRIPTION
As an effort to evaluate how often customers are using Image Streams and
the internal registry this commit introduces two new metrics to be
collected:

- The amount of Image Stream Tags in the cluster
- The amount of pushes and pulls executed against the registry

These new metrics are being collected through:

https://github.com/openshift/cluster-monitoring-operator/pull/1668

Signed-off-by: Ricardo Maraschini <rmarasch@redhat.com>