### PR TITLE
Bump rules-objstore replicas to 2

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -169,7 +169,7 @@ objects:
       app.kubernetes.io/version: ${RULES_OBJSTORE_IMAGE_TAG}
     name: rules-objstore
   spec:
-    replicas: 1
+    replicas: 2
     selector:
       matchLabels:
         app.kubernetes.io/component: rules-storage

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -154,7 +154,7 @@ local rulesObjstore = (import 'github.com/observatorium/rules-objstore/jsonnet/l
     name: 'rules-objstore',
     version: '${RULES_OBJSTORE_IMAGE_TAG}',
     image: '%s:%s' % ['${RULES_OBJSTORE_IMAGE}', cfg.version],
-    replicas: 1,
+    replicas: 2,
     objectStorageConfig: {
       name: '${RULES_OBJSTORE_SECRET}',
       key: 'objstore.yaml',


### PR DESCRIPTION
This PR increases the number of rules-objstore replicas to 2, for better resiliency.