### PR TITLE
Change Dockerfile path to be absolute in build_deploy script

### DIFF
--- a/tests/integration_tests/build_deploy.sh
+++ b/tests/integration_tests/build_deploy.sh
@@ -2,10 +2,13 @@
 
 set -exv
 
+# We need to find absolute path since CI is running the script from repo's root directory.
+ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 IMAGE="quay.io/app-sre/rhobs-e2e"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 
-docker build -t "${IMAGE}:${IMAGE_TAG}" .
+docker build -t "${IMAGE}:${IMAGE_TAG}" -f "${ABSOLUTE_PATH}/Dockerfile" .
 
 if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
     DOCKER_CONF="$PWD/.docker"


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Although the script is in a sub-directory, our internal CI runs the script from the root of the repository. Fixing this by changing the path to be absolute.