### PR TITLE
Fix breaking change between Parca version

### DIFF
--- a/resources/services/parca-template.yaml
+++ b/resources/services/parca-template.yaml
@@ -150,7 +150,7 @@ objects:
           - /parca
           - --config-path=/var/parca/parca.yaml
           - --log-level=info
-          - --storage-tsdb-retention-time=${RETENTION_TIME}
+          - --storage-active-memory=${STORAGE_ACTIVE_MEMORY}
           image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             exec:
@@ -353,5 +353,5 @@ parameters:
   value: 200Mi
 - name: SERVICE_ACCOUNT_NAME
   value: observatorium
-- name: RETENTION_TIME
-  value: 12h
+- name: STORAGE_ACTIVE_MEMORY
+  value: "7000000000"

--- a/services/parca-template.jsonnet
+++ b/services/parca-template.jsonnet
@@ -257,7 +257,7 @@ local proxyContainer = {
               serviceAccountName: config.serviceAccountName,
               containers: [
                 super.containers[0] {
-                  args+: ['--storage-tsdb-retention-time=${RETENTION_TIME}'],
+                  args+: ['--storage-active-memory=${STORAGE_ACTIVE_MEMORY}'],
                   resources: {
                     requests: {
                       cpu: '${PARCA_CPU_REQUEST}',
@@ -320,7 +320,7 @@ local proxyContainer = {
       { name: 'PARCA_PROXY_CPU_LIMITS', value: '200m' },
       { name: 'PARCA_PROXY_MEMORY_LIMITS', value: '200Mi' },
       { name: 'SERVICE_ACCOUNT_NAME', value: 'observatorium' },
-      { name: 'RETENTION_TIME', value: '12h' },
+      { name: 'STORAGE_ACTIVE_MEMORY', value: '7000000000' },
     ],
   },
   'parca-observatorium-remote-ns-rbac-template': {


### PR DESCRIPTION
There is a breaking change between 0.11.x and 0.12.0
TSDB has been removed in favour of column storage
so corresponding flag has been removed.