### PR TITLE
add elasticsearch subscription

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ whitelisted_metrics: $(GOJSONTOYAML) $(GOJQ)
 .PHONY: manifests
 manifests: format $(VENDOR_DIR)
 manifests: resources/services/telemeter-template.yaml resources/services/jaeger-template.yaml resources/services/parca-template.yaml tests/minio-template.yaml tests/dex-template.yaml
-manifests: resources/services/observatorium-template.yaml resources/services/observatorium-metrics-template.yaml resources/services/observatorium-logs-template.yaml resources/services/observatorium-traces-template.yaml
+manifests: resources/services/observatorium-template.yaml resources/services/observatorium-metrics-template.yaml resources/services/observatorium-logs-template.yaml resources/services/observatorium-traces-subscriptions-template.yaml resources/services/observatorium-traces-template.yaml
 manifests: resources/services/metric-federation-rule-template.yaml
 	$(MAKE) clean
 
@@ -128,6 +128,10 @@ resources/services/observatorium-logs-template.yaml: $(wildcard services/observa
 resources/services/observatorium-traces-template.yaml: $(wildcard services/observatorium-traces-*) $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
 	@echo ">>>>> Running observatorium-traces templates"
 	$(JSONNET) -J vendor services/observatorium-traces-template.jsonnet | $(GOJSONTOYAML) > $@
+
+resources/services/observatorium-traces-subscriptions-template.yaml: $(wildcard services/observatorium-traces-*) $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
+	@echo ">>>>> Running observatorium-traces-subscriptions templates"
+	$(JSONNET) -J vendor services/observatorium-traces-subscriptions-template.jsonnet | $(GOJSONTOYAML) > $@
 
 resources/services/metric-federation-rule-template.yaml: $(wildcard services/metric-federation-rule*) $(wildcard configuration/observatorium/metric-federation-rule*) $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
 	@echo ">>>>> Running metric-federation-rule templates"

--- a/resources/services/observatorium-traces-subscriptions-template.yaml
+++ b/resources/services/observatorium-traces-subscriptions-template.yaml
@@ -1,0 +1,60 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: observatorium-traces-subscriptions
+objects:
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: rhobs-opentelemetry
+    namespace: ${OPENTELEMETRY_OPERATOR_NAMESPACE}
+  spec:
+    channel: stable
+    installPlanApproval: Automatic
+    name: opentelemetry-product
+    source: ${OPENTELEMETRY_OPERATOR_SOURCE}
+    sourceNamespace: openshift-marketplace
+    startingCSV: opentelemetry-operator.v${OPENTELEMETRY_OPERATOR_VERSION}
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: rhobs-jaeger
+    namespace: ${JAEGER_OPERATOR_NAMESPACE}
+  spec:
+    channel: stable
+    installPlanApproval: Automatic
+    name: jaeger-product
+    source: ${JAEGER_OPERATOR_SOURCE}
+    sourceNamespace: openshift-marketplace
+    startingCSV: jaeger-operator.v${JAEGER_OPERATOR_VERSION}
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: rhobs-elasticsearch
+    namespace: ${ELASTIC_OPERATOR_NAMESPACE}
+  spec:
+    channel: stable
+    installPlanApproval: Automatic
+    name: elasticsearch-operator
+    source: ${ELASTICSEARCH_OPERATOR_SOURCE}
+    sourceNamespace: openshift-marketplace
+    startingCSV: elasticsearch-operator.${ELASTICSEARCH_OPERATOR_VERSION}
+parameters:
+- name: OPENTELEMETRY_OPERATOR_VERSION
+  value: 0.44.1-1
+- name: OPENTELEMETRY_OPERATOR_NAMESPACE
+  value: openshift-operators
+- name: OPENTELEMETRY_OPERATOR_SOURCE
+  value: redhat-operators
+- name: JAEGER_OPERATOR_VERSION
+  value: 1.30.2
+- name: JAEGER_OPERATOR_NAMESPACE
+  value: openshift-operators
+- name: JAEGER_OPERATOR_SOURCE
+  value: redhat-operators
+- name: ELASTICSEARCH_OPERATOR_VERSION
+  value: 5.4.1-24
+- name: ELASTICSEARCH_OPERATOR_NAMESPACE
+  value: openshift-operators
+- name: ELASTICSEARCH_OPERATOR_SOURCE
+  value: redhat-operators

--- a/resources/services/observatorium-traces-template.yaml
+++ b/resources/services/observatorium-traces-template.yaml
@@ -3,30 +3,6 @@ kind: Template
 metadata:
   name: observatorium-traces
 objects:
-- apiVersion: operators.coreos.com/v1alpha1
-  kind: Subscription
-  metadata:
-    name: rhobs-opentelemetry
-    namespace: ${OPENTELEMETRY_OPERATOR_NAMESPACE}
-  spec:
-    channel: stable
-    installPlanApproval: Automatic
-    name: opentelemetry-product
-    source: ${OPENTELEMETRY_OPERATOR_SOURCE}
-    sourceNamespace: openshift-marketplace
-    startingCSV: opentelemetry-operator.v${OPENTELEMETRY_OPERATOR_VERSION}
-- apiVersion: operators.coreos.com/v1alpha1
-  kind: Subscription
-  metadata:
-    name: rhobs-jaeger
-    namespace: ${JAEGER_OPERATOR_NAMESPACE}
-  spec:
-    channel: stable
-    installPlanApproval: Automatic
-    name: jaeger-product
-    source: ${JAEGER_OPERATOR_SOURCE}
-    sourceNamespace: openshift-marketplace
-    startingCSV: jaeger-operator.v${JAEGER_OPERATOR_VERSION}
 - apiVersion: jaegertracing.io/v1
   kind: Jaeger
   metadata:
@@ -103,19 +79,7 @@ objects:
 parameters:
 - name: NAMESPACE
   value: observatorium-traces
-- name: OPENTELEMETRY_OPERATOR_VERSION
-  value: 0.44.1-1
-- name: OPENTELEMETRY_OPERATOR_NAMESPACE
-  value: openshift-operators
-- name: OPENTELEMETRY_OPERATOR_SOURCE
-  value: redhat-operators
 - name: OPENTELEMETRY_COLLECTOR_IMAGE
   value: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
 - name: OPENTELEMETRY_COLLECTOR_IMAGE_TAG
   value: 0.46.0
-- name: JAEGER_OPERATOR_VERSION
-  value: 1.30.2
-- name: JAEGER_OPERATOR_NAMESPACE
-  value: openshift-operators
-- name: JAEGER_OPERATOR_SOURCE
-  value: redhat-operators

--- a/services/observatorium-traces-subscriptions-template.jsonnet
+++ b/services/observatorium-traces-subscriptions-template.jsonnet
@@ -1,0 +1,24 @@
+local subscriptions = import 'observatorium-traces-subscriptions.libsonnet';
+{
+  apiVersion: 'template.openshift.io/v1',
+  kind: 'Template',
+  metadata: {
+    name: 'observatorium-traces-subscriptions',
+  },
+  objects: [
+    subscriptions.otelcol,
+    subscriptions.jaeger,
+    subscriptions.elasticsearch,
+  ],
+  parameters: [
+    { name: 'OPENTELEMETRY_OPERATOR_VERSION', value: '0.44.1-1' },
+    { name: 'OPENTELEMETRY_OPERATOR_NAMESPACE', value: 'openshift-operators' },
+    { name: 'OPENTELEMETRY_OPERATOR_SOURCE', value: 'redhat-operators' },
+    { name: 'JAEGER_OPERATOR_VERSION', value: '1.30.2' },
+    { name: 'JAEGER_OPERATOR_NAMESPACE', value: 'openshift-operators' },
+    { name: 'JAEGER_OPERATOR_SOURCE', value: 'redhat-operators' },
+    { name: 'ELASTICSEARCH_OPERATOR_VERSION', value: '5.4.1-24' },
+    { name: 'ELASTICSEARCH_OPERATOR_NAMESPACE', value: 'openshift-operators' },
+    { name: 'ELASTICSEARCH_OPERATOR_SOURCE', value: 'redhat-operators' },
+  ],
+}

--- a/services/observatorium-traces-subscriptions.libsonnet
+++ b/services/observatorium-traces-subscriptions.libsonnet
@@ -1,0 +1,52 @@
+{
+  otelcol:: {
+    apiVersion: 'operators.coreos.com/v1alpha1',
+    kind: 'Subscription',
+    metadata: {
+      name: 'rhobs-opentelemetry',
+      namespace: '${OPENTELEMETRY_OPERATOR_NAMESPACE}',
+    },
+    spec: {
+      channel: 'stable',
+      installPlanApproval: 'Automatic',
+      name: 'opentelemetry-product',
+      source: '${OPENTELEMETRY_OPERATOR_SOURCE}',
+      sourceNamespace: 'openshift-marketplace',
+      startingCSV: 'opentelemetry-operator.v${OPENTELEMETRY_OPERATOR_VERSION}',
+    },
+  },
+
+  jaeger:: {
+    apiVersion: 'operators.coreos.com/v1alpha1',
+    kind: 'Subscription',
+    metadata: {
+      name: 'rhobs-jaeger',
+      namespace: '${JAEGER_OPERATOR_NAMESPACE}',
+    },
+    spec: {
+      channel: 'stable',
+      installPlanApproval: 'Automatic',
+      name: 'jaeger-product',
+      source: '${JAEGER_OPERATOR_SOURCE}',
+      sourceNamespace: 'openshift-marketplace',
+      startingCSV: 'jaeger-operator.v${JAEGER_OPERATOR_VERSION}',
+    },
+  },
+
+  elasticsearch:: {
+    apiVersion: 'operators.coreos.com/v1alpha1',
+    kind: 'Subscription',
+    metadata: {
+      name: 'rhobs-elasticsearch',
+      namespace: '${ELASTIC_OPERATOR_NAMESPACE}',
+    },
+    spec: {
+      channel: 'stable',
+      installPlanApproval: 'Automatic',
+      name: 'elasticsearch-operator',
+      source: '${ELASTICSEARCH_OPERATOR_SOURCE}',
+      sourceNamespace: 'openshift-marketplace',
+      startingCSV: 'elasticsearch-operator.${ELASTICSEARCH_OPERATOR_VERSION}',
+    },
+  },
+}

--- a/services/observatorium-traces-template.jsonnet
+++ b/services/observatorium-traces-template.jsonnet
@@ -8,6 +8,7 @@ local obs = import 'observatorium.libsonnet';
   objects: [
     obs.tracingsubs.otelcol,
     obs.tracingsubs.jaeger,
+    obs.tracingsubs.elasticsearch,
   ] + [
     obs.tracing.manifests[name] {
       metadata+: {
@@ -25,5 +26,8 @@ local obs = import 'observatorium.libsonnet';
     { name: 'JAEGER_OPERATOR_VERSION', value: '1.30.2' },
     { name: 'JAEGER_OPERATOR_NAMESPACE', value: 'openshift-operators' },
     { name: 'JAEGER_OPERATOR_SOURCE', value: 'redhat-operators' },
+    { name: 'ELASTICSEARCH_OPERATOR_VERSION', value: '5.4.1-24' },
+    { name: 'ELASTICSEARCH_OPERATOR_NAMESPACE', value: 'openshift-operators' },
+    { name: 'ELASTICSEARCH_OPERATOR_SOURCE', value: 'redhat-operators' },
   ],
 }

--- a/services/observatorium-traces-template.jsonnet
+++ b/services/observatorium-traces-template.jsonnet
@@ -6,10 +6,6 @@ local obs = import 'observatorium.libsonnet';
     name: 'observatorium-traces',
   },
   objects: [
-    obs.tracingsubs.otelcol,
-    obs.tracingsubs.jaeger,
-    obs.tracingsubs.elasticsearch,
-  ] + [
     obs.tracing.manifests[name] {
       metadata+: {
       },
@@ -18,16 +14,7 @@ local obs = import 'observatorium.libsonnet';
   ],
   parameters: [
     { name: 'NAMESPACE', value: 'observatorium-traces' },
-    { name: 'OPENTELEMETRY_OPERATOR_VERSION', value: '0.44.1-1' },
-    { name: 'OPENTELEMETRY_OPERATOR_NAMESPACE', value: 'openshift-operators' },
-    { name: 'OPENTELEMETRY_OPERATOR_SOURCE', value: 'redhat-operators' },
     { name: 'OPENTELEMETRY_COLLECTOR_IMAGE', value: 'ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib' },
     { name: 'OPENTELEMETRY_COLLECTOR_IMAGE_TAG', value: '0.46.0' },
-    { name: 'JAEGER_OPERATOR_VERSION', value: '1.30.2' },
-    { name: 'JAEGER_OPERATOR_NAMESPACE', value: 'openshift-operators' },
-    { name: 'JAEGER_OPERATOR_SOURCE', value: 'redhat-operators' },
-    { name: 'ELASTICSEARCH_OPERATOR_VERSION', value: '5.4.1-24' },
-    { name: 'ELASTICSEARCH_OPERATOR_NAMESPACE', value: 'openshift-operators' },
-    { name: 'ELASTICSEARCH_OPERATOR_SOURCE', value: 'redhat-operators' },
   ],
 }

--- a/services/observatorium-traces.libsonnet
+++ b/services/observatorium-traces.libsonnet
@@ -20,56 +20,5 @@ local tracing = (import 'github.com/observatorium/observatorium/configuration/co
   }),
 
 
