### PR TITLE
Fix api logs dashboard

### DIFF
--- a/observability/dashboards/observatorium-api-logs.libsonnet
+++ b/observability/dashboards/observatorium-api-logs.libsonnet
@@ -106,7 +106,7 @@ function(datasource, namespace) {
             tableColumn: '',
             targets: [
               {
-                expr: 'sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",group="logsv1",handler=~"query|label|labels|label_values",le="1"}[28d]))\n/\nsum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",group="logsv1",handler=~"query|label|labels|label_values"}[28d]))',
+                expr: 'sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",group="logsv1",handler=~"query|label|labels|label_values",le="1"}[28d]))\n/\nsum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",group="logsv1",handler=~"query|label|labels|label_values"}[28d]))',
                 instant: true,
                 refId: 'A',
               },
@@ -191,7 +191,7 @@ function(datasource, namespace) {
             tableColumn: '',
             targets: [
               {
-                expr: 'sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",group="logsv1",handler="query",le="5",code!~"5.."}[28d]))\n/\nsum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",group="logsv1",handler="query"}[28d]))',
+                expr: 'sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",group="logsv1",handler="query",le="5",code!~"5.."}[28d]))\n/\nsum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",group="logsv1",handler="query"}[28d]))',
                 instant: true,
                 refId: 'A',
               },
@@ -277,7 +277,7 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'sum by (code) (rate(http_requests_total{job="observatorium-observatorium-api",group="logsv1",handler=~"query|label|labels|label_values"}[5m]))',
+                expr: 'sum by (code) (rate(http_requests_total{job="observatorium-observatorium-mst-api",group="logsv1",handler=~"query|label|labels|label_values"}[5m]))',
                 format: 'time_series',
                 intervalFactor: 1,
                 legendFormat: '{{code}}',
@@ -379,7 +379,7 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'sum(rate(http_requests_total{job="observatorium-observatorium-api",group="logsv1",handler=~"query|label|labels|label_values",code=~"5.."}[5m]))\n/\nsum(rate(http_requests_total{job="observatorium-observatorium-api",group="logsv1",handler=~"query|label|labels|label_values"}[5m]))',
+                expr: 'sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="logsv1",handler=~"query|label|labels|label_values",code=~"5.."}[5m]))\n/\nsum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="logsv1",handler=~"query|label|labels|label_values"}[5m]))',
                 format: 'time_series',
                 intervalFactor: 1,
                 legendFormat: 'errors',
@@ -492,21 +492,21 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",group="logsv1",handler=~"query|label|labels|label_values",code!~"5.."}[5m])))',
+                expr: 'histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",group="logsv1",handler=~"query|label|labels|label_values",code!~"5.."}[5m])))',
                 format: 'time_series',
                 intervalFactor: 1,
                 legendFormat: '99th',
                 refId: 'A',
               },
               {
-                expr: 'histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",group="logsv1",handler=~"query|label|labels|label_values",code!~"5.."}[5m])))',
+                expr: 'histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",group="logsv1",handler=~"query|label|labels|label_values",code!~"5.."}[5m])))',
                 format: 'time_series',
                 intervalFactor: 1,
                 legendFormat: '95th',
                 refId: 'B',
               },
               {
-                expr: 'histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",group="logsv1",handler=~"query|label|labels|label_values",code!~"5.."}[5m])))',
+                expr: 'histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",group="logsv1",handler=~"query|label|labels|label_values",code!~"5.."}[5m])))',
                 format: 'time_series',
                 intervalFactor: 1,
                 legendFormat: '50th',
@@ -810,7 +810,7 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'sum by (code) (rate(http_requests_total{job="observatorium-observatorium-api",group="logsv1",handler="query_range"}[5m]))',
+                expr: 'sum by (code) (rate(http_requests_total{job="observatorium-observatorium-mst-api",group="logsv1",handler="query_range"}[5m]))',
                 format: 'time_series',
                 intervalFactor: 1,
                 legendFormat: '{{code}}',
@@ -912,7 +912,7 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'sum(rate(http_requests_total{job="observatorium-observatorium-api",group="logsv1",handler="query_range",code=~"5.."}[5m])) / \nsum(rate(http_requests_total{job="observatorium-observatorium-api",group="logsv1",handler="query_range"}[5m]))',
+                expr: 'sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="logsv1",handler="query_range",code=~"5.."}[5m])) / \nsum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="logsv1",handler="query_range"}[5m]))',
                 format: 'time_series',
                 intervalFactor: 1,
                 legendFormat: 'errors',
@@ -1025,21 +1025,21 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",group="logsv1",code!~"5..",handler="query_range"}[5m])))',
+                expr: 'histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",group="logsv1",code!~"5..",handler="query_range"}[5m])))',
                 format: 'time_series',
                 intervalFactor: 1,
                 legendFormat: '99th',
                 refId: 'A',
               },
               {
-                expr: 'histogram_quantile(0.9, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",group="logsv1",code!~"5..",handler="query_range"}[5m])))',
+                expr: 'histogram_quantile(0.9, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",group="logsv1",code!~"5..",handler="query_range"}[5m])))',
                 format: 'time_series',
                 intervalFactor: 1,
                 legendFormat: '90th',
                 refId: 'B',
               },
               {
-                expr: 'histogram_quantile(0.5, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",group="logsv1",code!~"5..",handler="query_range"}[5m])))',
+                expr: 'histogram_quantile(0.5, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",group="logsv1",code!~"5..",handler="query_range"}[5m])))',
                 format: 'time_series',
                 intervalFactor: 1,
                 legendFormat: '50th',
@@ -1174,7 +1174,7 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'sum by (code) (rate(http_requests_total{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler"}[5m]))',
+                expr: 'sum by (code) (rate(http_requests_total{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler"}[5m]))',
                 legendFormat: '{{ code }}',
                 refId: 'A',
               },
@@ -1273,7 +1273,7 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'sum(rate(http_requests_total{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler",code=~"5.."}[5m]))\n/\nsum(rate(http_requests_total{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler"}[5m]))',
+                expr: 'sum(rate(http_requests_total{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler",code=~"5.."}[5m]))\n/\nsum(rate(http_requests_total{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler"}[5m]))',
                 legendFormat: 'errors',
                 refId: 'A',
               },
@@ -1382,17 +1382,17 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
+                expr: 'histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
                 legendFormat: 'p50',
                 refId: 'C',
               },
               {
-                expr: 'histogram_quantile(0.90, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
+                expr: 'histogram_quantile(0.90, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
                 legendFormat: 'p90',
                 refId: 'B',
               },
               {
-                expr: 'histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
+                expr: 'histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
                 legendFormat: 'p99',
                 refId: 'A',
               },
@@ -1530,7 +1530,7 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'sum by (code) (rate(http_requests_total{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler"}[5m]))',
+                expr: 'sum by (code) (rate(http_requests_total{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler"}[5m]))',
                 legendFormat: '{{ code }}',
                 refId: 'A',
               },
