### PR TITLE
Post-deploy job: Parametrize metrics labels

### DIFF
--- a/tests/integration_tests/post-deploy-job-template.yaml
+++ b/tests/integration_tests/post-deploy-job-template.yaml
@@ -32,6 +32,8 @@ objects:
                       key: client_secret
                 - name: OBSERVATORIUM_API_URL
                   value: ${API_URL}
+                - name: METRIC_LABELS
+                  value: ${METRIC_LABELS}
         restartPolicy: Never
 parameters:
 - name: SUFFIX
@@ -40,7 +42,7 @@ parameters:
 - name: IMAGE
   value: 'quay.io/app-sre/rhobs-e2e'
 - name: IMAGE_TAG
-  value: "e21a7ce"
+  value: 'e21a7ce'
 - name: JOBID
   generate: expression
   from: "[0-9a-f]{7}"
@@ -48,3 +50,5 @@ parameters:
   value: 'secret'
 - name: API_URL
   value: 'observatorium.api'
+- name: METRIC_LABELS
+  value: '_id=\"test\"'


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

This parametrizes the metrics label, which will be leveraged in the AppSRE Interface to differentiate labels per namespace test. The aim is ensure there are no clashes / false positives in case of multiple concurrent test runs.
