### PR TITLE
Add Openshift Sandboxed Containers usage metric to allowlist

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -19,6 +19,7 @@
   "{__name__=\"cluster:capacity_memory_bytes:sum\"}",
   "{__name__=\"cluster:cpu_usage_cores:sum\"}",
   "{__name__=\"cluster:ingress_controller_aws_nlb_active:sum\"}",
+  "{__name__=\"cluster:kata_monitor_running_shim_count:sum\"}",
   "{__name__=\"cluster:kube_persistentvolume_plugin_type_counts:sum\"}",
   "{__name__=\"cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum\"}",
   "{__name__=\"cluster:kubelet_volume_stats_used_bytes:provisioner:sum\"}",

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -113,6 +113,7 @@ objects:
           - --whitelist={__name__="cluster:capacity_memory_bytes:sum"}
           - --whitelist={__name__="cluster:cpu_usage_cores:sum"}
           - --whitelist={__name__="cluster:ingress_controller_aws_nlb_active:sum"}
+          - --whitelist={__name__="cluster:kata_monitor_running_shim_count:sum"}
           - --whitelist={__name__="cluster:kube_persistentvolume_plugin_type_counts:sum"}
           - --whitelist={__name__="cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum"}
           - --whitelist={__name__="cluster:kubelet_volume_stats_used_bytes:provisioner:sum"}
@@ -312,6 +313,7 @@ objects:
           - --whitelist={__name__="cluster:capacity_memory_bytes:sum"}
           - --whitelist={__name__="cluster:cpu_usage_cores:sum"}
           - --whitelist={__name__="cluster:ingress_controller_aws_nlb_active:sum"}
+          - --whitelist={__name__="cluster:kata_monitor_running_shim_count:sum"}
           - --whitelist={__name__="cluster:kube_persistentvolume_plugin_type_counts:sum"}
           - --whitelist={__name__="cluster:kube_persistentvolumeclaim_resource_requests_storage_bytes:provisioner:sum"}
           - --whitelist={__name__="cluster:kubelet_volume_stats_used_bytes:provisioner:sum"}


### PR DESCRIPTION
This PR adds the metric added in https://github.com/openshift/cluster-monitoring-operator/pull/1662 to telemetry allowlist.