### PR TITLE
E2E: Remove fail with body option from curl

### DIFF
--- a/tests/integration_tests/runtest.sh
+++ b/tests/integration_tests/runtest.sh
@@ -20,7 +20,6 @@ export UP_DURATION=${UP_DURATION:-30s}
 export UP_INITIAL_DELAY=${UP_INITIAL_DELAY:-5s}
 
 export TOKEN=$(curl \
-    --fail-with-body \
     --request POST  \
     --url ${OIDC_URL} \
     --header 'content-type: application/x-www-form-urlencoded' \


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Older versions of `curl` do not support this option, removing as this is currently causing tests to fail.