### PR TITLE
add monthly storage use metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ resources/services/observatorium-traces-template.yaml: $(wildcard services/obser
 	@echo ">>>>> Running observatorium-traces templates"
 	$(JSONNET) -J vendor services/observatorium-traces-template.jsonnet | $(GOJSONTOYAML) > $@
 
-resources/services/metric-federation-rule-template.yaml: $(wildcard services/metric-federation-rule*) $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
+resources/services/metric-federation-rule-template.yaml: $(wildcard services/metric-federation-rule*) $(wildcard configuration/observatorium/metric-federation-rule*) $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
 	@echo ">>>>> Running metric-federation-rule templates"
 	$(JSONNET) -J vendor services/metric-federation-rule-template.jsonnet | $(GOJSONTOYAML) > $@
 

--- a/configuration/observatorium/metric-federation-rules.libsonnet
+++ b/configuration/observatorium/metric-federation-rules.libsonnet
@@ -36,6 +36,12 @@
                 kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes
               |||,
             },
+            {
+              record: 'kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months',
+              expr: |||
+                kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
+              |||,
+            },
           ],
         },
         {

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -280,6 +280,11 @@ objects:
           "labels":
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
           "record": "kafka_id:haproxy_server_bytes_in_out_total:rate1h_gibibytes"
+        - "expr": |
+            kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "kafka_id:kafka_broker_quota_totalstorageusedbytes:max_over_time1h_gibibyte_months"
       - "interval": "1m"
         "name": "telemeter-rhacs.rules"
         "rules":


### PR DESCRIPTION
Added new federation rules and ran `make manifests`. Output:

```
[peter@fedora configuration]$ make manifests 
>>>>> Running format
/home/peter/go/bin/jsonnetfmt-v0.18.0 -n 2 --max-blank-lines 2 --string-style s --comment-style s -i ./configuration/observatorium/queries.libsonnet ./configuration/observatorium/ruler-remote-write.libsonnet ./configuration/observatorium/tenants.libsonnet ./configuration/observatorium/metric-federation-rules.libsonnet ./configuration/observatorium/rbac.libsonnet ./observability/config.libsonnet ./observability/dashboards/observatorium-api-logs.libsonnet ./observability/dashboards/observatorium-api.libsonnet ./observability/dashboards/slo.libsonnet ./observability/dashboards/telemeter-canary.libsonnet ./observability/dashboards/telemeter.libsonnet ./observability/grafana-obs-logs.jsonnet ./observability/grafana.jsonnet ./observability/observatorium-logs/loki-overview.libsonnet ./observability/observatorium-logs/loki-tenant-alerts.libsonnet ./observability/prometheusrules.jsonnet ./services/components/jaeger-collector.libsonnet ./services/components/loki-caches.libsonnet ./services/dex-template.jsonnet ./services/jaeger-template.jsonnet ./services/metric-federation-rule-template.jsonnet ./services/minio-template.jsonnet ./services/observatorium-logs-template-overwrites.libsonnet ./services/observatorium-logs-template.jsonnet ./services/observatorium-logs.libsonnet ./services/observatorium-metrics-template-overwrites.libsonnet ./services/observatorium-metrics-template.jsonnet ./services/observatorium-metrics.libsonnet ./services/parca-template.jsonnet ./services/prometheus/remote-write-proxy.libsonnet ./services/sidecars/jaeger-agent.libsonnet ./services/sidecars/oauth-proxy.libsonnet ./services/sidecars/opa-ams.libsonnet ./services/sidecars/thanos-rule-syncer.libsonnet ./services/telemeter-template.jsonnet ./services/telemeter.libsonnet ./services/observatorium-template.jsonnet ./services/observatorium-traces-template.jsonnet ./services/observatorium-traces.libsonnet ./services/observatorium.libsonnet
make clean
make[1]: Verzeichnis „/home/peter/WebstormProjects/configuration“ wird betreten
find resources/services -type f ! -name '*.yaml' -delete
find resources/observability/prometheusrules -type f ! -name '*.yaml' -delete
find resources/observability/grafana/observatorium -type f ! -name '*.yaml' -delete
find resources/observability/grafana/observatorium-logs -type f ! -name '*.yaml' -delete
find resources/services/telemeter-template.yaml -type f ! -name '*.yaml' -delete
```

No additional changes after running the make target.