### PR TITLE
Adjust E2E post-deploy job Dockerfile

### DIFF
--- a/tests/integration_tests/Dockerfile
+++ b/tests/integration_tests/Dockerfile
@@ -1,4 +1,11 @@
-FROM quay.io/observatorium/up:master-2022-07-13-7f0630b
+# This is a workaround since `up` images are now built with scratch,
+# meaning we cannot execture other commands. This copies `up` binary
+# and runs the tests in an Alpine-based container.
+FROM quay.io/observatorium/up:master-2022-07-13-7f0630b as source
+
+FROM alpine
+
+COPY --from=source /usr/bin/up /usr/bin/up
 
 RUN apk update &&\
     apk add curl jq


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

I have bumped the `up` image tag in our post-deploy job Dockerfile (https://github.com/rhobs/configuration/pull/272), without realizing that `up` has change it's based image to `scratch` (https://github.com/observatorium/up/pull/41).

The easiest way I found working around this (give that we do not really have proper releases for `up`) is to copy the `up` binary (desired version) to an Alpine container and run test in there.