### PR TITLE
Add rhobs logs only tenants

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -20,6 +20,7 @@ const (
 	rhodsTenant      tenantID = "rhods"
 	rhacsTenant      tenantID = "rhacs"
 	rhocTenant       tenantID = "rhoc"
+	ocmTenant        tenantID = "ocm"
 	odfmsTenant      tenantID = "odfms"
 	refAddonTenant   tenantID = "reference-addon"
 	hypershiftTenant tenantID = "hypershift-platform"
@@ -226,6 +227,24 @@ func GenerateRBAC(gen *mimic.Generator) {
 	attachBinding(&obsRBAC, bindingOpts{
 		name:    "observatorium-dptp-collector",
 		tenant:  dptpTenant,
+		signals: []signal{logsSignal},
+		perms:   []rbac.Permission{rbac.Write},
+		envs:    []env{stagingEnv, productionEnv},
+	})
+
+	// OCM
+	// Reader serviceaccount
+	attachBinding(&obsRBAC, bindingOpts{
+		name:    "observatorium-ocm-reader",
+		tenant:  ocmTenant,
+		signals: []signal{logsSignal},
+		perms:   []rbac.Permission{rbac.Read},
+		envs:    []env{stagingEnv, productionEnv},
+	})
+	// Writer serviceaccount
+	attachBinding(&obsRBAC, bindingOpts{
+		name:    "observatorium-ocm-collector",
+		tenant:  ocmTenant,
 		signals: []signal{logsSignal},
 		perms:   []rbac.Permission{rbac.Write},
 		envs:    []env{stagingEnv, productionEnv},

--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -13,6 +13,7 @@ type tenantID string
 
 const (
 	cnvqeTenant      tenantID = "cnvqe"
+	dptpTenant       tenantID = "dptp"
 	telemeterTenant  tenantID = "telemeter"
 	rhobsTenant      tenantID = "rhobs"
 	psiocpTenant     tenantID = "psiocp"
@@ -207,6 +208,26 @@ func GenerateRBAC(gen *mimic.Generator) {
 		tenant:  hypershiftTenant,
 		signals: []signal{metricsSignal},
 		perms:   []rbac.Permission{rbac.Write, rbac.Read},
+		envs:    []env{stagingEnv, productionEnv},
+	})
+
+	// RHOBS Logs only tenants
+
+	// DPTP
+	// Reader serviceaccount
+	attachBinding(&obsRBAC, bindingOpts{
+		name:    "observatorium-dptp-reader",
+		tenant:  dptpTenant,
+		signals: []signal{logsSignal},
+		perms:   []rbac.Permission{rbac.Read},
+		envs:    []env{stagingEnv, productionEnv},
+	})
+	// Writer serviceaccount
+	attachBinding(&obsRBAC, bindingOpts{
+		name:    "observatorium-dptp-collector",
+		tenant:  dptpTenant,
+		signals: []signal{logsSignal},
+		perms:   []rbac.Permission{rbac.Write},
 		envs:    []env{stagingEnv, productionEnv},
 	})
 

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -578,6 +578,22 @@ objects:
           "name": "service-account-observatorium-dptp-collector-staging"
         - "kind": "user"
           "name": "service-account-observatorium-dptp-collector"
+      - "name": "observatorium-ocm-reader"
+        "roles":
+        - "ocm-logs-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-ocm-reader-staging"
+        - "kind": "user"
+          "name": "service-account-observatorium-ocm-reader"
+      - "name": "observatorium-ocm-collector"
+        "roles":
+        - "ocm-logs-write"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-ocm-collector-staging"
+        - "kind": "user"
+          "name": "service-account-observatorium-ocm-collector"
       "roles":
       - "name": "cnvqe-metrics-write"
         "permissions":
@@ -775,6 +791,20 @@ objects:
         - "logs"
         "tenants":
         - "dptp"
+      - "name": "ocm-logs-read"
+        "permissions":
+        - "read"
+        "resources":
+        - "logs"
+        "tenants":
+        - "ocm"
+      - "name": "ocm-logs-write"
+        "permissions":
+        - "write"
+        "resources":
+        - "logs"
+        "tenants":
+        - "ocm"
   kind: ConfigMap
   metadata:
     annotations:

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -562,6 +562,22 @@ objects:
           "name": "service-account-observatorium-hypershift-platform-staging"
         - "kind": "user"
           "name": "service-account-observatorium-hypershift-platform"
+      - "name": "observatorium-dptp-reader"
+        "roles":
+        - "dptp-logs-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-dptp-reader-staging"
+        - "kind": "user"
+          "name": "service-account-observatorium-dptp-reader"
+      - "name": "observatorium-dptp-collector"
+        "roles":
+        - "dptp-logs-write"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-dptp-collector-staging"
+        - "kind": "user"
+          "name": "service-account-observatorium-dptp-collector"
       "roles":
       - "name": "cnvqe-metrics-write"
         "permissions":
@@ -745,6 +761,20 @@ objects:
         - "metrics"
         "tenants":
         - "hypershift-platform"
+      - "name": "dptp-logs-read"
+        "permissions":
+        - "read"
+        "resources":
+        - "logs"
+        "tenants":
+        - "dptp"
+      - "name": "dptp-logs-write"
+        "permissions":
+        - "write"
+        "resources":
+        - "logs"
+        "tenants":
+        - "dptp"
   kind: ConfigMap
   metadata:
     annotations:


### PR DESCRIPTION
- Tenant DPTP is migrated from observatorium.api to observatorium-mst.api
- Tenant OCM is new for the PoC with AppSRE OCM team.