### PR TITLE
Fix RHODS read-only account in staging

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -61,10 +61,10 @@ func GenerateRBAC(gen *mimic.Generator) {
 
 	// RHODS
 	attachBinding(&obsRBAC, bindingOpts{
-		name:    "observatorium-rhods-isv",
+		name:    "rhods-isv-staging",
 		tenant:  rhodsTenant,
 		signals: []signal{metricsSignal},
-		perms:   []rbac.Permission{rbac.Write, rbac.Read},
+		perms:   []rbac.Permission{rbac.Read},
 		envs:    []env{stagingEnv},
 	})
 	attachBinding(&obsRBAC, bindingOpts{

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -417,13 +417,12 @@ objects:
           "name": "service-account-observatorium-cnv-qe-staging"
         - "kind": "user"
           "name": "service-account-observatorium-cnv-qe"
-      - "name": "observatorium-rhods-isv"
+      - "name": "rhods-isv-staging"
         "roles":
-        - "rhods-metrics-write"
         - "rhods-metrics-read"
         "subjects":
         - "kind": "user"
-          "name": "service-account-observatorium-rhods-isv-staging"
+          "name": "service-account-rhods-isv-staging-staging"
       - "name": "observatorium-rhods-isv-staging-wo"
         "roles":
         - "rhods-metrics-write"
@@ -564,16 +563,16 @@ objects:
         - "metrics"
         "tenants":
         - "cnvqe"
-      - "name": "rhods-metrics-write"
+      - "name": "rhods-metrics-read"
         "permissions":
-        - "write"
+        - "read"
         "resources":
         - "metrics"
         "tenants":
         - "rhods"
-      - "name": "rhods-metrics-read"
+      - "name": "rhods-metrics-write"
         "permissions":
-        - "read"
+        - "write"
         "resources":
         - "metrics"
         "tenants":


### PR DESCRIPTION
According to data provided to us by RHODS, their read-only service account client id in staging is `rhods-isv-staging`.

Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>