### PR TITLE
[rhobs-logs] Add missing qontract.recycle annotation for configmap

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -714,6 +714,8 @@ objects:
     overrides.yaml: '{}'
   kind: ConfigMap
   metadata:
+    annotations:
+      qontract.recycle: "true"
     labels:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: loki

--- a/services/observatorium-logs-template-overwrites.libsonnet
+++ b/services/observatorium-logs-template-overwrites.libsonnet
@@ -59,7 +59,15 @@ local jaegerAgentSidecar = (import 'sidecars/jaeger-agent.libsonnet')({
     manifests+:: {
       [name]+:
         local m = super[name];
-        if m.kind == 'StatefulSet' && std.length(std.findSubstr('querier', name)) != 0 then
+        if m.kind == 'ConfigMap' then
+          m {
+            metadata+: {
+              annotations+: {
+                'qontract.recycle': 'true',
+              },
+            },
+          }
+        else if m.kind == 'StatefulSet' && std.length(std.findSubstr('querier', name)) != 0 then
           m {
             spec+: {
               template+: {


### PR DESCRIPTION
Sets the `qontract.recycle` to `true` for the Loki ConfigMap to enable restarting the components on changes.