### PR TITLE
Bump up image

### DIFF
--- a/tests/integration_tests/Dockerfile
+++ b/tests/integration_tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/observatorium/up:master-2022-03-31-2aa26e9
+FROM quay.io/observatorium/up:master-2022-07-13-7f0630b
 
 RUN apk update &&\
     apk add curl jq


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Bumping the up image tag for post-delpoy job, to get https://github.com/observatorium/up/pull/45 fix in.