### PR TITLE
Telemeter: Bump jsonnet version

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -233,8 +233,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "91bff806c60507a1f806b9dc48bd64b83c2d9cb6",
-      "sum": "k4Tv/+U6SM/5pEIYCrFtlNa+tbsrl3rR5Iw5rIH5olQ="
+      "version": "21355f9d5b6f4f06b4bb8f7cf655b552a112aaf6",
+      "sum": "OVRpwHQyHP6Ba7x7cM6Jhe4wi/0uPR65wZtHp2HStso="
     },
     {
       "source": {

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -439,7 +439,7 @@ objects:
   data:
     observatorium.yaml: |-
       "groups":
-      - "interval": "1m"
+      - "interval": "3m"
         "name": "telemeter-telemeter.rules"
         "rules":
         - "expr": |


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Bump version to include changes from https://github.com/openshift/telemeter/pull/417, i.e. bumping rules eval interval to `3m`.