### PR TITLE
MON-2555: Add RHACS metric to federation Ruler for consumption billing

### DIFF
--- a/configuration/observatorium/metric-federation-rules.libsonnet
+++ b/configuration/observatorium/metric-federation-rules.libsonnet
@@ -38,6 +38,18 @@
             },
           ],
         },
+        {
+          name: 'rhacs.rules',
+          interval: '1m',
+          rules: [
+            {
+              record: 'rox_central_cluster_metrics_cpu_capacity',
+              expr: |||
+                rox_central_cluster_metrics_cpu_capacity
+              |||,
+            },
+          ],
+        },
       ],
     },
   },

--- a/configuration/observatorium/metric-federation-rules.libsonnet
+++ b/configuration/observatorium/metric-federation-rules.libsonnet
@@ -43,9 +43,9 @@
           interval: '1m',
           rules: [
             {
-              record: 'rox_central_cluster_metrics_cpu_capacity',
+              record: 'rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h',
               expr: |||
-                rox_central_cluster_metrics_cpu_capacity
+                rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h
               |||,
             },
           ],

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -39,10 +39,10 @@ objects:
         "name": "telemeter-rhacs.rules"
         "rules":
         - "expr": |
-            rox_central_cluster_metrics_cpu_capacity
+            rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h
           "labels":
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
-          "record": "rox_central_cluster_metrics_cpu_capacity"
+          "record": "rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h"
   kind: ConfigMap
   metadata:
     annotations:

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -35,6 +35,14 @@ objects:
           "labels":
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
           "record": "kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes"
+      - "interval": "1m"
+        "name": "telemeter-rhacs.rules"
+        "rules":
+        - "expr": |
+            rox_central_cluster_metrics_cpu_capacity
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "rox_central_cluster_metrics_cpu_capacity"
   kind: ConfigMap
   metadata:
     annotations:


### PR DESCRIPTION
This PR adds a new rule group to the Thanos Federation Ruler. This enabled SubWatch to perform consumption based billing for ACS.

Signed-off-by: Ian Billett <ibillett@redhat.com>