### PR TITLE
Replace Alpine with Ubi

### DIFF
--- a/tests/integration_tests/Dockerfile
+++ b/tests/integration_tests/Dockerfile
@@ -3,12 +3,12 @@
 # and runs the tests in an Alpine-based container.
 FROM quay.io/observatorium/up:master-2022-07-13-7f0630b as source
 
-FROM alpine
+FROM quay.io/app-sre/ubi8-ubi-minimal
 
 COPY --from=source /usr/bin/up /usr/bin/up
 
-RUN apk update &&\
-    apk add curl jq
+RUN dnf update -y &&\
+    dnf install -y curl jq
 
 COPY ./tests/integration_tests/runtest.sh /tests/runtest.sh
 


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

AppSRE Interface apparently does not allow (actually, blocks) use of DockerHub images (https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/moving-off-of-docker-hub.md).

This PR is therefore to replace the test container to be `ubi` (from quay.io) instead of `alpine`.