### PR TITLE
Fix ODFMS permissions

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -164,11 +164,11 @@ func GenerateRBAC(gen *mimic.Generator) {
 
 	// ODFMS
 	attachBinding(&obsRBAC, bindingOpts{
-		name:    "observatorium-odfms",
+		name:    "observatorium-odfms-write",
 		tenant:  odfmsTenant,
 		signals: []signal{metricsSignal},
 		perms:   []rbac.Permission{rbac.Write}, // Write only.
-		envs:    []env{stagingEnv, productionEnv},
+		envs:    []env{productionEnv},
 	})
 	// Special request of extra read account.
 	// Ref: https://issues.redhat.com/browse/MON-2536?focusedCommentId=20492830&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-20492830
@@ -177,8 +177,18 @@ func GenerateRBAC(gen *mimic.Generator) {
 		tenant:  odfmsTenant,
 		signals: []signal{metricsSignal},
 		perms:   []rbac.Permission{rbac.Read}, // Read only.
-		envs:    []env{stagingEnv, productionEnv},
+		envs:    []env{productionEnv},
 	})
+
+	// ODFMS has one set of staging credentials that has read & write permissions
+	attachBinding(&obsRBAC, bindingOpts{
+		name:    "observatorium-odfms",
+		tenant:  odfmsTenant,
+		signals: []signal{metricsSignal},
+		perms:   []rbac.Permission{rbac.Read, rbac.Write},
+		envs:    []env{stagingEnv},
+	})
+
 
 	// reference-addon
 	attachBinding(&obsRBAC, bindingOpts{

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -523,22 +523,25 @@ objects:
         "subjects":
         - "kind": "user"
           "name": "service-account-observatorium-rhoc-staging"
-      - "name": "observatorium-odfms"
+      - "name": "observatorium-odfms-write"
         "roles":
         - "odfms-metrics-write"
         "subjects":
         - "kind": "user"
-          "name": "service-account-observatorium-odfms-staging"
-        - "kind": "user"
-          "name": "service-account-observatorium-odfms"
+          "name": "service-account-observatorium-odfms-write"
       - "name": "observatorium-odfms-read"
         "roles":
         - "odfms-metrics-read"
         "subjects":
         - "kind": "user"
-          "name": "service-account-observatorium-odfms-read-staging"
-        - "kind": "user"
           "name": "service-account-observatorium-odfms-read"
+      - "name": "observatorium-odfms"
+        "roles":
+        - "odfms-metrics-read"
+        - "odfms-metrics-write"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-odfms-staging"
       - "name": "observatorium-reference-addon"
         "roles":
         - "reference-addon-metrics-write"


### PR DESCRIPTION
The ODFMS team have three service accounts:
* `observatorium-odfms-staging`
* `observatorium-odfms-read`
* `observatorium-odfms-write`

Due to the way we're now constructing service account names we generated the wrong service account name which was causing them not to be able to perform any read operations against staging.

Signed-off-by: Ian Billett <ibillett@redhat.com>