### PR TITLE
Bump Telemeter jsonnet version to latest

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -233,8 +233,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "21355f9d5b6f4f06b4bb8f7cf655b552a112aaf6",
-      "sum": "OVRpwHQyHP6Ba7x7cM6Jhe4wi/0uPR65wZtHp2HStso="
+      "version": "dbfc19afe778f1311860dfe9ebf0e94b403de9de",
+      "sum": "jPX3JQZndZSVPDmkW2HZEib7/oeuVpxGOB/rXSgyOcI="
     },
     {
       "source": {

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -439,7 +439,7 @@ objects:
   data:
     observatorium.yaml: |-
       "groups":
-      - "interval": "3m"
+      - "interval": "4m"
         "name": "telemeter-telemeter.rules"
         "rules":
         - "expr": |


### PR DESCRIPTION
This PR bumps Telemeter jsonnet version to get https://github.com/openshift/telemeter/pull/420.