### PR TITLE
Remove metric-fed ruler from Querier

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1047,8 +1047,6 @@ objects:
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-receive-default.${NAMESPACE}.svc.cluster.local
           - --rule=dnssrv+_grpc._tcp.observatorium-thanos-rule.${NAMESPACE}.svc.cluster.local
           - --rule=dnssrv+_grpc._tcp.observatorium-thanos-stateless-rule.${NAMESPACE}.svc.cluster.local
-          - --rule=dnssrv+_grpc._tcp.observatorium-thanos-metric-federation-rule.${NAMESPACE}.svc.cluster.local
-          - --rule=dnssrv+_grpc._tcp.observatorium-thanos-metric-fed-stateless-rule.${NAMESPACE}.svc.cluster.local
           - --web.prefix-header=X-Forwarded-Prefix
           - --query.timeout=15m
           - --query.lookback-delta=15m

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -573,9 +573,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
         'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
         for service in
           [thanos.rule.service] +
-          [thanos.statelessRule.service] +
-          [thanos.metricFederationRule.service] +
-          [thanos.metricFederationStatelessRule.service]
+          [thanos.statelessRule.service]
       ],
       serviceMonitor: true,
       resources: {


### PR DESCRIPTION
This PR removes metric-fed ruler from observatorium-mst Querier to stop the spam of "no such host" logs.