### PR TITLE
Post-deploy job: Use image tag

### DIFF
--- a/tests/integration_tests/post-deploy-job-template.yaml
+++ b/tests/integration_tests/post-deploy-job-template.yaml
@@ -16,7 +16,7 @@ objects:
         name: rhobs-e2e-tests
       spec:
         containers:
-            - image: ${IMAGE}
+            - image: ${IMAGE}:{IMAGE_TAG}
               imagePullPolicy: Always
               name: rhobs-e2e-tests
               env:
@@ -39,6 +39,8 @@ parameters:
   required: true
 - name: IMAGE
   value: 'quay.io/app-sre/rhobs-e2e'
+- name: IMAGE_TAG
+  value: "e21a7ce"
 - name: JOBID
   generate: expression
   from: "[0-9a-f]{7}"


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

I'd like to be able specify which tag to use, as now it would default to `latest`. Adding new parameter `IMAGE_TAG`.