-  tracingsubs:: {
-    otelcol:: {
-      apiVersion: 'operators.coreos.com/v1alpha1',
-      kind: 'Subscription',
-      metadata: {
-        name: 'rhobs-opentelemetry',
-        namespace: '${OPENTELEMETRY_OPERATOR_NAMESPACE}',
-      },
-      spec: {
-        channel: 'stable',
-        installPlanApproval: 'Automatic',
-        name: 'opentelemetry-product',
-        source: '${OPENTELEMETRY_OPERATOR_SOURCE}',
-        sourceNamespace: 'openshift-marketplace',
-        startingCSV: 'opentelemetry-operator.v${OPENTELEMETRY_OPERATOR_VERSION}',
-      },
-    },
-
-    jaeger:: {
-      apiVersion: 'operators.coreos.com/v1alpha1',
-      kind: 'Subscription',
-      metadata: {
-        name: 'rhobs-jaeger',
-        namespace: '${JAEGER_OPERATOR_NAMESPACE}',
-      },
-      spec: {
-        channel: 'stable',
-        installPlanApproval: 'Automatic',
-        name: 'jaeger-product',
-        source: '${JAEGER_OPERATOR_SOURCE}',
-        sourceNamespace: 'openshift-marketplace',
-        startingCSV: 'jaeger-operator.v${JAEGER_OPERATOR_VERSION}',
-      },
-    },
-
-    elasticsearch:: {
-      apiVersion: 'operators.coreos.com/v1alpha1',
-      kind: 'Subscription',
-      metadata: {
-        name: 'rhobs-elasticsearch',
-        namespace: '${ELASTIC_OPERATOR_NAMESPACE}',
-      },
-      spec: {
-        channel: 'stable',
-        installPlanApproval: 'Automatic',
-        name: 'elasticsearch-operator',
-        source: '${ELASTICSEARCH_OPERATOR_SOURCE}',
-        sourceNamespace: 'openshift-marketplace',
-        startingCSV: 'elasticsearch-operator.${ELASTICSEARCH_OPERATOR_VERSION}',
-      },
-    },
-  },
+  tracingsubs:: (import 'observatorium-traces-subscriptions.libsonnet'),
 }

