### PR TITLE
Whitelist metrics for MCG addon

### DIFF
--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -173,8 +173,15 @@ objects:
           - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_cores:sum"}
           - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_sockets:sum"}
           - --whitelist={__name__="node_uname_info"}
+          - --whitelist={__name__="NooBaa_num_buckets_claims"}
+          - --whitelist={__name__="NooBaa_num_namespace_buckets"}
+          - --whitelist={__name__="NooBaa_num_unhealthy_bucket_claims"}
+          - --whitelist={__name__="NooBaa_num_unhealthy_namespace_buckets"}
           - --whitelist={__name__="noobaa_accounts_num"}
           - --whitelist={__name__="noobaa_total_usage"}
+          - --whitelist={__name__="odf_system_health_status"}
+          - --whitelist={__name__="odf_system_iops_total_bytes"}
+          - --whitelist={__name__="odf_system_throughput_total_bytes"}
           - --whitelist={__name__="nto_custom_profiles:count"}
           - --whitelist={__name__="olm_resolution_duration_seconds"}
           - --whitelist={__name__="openshift:build_by_strategy:sum"}
@@ -374,8 +381,15 @@ objects:
           - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_cores:sum"}
           - --whitelist={__name__="node_role_os_version_machine:cpu_capacity_sockets:sum"}
           - --whitelist={__name__="node_uname_info"}
+          - --whitelist={__name__="NooBaa_num_buckets_claims"}
+          - --whitelist={__name__="NooBaa_num_namespace_buckets"}
+          - --whitelist={__name__="NooBaa_num_unhealthy_bucket_claims"}
+          - --whitelist={__name__="NooBaa_num_unhealthy_namespace_buckets"}
           - --whitelist={__name__="noobaa_accounts_num"}
           - --whitelist={__name__="noobaa_total_usage"}
+          - --whitelist={__name__="odf_system_health_status"}
+          - --whitelist={__name__="odf_system_iops_total_bytes"}
+          - --whitelist={__name__="odf_system_throughput_total_bytes"}
           - --whitelist={__name__="nto_custom_profiles:count"}
           - --whitelist={__name__="olm_resolution_duration_seconds"}
           - --whitelist={__name__="openshift:build_by_strategy:sum"}


### PR DESCRIPTION
Whitelist metrics for MCG addon, based on following document:
* https://docs.google.com/document/d/19JST--IQyxTa_330D7mjJZUTEi2dqJ9NXcJ9J0SrhyY/edit?usp=sharing

This would enable us to create a dashboard in staging and production
telemeter datahub environments to realize our achieved SLIs in the defined SLO
range.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>
***
All SLI metrics required by the MCG addon:
```
  - NooBaa_num_buckets_claims
  - NooBaa_num_namespace_buckets
  - NooBaa_num_unhealthy_bucket_claims
  - NooBaa_num_unhealthy_namespace_buckets
  - noobaa_accounts_num
  - noobaa_total_usage
  - odf_system_health_status
  - odf_system_iops_total_bytes
  - odf_system_throughput_total_bytes
```