### PR TITLE
[rhobs-logs] Remove obsolete ams mappings for dptp and ocm tenants

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -920,9 +920,7 @@ objects:
           - --memcached=observatorium-api-cache-memcached.${NAMESPACE}.svc.cluster.local:11211
           - --memcached.expire=${OPA_AMS_MEMCACHED_EXPIRE}
           - --ams.mappings=cnvqe=${CNVQE_ORGANIZATION_ID}
-          - --ams.mappings=dptp=${DPTP_ORGANIZATION_ID}
           - --ams.mappings=managedkafka=${MANAGEDKAFKA_ORGANIZATION_ID}
-          - --ams.mappings=ocm=${OCM_ORGANIZATION_ID}
           - --ams.mappings=osd=${OSD_ORGANIZATION_ID}
           - --internal.tracing.endpoint=localhost:6831
           env:
@@ -1283,10 +1281,6 @@ parameters:
 - name: AMS_URL
   value: https://api.openshift.com
 - name: CNVQE_ORGANIZATION_ID
-  value: ""
-- name: DPTP_ORGANIZATION_ID
-  value: ""
-- name: OCM_ORGANIZATION_ID
   value: ""
 - name: GUBERNATOR_CPU_LIMIT
   value: 200m

--- a/services/observatorium-template.jsonnet
+++ b/services/observatorium-template.jsonnet
@@ -25,8 +25,6 @@ local obs = import 'observatorium.libsonnet';
     { name: 'OBSERVATORIUM_TRACES_NAMESPACE', value: 'observatorium-traces' },
     { name: 'AMS_URL', value: 'https://api.openshift.com' },
     { name: 'CNVQE_ORGANIZATION_ID', value: '' },
-    { name: 'DPTP_ORGANIZATION_ID', value: '' },
-    { name: 'OCM_ORGANIZATION_ID', value: '' },
     { name: 'GUBERNATOR_CPU_LIMIT', value: '200m' },
     { name: 'GUBERNATOR_CPU_REQUEST', value: '100m' },
     { name: 'GUBERNATOR_IMAGE_TAG', value: '1.0.0-rc.1' },

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -339,8 +339,6 @@ local rulesObjstore = (import 'github.com/observatorium/rules-objstore/jsonnet/l
       amsURL: '${AMS_URL}',
       mappings: {
         osd: '${OSD_ORGANIZATION_ID}',
-        dptp: '${DPTP_ORGANIZATION_ID}',
-        ocm: '${OCM_ORGANIZATION_ID}',
         managedkafka: '${MANAGEDKAFKA_ORGANIZATION_ID}',
         cnvqe: '${CNVQE_ORGANIZATION_ID}',
       },


### PR DESCRIPTION
The logs-only tenants DPTP and OCM were migrated into static rbac by #270 and this PR is a follow-up to cleanup AMS mappings.