### PR TITLE
[rhobs] Rename ocm tenant as appsre

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -12,6 +12,7 @@ import (
 type tenantID string
 
 const (
+	appsreTenant     tenantID = "appsre"
 	cnvqeTenant      tenantID = "cnvqe"
 	dptpTenant       tenantID = "dptp"
 	telemeterTenant  tenantID = "telemeter"
@@ -20,7 +21,6 @@ const (
 	rhodsTenant      tenantID = "rhods"
 	rhacsTenant      tenantID = "rhacs"
 	rhocTenant       tenantID = "rhoc"
-	ocmTenant        tenantID = "ocm"
 	odfmsTenant      tenantID = "odfms"
 	refAddonTenant   tenantID = "reference-addon"
 	hypershiftTenant tenantID = "hypershift-platform"
@@ -232,22 +232,14 @@ func GenerateRBAC(gen *mimic.Generator) {
 		envs:    []env{stagingEnv, productionEnv},
 	})
 
-	// OCM
-	// Reader serviceaccount
+	// APPSRE
+	// Reader and Writer serviceaccount
 	attachBinding(&obsRBAC, bindingOpts{
-		name:    "observatorium-ocm-reader",
-		tenant:  ocmTenant,
+		name:    "observatorium-appsre",
+		tenant:  appsreTenant,
 		signals: []signal{logsSignal},
-		perms:   []rbac.Permission{rbac.Read},
-		envs:    []env{stagingEnv, productionEnv},
-	})
-	// Writer serviceaccount
-	attachBinding(&obsRBAC, bindingOpts{
-		name:    "observatorium-ocm-collector",
-		tenant:  ocmTenant,
-		signals: []signal{logsSignal},
-		perms:   []rbac.Permission{rbac.Write},
-		envs:    []env{stagingEnv, productionEnv},
+		perms:   []rbac.Permission{rbac.Read, rbac.Write},
+		envs:    []env{stagingEnv},
 	})
 
 	// Use JSON because we want to have jsonnet using that in configmaps/secrets.

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -578,22 +578,13 @@ objects:
           "name": "service-account-observatorium-dptp-collector-staging"
         - "kind": "user"
           "name": "service-account-observatorium-dptp-collector"
-      - "name": "observatorium-ocm-reader"
+      - "name": "observatorium-appsre"
         "roles":
-        - "ocm-logs-read"
+        - "appsre-logs-read"
+        - "appsre-logs-write"
         "subjects":
         - "kind": "user"
-          "name": "service-account-observatorium-ocm-reader-staging"
-        - "kind": "user"
-          "name": "service-account-observatorium-ocm-reader"
-      - "name": "observatorium-ocm-collector"
-        "roles":
-        - "ocm-logs-write"
-        "subjects":
-        - "kind": "user"
-          "name": "service-account-observatorium-ocm-collector-staging"
-        - "kind": "user"
-          "name": "service-account-observatorium-ocm-collector"
+          "name": "service-account-observatorium-appsre-staging"
       "roles":
       - "name": "cnvqe-metrics-write"
         "permissions":
@@ -791,20 +782,20 @@ objects:
         - "logs"
         "tenants":
         - "dptp"
-      - "name": "ocm-logs-read"
+      - "name": "appsre-logs-read"
         "permissions":
         - "read"
         "resources":
         - "logs"
         "tenants":
-        - "ocm"
-      - "name": "ocm-logs-write"
+        - "appsre"
+      - "name": "appsre-logs-write"
         "permissions":
         - "write"
         "resources":
         - "logs"
         "tenants":
-        - "ocm"
+        - "appsre"
   kind: ConfigMap
   metadata:
     annotations:


### PR DESCRIPTION
OCM Team decided to rename to tenant `appsre`. This tenant was and is still unused so renaming has no impact on any system.