### PR TITLE
Add group to API version for OCP templates

### DIFF
--- a/observability/grafana-obs-logs.jsonnet
+++ b/observability/grafana-obs-logs.jsonnet
@@ -22,7 +22,7 @@ local dashboards = {
 };
 
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: {
     name: 'observatorium-logs-dahboards-templates',

--- a/resources/observability/grafana/observatorium-logs/grafana-dashboards-template.yaml
+++ b/resources/observability/grafana/observatorium-logs/grafana-dashboards-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: observatorium-logs-dahboards-templates

--- a/resources/services/jaeger-template.yaml
+++ b/resources/services/jaeger-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: jaeger

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: metric-federation-rule

--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: observatorium-logs

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: observatorium-metrics

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: observatorium

--- a/resources/services/observatorium-traces-template.yaml
+++ b/resources/services/observatorium-traces-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: observatorium-traces

--- a/resources/services/parca-observatorium-remote-ns-rbac-template.yaml
+++ b/resources/services/parca-observatorium-remote-ns-rbac-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: parca-observatorium-rbac

--- a/resources/services/parca-template.yaml
+++ b/resources/services/parca-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: parca

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: telemeter

--- a/services/dex-template.jsonnet
+++ b/services/dex-template.jsonnet
@@ -81,7 +81,7 @@ local dex = (import 'github.com/observatorium/observatorium/configuration/compon
 };
 
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: {
     name: 'dex',

--- a/services/jaeger-template.jsonnet
+++ b/services/jaeger-template.jsonnet
@@ -116,7 +116,7 @@ local jaeger = (import 'components/jaeger-collector.libsonnet')({
 };
 
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: {
     name: 'jaeger',

--- a/services/metric-federation-rule-template.jsonnet
+++ b/services/metric-federation-rule-template.jsonnet
@@ -1,6 +1,6 @@
 local obs = import 'observatorium.libsonnet';
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: { name: 'metric-federation-rule' },
   objects: [

--- a/services/minio-template.jsonnet
+++ b/services/minio-template.jsonnet
@@ -34,7 +34,7 @@ local minio = (import 'github.com/observatorium/observatorium/configuration/comp
 };
 
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: {
     name: 'minio',

--- a/services/observatorium-logs-template.jsonnet
+++ b/services/observatorium-logs-template.jsonnet
@@ -1,6 +1,6 @@
 local obs = import 'observatorium.libsonnet';
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: {
     name: 'observatorium-logs',

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -1,6 +1,6 @@
 local obs = import 'observatorium.libsonnet';
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: { name: 'observatorium-metrics' },
   objects: [

--- a/services/observatorium-template.jsonnet
+++ b/services/observatorium-template.jsonnet
@@ -1,6 +1,6 @@
 local obs = import 'observatorium.libsonnet';
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: { name: 'observatorium' },
   objects:

--- a/services/observatorium-traces-template.jsonnet
+++ b/services/observatorium-traces-template.jsonnet
@@ -1,6 +1,6 @@
 local obs = import 'observatorium.libsonnet';
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: {
     name: 'observatorium-traces',

--- a/services/parca-template.jsonnet
+++ b/services/parca-template.jsonnet
@@ -231,7 +231,7 @@ local proxyContainer = {
 
 {
   'parca-template': {
-    apiVersion: 'v1',
+    apiVersion: 'template.openshift.io/v1',
     kind: 'Template',
     metadata: {
       name: 'parca',
@@ -323,7 +323,7 @@ local proxyContainer = {
     ],
   },
   'parca-observatorium-remote-ns-rbac-template': {
-    apiVersion: 'v1',
+    apiVersion: 'template.openshift.io/v1',
     kind: 'Template',
     metadata: {
       name: 'parca-observatorium-rbac',

--- a/services/telemeter-template.jsonnet
+++ b/services/telemeter-template.jsonnet
@@ -118,7 +118,7 @@ local tr = (import 'github.com/observatorium/token-refresher/jsonnet/lib/token-r
 };
 
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: { name: 'telemeter' },
   objects: [

--- a/tests/dex-template.yaml
+++ b/tests/dex-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: dex

--- a/tests/minio-template.yaml
+++ b/tests/minio-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: minio

--- a/tests/observatorium-metrics-thanos-objectstorage-secret-template.yaml
+++ b/tests/observatorium-metrics-thanos-objectstorage-secret-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: minio-secret


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This fixes warning when applying OCP template

```
oc process -f resources/services/observatorium-traces-template.yaml  -p NAMESPACE=observatorium-traces-testing -p JAEGER_OPERATOR_SOURCE="" -o yaml                                                                                                                                            ploffay@fedora
W0609 11:18:00.995114  977639 shim_kubectl.go:58] Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "template.openshift.io/v1" for your resource

```