### PR TITLE
add qcontract reconcile to tenant template

### DIFF
--- a/resources/services/observatorium-tenants-template.yaml
+++ b/resources/services/observatorium-tenants-template.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Template
 metadata:
+  annotations:
+    qontract.recycle: "true"
   name: ${SECRET_NAME}
 objects:
 - apiVersion: v1

--- a/services/observatorium-tenants-template.jsonnet
+++ b/services/observatorium-tenants-template.jsonnet
@@ -1,7 +1,12 @@
 {
   apiVersion: 'v1',
   kind: 'Template',
-  metadata: { name: '${SECRET_NAME}' },
+  metadata: {
+    name: '${SECRET_NAME}',
+    annotations: {
+      'qontract.recycle': 'true',
+    },
+  },
   objects: [
     {
       apiVersion: 'v1',


### PR DESCRIPTION
This makes it so that when a new version of the secret is rolled out, the pod that consumes this secret will be restarted.

Signed-off-by: Ian Billett <ibillett@redhat.com>