--- a/services/observatorium-traces.libsonnet
+++ b/services/observatorium-traces.libsonnet
@@ -19,6 +19,4 @@ local tracing = (import 'github.com/observatorium/observatorium/configuration/co
     otelcolVersion: '${OPENTELEMETRY_COLLECTOR_IMAGE_TAG}',
   }),
 
-
-  tracingsubs:: (import 'observatorium-traces-subscriptions.libsonnet'),
 }

--- a/services/observatorium-traces.libsonnet
+++ b/services/observatorium-traces.libsonnet
@@ -54,5 +54,22 @@ local tracing = (import 'github.com/observatorium/observatorium/configuration/co
         startingCSV: 'jaeger-operator.v${JAEGER_OPERATOR_VERSION}',
       },
     },
+
+    elasticsearch:: {
+      apiVersion: 'operators.coreos.com/v1alpha1',
+      kind: 'Subscription',
+      metadata: {
+        name: 'rhobs-elasticsearch',
+        namespace: '${ELASTIC_OPERATOR_NAMESPACE}',
+      },
+      spec: {
+        channel: 'stable',
+        installPlanApproval: 'Automatic',
+        name: 'elasticsearch-operator',
+        source: '${ELASTICSEARCH_OPERATOR_SOURCE}',
+        sourceNamespace: 'openshift-marketplace',
+        startingCSV: 'elasticsearch-operator.${ELASTICSEARCH_OPERATOR_VERSION}',
+      },
+    },
   },
 }


### PR DESCRIPTION
~i would like to create an elasticsearch default instance that backs up the data for different tenants. Where exactly do I do this best in rhobs? In observatorium there is something like [examples/local/main.jsonnet](https://github.com/observatorium/observatorium/blob/main/configuration/examples/local/main.jsonnet).~

Whats the prefered way, should i add my elasticsearch deployment in `services/observatorium-traces.libsonnet` or create `elasticsearch.libsonet` in [observatorium](https://github.com/observatorium/observatorium) and import it?