### PR TITLE
Revert "Allow Thanos Compact to ignore out of order labels"

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -142,7 +142,6 @@ objects:
           - --downsample.concurrency=1
           - --deduplication.replica-label=replica
           - --debug.max-compaction-level=3
-          - --debug.accept-malformed-index=true
           - ${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}
           env:
           - name: OBJSTORE_CONFIG

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -92,7 +92,7 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                   // Temporary workaround on high cardinality blocks for 2w.
                   // Since we have only 2w retention, there is no point in having 2w blocks.
                   // See: https://issues.redhat.com/browse/OBS-437
-                  args+: ['--debug.max-compaction-level=3'] + ['--debug.accept-malformed-index=true'] + disableDownsamplingFlag,
+                  args+: ['--debug.max-compaction-level=3'] + disableDownsamplingFlag,
                 } else c
                 for c in super.containers
               ],


### PR DESCRIPTION
Reverts rhobs/configuration#269.

The flag is already here, see https://github.com/rhobs/configuration/blob/af216ca2edb0a126b499697e56f3a6825a54e6af/resources/services/observatorium-metrics-template.yaml#L136.