@@ -1632,7 +1632,7 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'sum(rate(http_requests_total{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler",code=~"5.."}[5m]))\n/\nsum(rate(http_requests_total{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler"}[5m]))',
+                expr: 'sum(rate(http_requests_total{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler",code=~"5.."}[5m]))\n/\nsum(rate(http_requests_total{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler"}[5m]))',
                 legendFormat: 'errors',
                 refId: 'A',
               },
@@ -1744,17 +1744,17 @@ function(datasource, namespace) {
             steppedLine: false,
             targets: [
               {
-                expr: 'histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
+                expr: 'histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
                 legendFormat: 'p50',
                 refId: 'C',
               },
               {
-                expr: 'histogram_quantile(0.90, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
+                expr: 'histogram_quantile(0.90, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
                 legendFormat: 'p90',
                 refId: 'B',
               },
               {
-                expr: 'histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
+                expr: 'histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api", namespace="$namespace", group="logsv1", handler=~"$handler",code!~"5.."}[5m])))',
                 legendFormat: 'p99',
                 refId: 'A',
               },
@@ -1866,14 +1866,14 @@ function(datasource, namespace) {
                 ],
               },
               datasource: '$datasource',
-              definition: 'label_values(http_requests_total{job="observatorium-observatorium-api", group="logsv1", namespace="$namespace"}, handler)',
+              definition: 'label_values(http_requests_total{job="observatorium-observatorium-mst-api", group="logsv1", namespace="$namespace"}, handler)',
               hide: 0,
               includeAll: true,
               label: null,
               multi: true,
               name: 'handler',
               options: [],
-              query: 'label_values(http_requests_total{job="observatorium-observatorium-api", group="logsv1", namespace="$namespace"}, handler)',
+              query: 'label_values(http_requests_total{job="observatorium-observatorium-mst-api", group="logsv1", namespace="$namespace"}, handler)',
               refresh: 1,
               regex: '(query.*|label.*|push)',
               skipUrlSync: false,

--- a/resources/observability/grafana/observatorium-logs/grafana-dashboards-template.yaml
+++ b/resources/observability/grafana/observatorium-logs/grafana-dashboards-template.yaml
@@ -114,7 +114,7 @@ objects:
             "tableColumn": "",
             "targets": [
               {
-                "expr": "sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\",le=\"1\"}[28d]))\n/\nsum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\"}[28d]))",
+                "expr": "sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\",le=\"1\"}[28d]))\n/\nsum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\"}[28d]))",
                 "instant": true,
                 "refId": "A"
               }
@@ -203,7 +203,7 @@ objects:
             "tableColumn": "",
             "targets": [
               {
-                "expr": "sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=\"query\",le=\"5\",code!~\"5..\"}[28d]))\n/\nsum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=\"query\"}[28d]))",
+                "expr": "sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",le=\"5\",code!~\"5..\"}[28d]))\n/\nsum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\"}[28d]))",
                 "instant": true,
                 "refId": "A"
               }
@@ -293,7 +293,7 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum by (code) (rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\"}[5m]))",
+                "expr": "sum by (code) (rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\"}[5m]))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "{{code}}",
@@ -405,7 +405,7 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\",code=~\"5..\"}[5m]))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\"}[5m]))",
+                "expr": "sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\",code=~\"5..\"}[5m]))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\"}[5m]))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "errors",
@@ -528,21 +528,21 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\",code!~\"5..\"}[5m])))",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\",code!~\"5..\"}[5m])))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "99th",
                 "refId": "A"
               },
               {
-                "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\",code!~\"5..\"}[5m])))",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\",code!~\"5..\"}[5m])))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "95th",
                 "refId": "B"
               },
               {
-                "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\",code!~\"5..\"}[5m])))",
+                "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query|label|labels|label_values\",code!~\"5..\"}[5m])))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "50th",
@@ -866,7 +866,7 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum by (code) (rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=\"query_range\"}[5m]))",
+                "expr": "sum by (code) (rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query_range\"}[5m]))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "{{code}}",
@@ -978,7 +978,7 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=\"query_range\",code=~\"5..\"}[5m])) / \nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"logsv1\",handler=\"query_range\"}[5m]))",
+                "expr": "sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query_range\",code=~\"5..\"}[5m])) / \nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query_range\"}[5m]))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "errors",
@@ -1101,21 +1101,21 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",group=\"logsv1\",code!~\"5..\",handler=\"query_range\"}[5m])))",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",code!~\"5..\",handler=\"query_range\"}[5m])))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "99th",
                 "refId": "A"
               },
               {
-                "expr": "histogram_quantile(0.9, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",group=\"logsv1\",code!~\"5..\",handler=\"query_range\"}[5m])))",
+                "expr": "histogram_quantile(0.9, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",code!~\"5..\",handler=\"query_range\"}[5m])))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "90th",
                 "refId": "B"
               },
               {
-                "expr": "histogram_quantile(0.5, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",group=\"logsv1\",code!~\"5..\",handler=\"query_range\"}[5m])))",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",code!~\"5..\",handler=\"query_range\"}[5m])))",
                 "format": "time_series",
                 "intervalFactor": 1,
                 "legendFormat": "50th",
@@ -1262,7 +1262,7 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum by (code) (rate(http_requests_total{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\"}[5m]))",
+                "expr": "sum by (code) (rate(http_requests_total{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\"}[5m]))",
                 "legendFormat": "{{ code }}",
                 "refId": "A"
               }
@@ -1371,7 +1371,7 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(http_requests_total{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code=~\"5..\"}[5m]))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\"}[5m]))",
+                "expr": "sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code=~\"5..\"}[5m]))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\"}[5m]))",
                 "legendFormat": "errors",
                 "refId": "A"
               }
@@ -1490,17 +1490,17 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
+                "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
                 "legendFormat": "p50",
                 "refId": "C"
               },
               {
-                "expr": "histogram_quantile(0.90, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
+                "expr": "histogram_quantile(0.90, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
                 "legendFormat": "p90",
                 "refId": "B"
               },
               {
-                "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
                 "legendFormat": "p99",
                 "refId": "A"
               }
@@ -1650,7 +1650,7 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum by (code) (rate(http_requests_total{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\"}[5m]))",
+                "expr": "sum by (code) (rate(http_requests_total{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\"}[5m]))",
                 "legendFormat": "{{ code }}",
                 "refId": "A"
               }
@@ -1762,7 +1762,7 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(rate(http_requests_total{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code=~\"5..\"}[5m]))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\"}[5m]))",
+                "expr": "sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code=~\"5..\"}[5m]))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\"}[5m]))",
                 "legendFormat": "errors",
                 "refId": "A"
               }
@@ -1884,17 +1884,17 @@ objects:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
+                "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
                 "legendFormat": "p50",
                 "refId": "C"
               },
               {
-                "expr": "histogram_quantile(0.90, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
+                "expr": "histogram_quantile(0.90, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
                 "legendFormat": "p90",
                 "refId": "B"
               },
               {
-                "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\", namespace=\"$namespace\", group=\"logsv1\", handler=~\"$handler\",code!~\"5..\"}[5m])))",
                 "legendFormat": "p99",
                 "refId": "A"
               }
@@ -2014,7 +2014,7 @@ objects:
                 ]
               },
               "datasource": "$datasource",
-              "definition": "label_values(http_requests_total{job=\"observatorium-observatorium-api\", group=\"logsv1\", namespace=\"$namespace\"}, handler)",
+              "definition": "label_values(http_requests_total{job=\"observatorium-observatorium-mst-api\", group=\"logsv1\", namespace=\"$namespace\"}, handler)",
               "hide": 0,
               "includeAll": true,
               "label": null,
@@ -2023,7 +2023,7 @@ objects:
               "options": [
 
               ],
-              "query": "label_values(http_requests_total{job=\"observatorium-observatorium-api\", group=\"logsv1\", namespace=\"$namespace\"}, handler)",
+              "query": "label_values(http_requests_total{job=\"observatorium-observatorium-mst-api\", group=\"logsv1\", namespace=\"$namespace\"}, handler)",
               "refresh": 1,
               "regex": "(query.*|label.*|push)",
               "skipUrlSync": false,


### PR DESCRIPTION
Switch dashboard queries to use the new job name for loki on MST is `observatorium-obsrvatorium-mst-api`.
