### PR TITLE
Fix copy path in E2E Dockerfile

### DIFF
--- a/tests/integration_tests/Dockerfile
+++ b/tests/integration_tests/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/observatorium/up:master-2022-03-31-2aa26e9
 RUN apk update &&\
     apk add curl jq
 
-COPY runtest.sh /tests/runtest.sh
+COPY ./tests/integration_tests/runtest.sh /tests/runtest.sh
 
 WORKDIR /tests
 ENTRYPOINT ["/bin/sh", "runtest.sh"]


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Continuation of https://github.com/rhobs/configuration/pull/252 - the path within `Dockerfile` in the copy directive was not working. This should fix it.