### PR TITLE
Add Rules and Alertmanager SLOs

### DIFF
--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -510,8 +510,8 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of alerts are successfully delivered to upstream targets',
       0.95,
-      'sum(alertmanager_notifications_failed_total{service="observatorium-alertmanager", namespace="%s"})' % instance.upNamespace,
-      'sum(alertmanager_notifications_total{service="observatorium-alertmanager", namespace="%s"})' % instance.upNamespace,
+      'sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager", namespace="%s"}[28d]))' % instance.upNamespace,
+      'sum(rate(alertmanager_notifications_total{service="observatorium-alertmanager", namespace="%s"}[28d]))' % instance.upNamespace,
       14
     ),
   local apiLogsPanels =

--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -479,8 +479,8 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of rules are successfully synced to Thanos Ruler',
       0.95,
-      'sum(rate(client_api_requests_total{client="oauth",namespace="%s",code=~"5.+"}[28d]))' % instance.upNamespace,
-      'sum(rate(client_api_requests_total{client="oauth",namespace="%s",code!~"4.+"}[28d]))' % instance.upNamespace,
+      'sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="%s",code=~"5.+"}[28d]))' % instance.upNamespace,
+      'sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="%s",code!~"4.+"}[28d]))' % instance.upNamespace,
       10
     ) +
     titleRow('API > Rules Read (/rules) > Availability') +

--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -392,7 +392,7 @@ function(instanceName, environment, dashboardName) {
       '95% of valid requests return successfully',
       0.95,
       'sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code="5xx"}[28d]))',
-      'sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive", code!="4xx"}[28d]))',
+      'sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code!="4xx"}[28d]))',
       0
     ) +
     titleRow('Telemeter Server > Metrics Write > Latency') +
@@ -400,7 +400,7 @@ function(instanceName, environment, dashboardName) {
       '90% of valid requests return < 5s',
       0.9,
       5,
-      'sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive", code!~"4..", le="5"}[28d]))',
+      'sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code!~"4..",le="5"}[28d]))',
       'rate(http_request_duration_seconds_bucket{job="telemeter-server",code!~"4..",handler=~"upload|receive"}[28d])',
       'sum(rate(http_request_duration_seconds_count{job="telemeter-server",code!~"4..",handler=~"upload|receive"}[28d]))',
       1
@@ -410,8 +410,8 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of valid requests return successfully',
       0.95,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"receive", code=~"5.+"}[28d]))' % instance.apiJob,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"receive", code!~"4.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"receive",code=~"5.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"receive",code!~"4.+"}[28d]))' % instance.apiJob,
       2
     ) +
     titleRow('API > Metrics Write > Latency') +
@@ -419,7 +419,7 @@ function(instanceName, environment, dashboardName) {
       '90% of valid requests return < 5s',
       0.9,
       5,
-      'sum(rate(http_request_duration_seconds_bucket{job="%s",code!~"4..",group="metricsv1",handler=~"receive", le="5"}[28d]))' % instance.apiJob,
+      'sum(rate(http_request_duration_seconds_bucket{job="%s",code!~"4..",group="metricsv1",handler=~"receive",le="5"}[28d]))' % instance.apiJob,
       'rate(http_request_duration_seconds_bucket{job="%s",code!~"4..",group="metricsv1",handler=~"receive"}[28d])' % instance.apiJob,
       'sum(rate(http_request_duration_seconds_count{job="%s",code!~"4..",group="metricsv1",handler=~"receive"}[28d]))' % instance.apiJob,
       3
@@ -428,15 +428,15 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of valid /query requests return successfully',
       0.95,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler="query", code=~"5.+"}[28d]))' % instance.apiJob,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler="query", code!~"4.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler="query",code=~"5.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler="query",code!~"4.+"}[28d]))' % instance.apiJob,
       4
     ) +
     availabilityRow(
       '95% of valid /query_range requests return successfully',
       0.95,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"query_range", code=~"5.+"}[28d]))' % instance.apiJob,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"query_range", code!~"4.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"query_range",code=~"5.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"query_range",code!~"4.+"}[28d]))' % instance.apiJob,
       5
     ) +
     titleRow('API > Metrics Read > Latency') +
@@ -471,32 +471,32 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of valid write requests return successfully',
       0.95,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules-raw", code=~"5.+", method=~"PUT"}[28d]))' % instance.apiJob,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules-raw", code!~"4.+", method=~"PUT"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules-raw",code=~"5.+",method=~"PUT"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules-raw",code!~"4.+",method=~"PUT"}[28d]))' % instance.apiJob,
       9
     ) +
-    titleRow('API > Rules Write > Availability') +
+    titleRow('API > Rules Sync > Availability') +
     availabilityRow(
       '95% of rules are successfully synced to Thanos Ruler',
       0.95,
-      'sum(thanos_rule_loaded_rules{container="thanos-rule",namespace="%s"}) < 0' % instance.upNamespace,
-      'sum(prometheus_rule_group_rules{job="observatorium-thanos-rule",namespace="%s"})' % instance.upNamespace,
+      'sum(rate(client_api_requests_total{client="oauth",namespace="%s",code=~"5.+"}[28d]))' % instance.upNamespace,
+      'sum(rate(client_api_requests_total{client="oauth",namespace="%s",code!~"4.+"}[28d]))' % instance.upNamespace,
       10
     ) +
     titleRow('API > Rules Read (/rules) > Availability') +
     availabilityRow(
       '90% of valid requests return successfully',
       0.9,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules", code=~"5.+"}[28d]))' % instance.apiJob,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules", code!~"4.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules",code=~"5.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules",code!~"4.+"}[28d]))' % instance.apiJob,
       11
     ) +
     titleRow('API > Rules Read (/rules/raw) > Availability') +
     availabilityRow(
       '90% of valid requests return successfully',
       0.9,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules-raw", code=~"5.+"}[28d]))' % instance.apiJob,
-      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules-raw", code!~"4.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules-raw",code=~"5.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules-raw",code!~"4.+"}[28d]))' % instance.apiJob,
       12
     ) +
     titleRow('API > Alerting > Availability') +
@@ -510,8 +510,8 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of alerts are successfully delivered to upstream targets',
       0.95,
-      'sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager", namespace="%s"}[28d]))' % instance.upNamespace,
-      'sum(rate(alertmanager_notifications_total{service="observatorium-alertmanager", namespace="%s"}[28d]))' % instance.upNamespace,
+      'sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="%s"}[28d]))' % instance.upNamespace,
+      'sum(rate(alertmanager_notifications_total{service="observatorium-alertmanager",namespace="%s"}[28d]))' % instance.upNamespace,
       14
     ),
   local apiLogsPanels =
@@ -519,8 +519,8 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of valid requests return successfully',
       0.95,
-      'sum(rate(http_requests_total{job="%s",group="logsv1",handler=~"push", code=~"5.+"}[28d]))' % instance.apiJob,
-      'sum(rate(http_requests_total{job="%s",group="logsv1",handler=~"push", code!~"4.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="logsv1",handler=~"push",code=~"5.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="logsv1",handler=~"push",code!~"4.+"}[28d]))' % instance.apiJob,
       2
     ) +
     titleRow('API > Logs Write > Latency') +
@@ -528,7 +528,7 @@ function(instanceName, environment, dashboardName) {
       '90% of valid requests return < 5s',
       0.9,
       5,
-      'sum(rate(http_request_duration_seconds_bucket{job="%s",code!~"4..",group="logsv1",handler=~"push", le="5"}[28d]))' % instance.apiJob,
+      'sum(rate(http_request_duration_seconds_bucket{job="%s",code!~"4..",group="logsv1",handler=~"push",le="5"}[28d]))' % instance.apiJob,
       'rate(http_request_duration_seconds_bucket{job="%s",code!~"4..",group="logsv1",handler=~"push"}[28d])' % instance.apiJob,
       'sum(rate(http_request_duration_seconds_count{job="%s",code!~"4..",group="logsv1",handler=~"push"}[28d]))' % instance.apiJob,
       3
@@ -537,15 +537,15 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of valid /query requests return successfully',
       0.95,
-      'sum(rate(http_requests_total{job="%s",group="logsv1",handler="query", code=~"5.+"}[28d]))' % instance.apiJob,
-      'sum(rate(http_requests_total{job="%s",group="logsv1",handler="query", code!~"4.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="logsv1",handler="query",code=~"5.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="logsv1",handler="query",code!~"4.+"}[28d]))' % instance.apiJob,
       4
     ) +
     availabilityRow(
       '95% of valid /query_range requests return successfully',
       0.95,
-      'sum(rate(http_requests_total{job="%s",group="logsv1",handler=~"query_range", code=~"5.+"}[28d]))' % instance.apiJob,
-      'sum(rate(http_requests_total{job="%s",group="logsv1",handler=~"query_range", code!~"4.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="logsv1",handler=~"query_range",code=~"5.+"}[28d]))' % instance.apiJob,
+      'sum(rate(http_requests_total{job="%s",group="logsv1",handler=~"query_range",code!~"4.+"}[28d]))' % instance.apiJob,
       5
     ),
 

--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -9,11 +9,13 @@ function(instanceName, environment, dashboardName) {
         datasource: 'telemeter-prod-01-prometheus',
         upNamespace: 'observatorium-production',
         apiJob: 'observatorium-observatorium-api',
+        metricsNamespace: 'observatorium-metrics-production',
       },
       stage: {
         datasource: 'app-sre-stage-01-prometheus',
         upNamespace: 'observatorium-stage',
         apiJob: 'observatorium-observatorium-api',
+        metricsNamespace: 'observatorium-metrics-stage',
       },
     },
     mst: {
@@ -30,6 +32,7 @@ function(instanceName, environment, dashboardName) {
     },
   },
   local instance = instanceConfig[instanceName][environment],
+  local instanceNamespace(name) = if name == 'telemeter' then instance.metricsNamespace else instance.upNamespace,
   // This is part of a dirty hack because I can't figure out how to do an auto-incrementing counter in Jsonnet.
   // Each grafana dashboard that requests data needs a unique ID, we use the panels per row + a unqiue index per panel
   // to generate a continuous stream of integers from 0...
@@ -479,8 +482,8 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of rules are successfully synced to Thanos Ruler',
       0.95,
-      'sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="%s",code=~"5.+"}[28d]))' % instance.upNamespace,
-      'sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="%s",code!~"4.+"}[28d]))' % instance.upNamespace,
+      'sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="%s",code=~"5.+"}[28d]))' % instanceNamespace(instanceName),
+      'sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="%s",code!~"4.+"}[28d]))' % instanceNamespace(instanceName),
       10
     ) +
     titleRow('API > Rules Read (/rules) > Availability') +
@@ -503,15 +506,15 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of alerts are successfully delivered to Alertmanager',
       0.95,
-      'sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="%s"}[28d]))' % instance.upNamespace,
-      'sum(rate(thanos_alert_sender_alerts_sent_total{container="thanos-rule",namespace="%s"}[28d]))' % instance.upNamespace,
+      'sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="%s"}[28d]))' % instanceNamespace(instanceName),
+      'sum(rate(thanos_alert_sender_alerts_sent_total{container="thanos-rule",namespace="%s"}[28d]))' % instanceNamespace(instanceName),
       13
     ) +
     availabilityRow(
       '95% of alerts are successfully delivered to upstream targets',
       0.95,
-      'sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="%s"}[28d]))' % instance.upNamespace,
-      'sum(rate(alertmanager_notifications_total{service="observatorium-alertmanager",namespace="%s"}[28d]))' % instance.upNamespace,
+      'sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="%s"}[28d]))' % instanceNamespace(instanceName),
+      'sum(rate(alertmanager_notifications_total{service="observatorium-alertmanager",namespace="%s"}[28d]))' % instanceNamespace(instanceName),
       14
     ),
   local apiLogsPanels =

--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -557,7 +557,7 @@ function(instanceName, environment, dashboardName) {
   data: {
     'slo.json': std.manifestJson({
       // Only add telemeter-server panels if we're generating SLOs for the telemeter instance.
-      // Only add API Logs and alerting panels if we're generating SLOs for the mst instance.
+      // Only add API Logs panels if we're generating SLOs for the mst instance.
       panels: titlePanel +
               (if instanceName == 'telemeter' then telemeterPanels else []) +
               apiPanels +

--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -466,8 +466,7 @@ function(instanceName, environment, dashboardName) {
       'rate(up_custom_query_duration_seconds_bucket{namespace="%s",query="query-path-sli-100M-samples"}[1d])' % instance.upNamespace,
       'sum(rate(up_custom_query_duration_seconds_count{namespace="%s",query="query-path-sli-100M-samples"}[28d]))' % instance.upNamespace,
       8
-    ),
-  local apiRulesPanels =
+    ) +
     titleRow('API > Rules Write (/rules/raw) > Availability') +
     availabilityRow(
       '95% of valid write requests return successfully',
@@ -499,8 +498,7 @@ function(instanceName, environment, dashboardName) {
       'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules-raw", code=~"5.+"}[28d]))' % instance.apiJob,
       'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"rules-raw", code!~"4.+"}[28d]))' % instance.apiJob,
       12
-    ),
-  local apiAlertingPanels =
+    ) +
     titleRow('API > Alerting > Availability') +
     availabilityRow(
       '95% of alerts are successfully delivered to Alertmanager',
@@ -563,7 +561,7 @@ function(instanceName, environment, dashboardName) {
       panels: titlePanel +
               (if instanceName == 'telemeter' then telemeterPanels else []) +
               apiPanels +
-              (if instanceName == 'mst' then apiRulesPanels + apiAlertingPanels + apiLogsPanels else []),
+              (if instanceName == 'mst' then apiLogsPanels else []),
       refresh: false,
       schemaVersion: 31,
       style: 'dark',

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
@@ -1247,7 +1247,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\",method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\",method=~\"PUT\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1319,7 +1319,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\",method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\",method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
@@ -102,7 +102,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -174,7 +174,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -341,7 +341,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\", le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\",le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -436,7 +436,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -508,7 +508,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -595,7 +595,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -667,7 +667,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1247,7 +1247,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1319,7 +1319,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1334,7 +1334,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Rules Write > Availability",
+                "title": "API > Rules Sync > Availability",
                 "type": "row"
             },
             {
@@ -1414,7 +1414,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}) < 0 or vector(0))\n/\nsum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-mst-production\"})\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1486,7 +1486,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}) < 0 or vector(0))\n        /\n        sum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-mst-production\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1581,7 +1581,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1653,7 +1653,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1748,7 +1748,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1820,7 +1820,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2074,7 +2074,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-production\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2146,7 +2146,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2241,7 +2241,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2313,7 +2313,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2480,7 +2480,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\", le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\",le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2575,7 +2575,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2647,7 +2647,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2734,7 +2734,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2806,7 +2806,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
@@ -2074,7 +2074,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}) or vector(0))\n/\nsum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"})\n",
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2146,7 +2146,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}) or vector(0))\n        /\n        sum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
@@ -1414,7 +1414,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1486,7 +1486,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
@@ -1414,7 +1414,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1486,7 +1486,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
@@ -1167,6 +1167,1000 @@ data:
                 "panels": [
 
                 ],
+                "title": "API > Rules Write (/rules/raw) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid write requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 18,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 19,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Write > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of rules are successfully synced to Thanos Ruler</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 20,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}) < 0 or vector(0))\n/\nsum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-mst-production\"})\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 21,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}) < 0 or vector(0))\n        /\n        sum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-mst-production\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Read (/rules) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 22,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 23,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Read (/rules/raw) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 24,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 25,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Alerting > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of alerts are successfully delivered to Alertmanager</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 26,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n/\nsum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 27,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n        /\n        sum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of alerts are successfully delivered to upstream targets</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 28,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}) or vector(0))\n/\nsum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"})\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 29,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"}) or vector(0))\n        /\n        sum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-production\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
                 "title": "API > Logs Write > Availability",
                 "type": "row"
             },

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
@@ -1167,6 +1167,1000 @@ data:
                 "panels": [
 
                 ],
+                "title": "API > Rules Write (/rules/raw) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid write requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 18,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 19,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Write > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of rules are successfully synced to Thanos Ruler</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 20,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-mst-stage\"}) < 0 or vector(0))\n/\nsum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-mst-stage\"})\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 21,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-mst-stage\"}) < 0 or vector(0))\n        /\n        sum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-mst-stage\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Read (/rules) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 22,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 23,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Read (/rules/raw) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 24,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 25,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Alerting > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of alerts are successfully delivered to Alertmanager</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 26,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-mst-stage\"}[28d])) or vector(0))\n/\nsum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-mst-stage\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 27,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-mst-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-mst-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of alerts are successfully delivered to upstream targets</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 28,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}) or vector(0))\n/\nsum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"})\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 29,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}) or vector(0))\n        /\n        sum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
                 "title": "API > Logs Write > Availability",
                 "type": "row"
             },

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
@@ -2074,7 +2074,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}) or vector(0))\n/\nsum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"})\n",
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2146,7 +2146,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}) or vector(0))\n        /\n        sum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
@@ -1247,7 +1247,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\",method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\",method=~\"PUT\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1319,7 +1319,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\",method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\",method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
@@ -1414,7 +1414,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1486,7 +1486,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
@@ -1414,7 +1414,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-stage\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-stage\",code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1486,7 +1486,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-stage\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-stage\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-stage\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
@@ -102,7 +102,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -174,7 +174,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -341,7 +341,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\", le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\",le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -436,7 +436,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -508,7 +508,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -595,7 +595,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -667,7 +667,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1247,7 +1247,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1319,7 +1319,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1334,7 +1334,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Rules Write > Availability",
+                "title": "API > Rules Sync > Availability",
                 "type": "row"
             },
             {
@@ -1414,7 +1414,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-mst-stage\"}) < 0 or vector(0))\n/\nsum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-mst-stage\"})\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-stage\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-stage\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1486,7 +1486,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-mst-stage\"}) < 0 or vector(0))\n        /\n        sum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-mst-stage\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-stage\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-mst-stage\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1581,7 +1581,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1653,7 +1653,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1748,7 +1748,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1820,7 +1820,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2074,7 +2074,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-stage\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-stage\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2146,7 +2146,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-mst-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2241,7 +2241,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2313,7 +2313,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2480,7 +2480,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\", le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\",le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2575,7 +2575,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2647,7 +2647,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2734,7 +2734,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2806,7 +2806,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
@@ -1748,7 +1748,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-production\",code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-production\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1820,7 +1820,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
@@ -1581,7 +1581,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\",method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\",method=~\"PUT\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1653,7 +1653,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\",method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\",method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
@@ -1495,6 +1495,1000 @@ data:
                 ],
                 "title": "Error Budget (28d)",
                 "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Write (/rules/raw) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid write requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 18,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 19,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Write > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of rules are successfully synced to Thanos Ruler</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 20,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-production\"}) < 0 or vector(0))\n/\nsum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-production\"})\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 21,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-production\"}) < 0 or vector(0))\n        /\n        sum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-production\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Read (/rules) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 22,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 23,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Read (/rules/raw) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 24,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 25,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Alerting > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of alerts are successfully delivered to Alertmanager</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 26,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-production\"}[28d])) or vector(0))\n/\nsum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-production\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 27,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-production\"}[28d])) or vector(0))\n        /\n        sum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of alerts are successfully delivered to upstream targets</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 28,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}) or vector(0))\n/\nsum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"})\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 29,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}) or vector(0))\n        /\n        sum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
             }
         ],
         "refresh": false,

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
@@ -1748,7 +1748,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-production\",code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-metrics-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-metrics-production\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1820,7 +1820,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-metrics-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-metrics-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2249,7 +2249,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-production\"}[28d])) or vector(0))\n/\nsum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-production\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-metrics-production\"}[28d])) or vector(0))\n/\nsum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-metrics-production\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2321,7 +2321,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-production\"}[28d])) or vector(0))\n        /\n        sum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-metrics-production\"}[28d])) or vector(0))\n        /\n        sum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-metrics-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2408,7 +2408,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-production\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-production\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-metrics-production\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-metrics-production\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2480,7 +2480,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-production\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-metrics-production\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-metrics-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
@@ -2408,7 +2408,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}) or vector(0))\n/\nsum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"})\n",
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2480,7 +2480,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}) or vector(0))\n        /\n        sum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
@@ -102,7 +102,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0))\n/\nsum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\", code!=\"4xx\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0))\n/\nsum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code!=\"4xx\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -174,7 +174,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0))\n        /\n        sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\", code!=\"4xx\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0))\n        /\n        sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code!=\"4xx\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -341,7 +341,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"telemeter-server\",handler=~\"upload|receive\", code!~\"4..\", le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"telemeter-server\",code!~\"4..\",handler=~\"upload|receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"telemeter-server\",handler=~\"upload|receive\",code!~\"4..\",le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"telemeter-server\",code!~\"4..\",handler=~\"upload|receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -436,7 +436,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -508,7 +508,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -675,7 +675,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\", le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\",le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -770,7 +770,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -842,7 +842,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -929,7 +929,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1001,7 +1001,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1581,7 +1581,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1653,7 +1653,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1668,7 +1668,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Rules Write > Availability",
+                "title": "API > Rules Sync > Availability",
                 "type": "row"
             },
             {
@@ -1748,7 +1748,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-production\"}) < 0 or vector(0))\n/\nsum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-production\"})\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-production\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1820,7 +1820,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-production\"}) < 0 or vector(0))\n        /\n        sum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-production\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1915,7 +1915,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1987,7 +1987,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\",code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2082,7 +2082,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2154,7 +2154,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2408,7 +2408,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-production\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-production\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2480,7 +2480,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-production\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
@@ -1748,7 +1748,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-stage\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-stage\",code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-metrics-stage\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-metrics-stage\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1820,7 +1820,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-stage\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-stage\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-metrics-stage\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-metrics-stage\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2249,7 +2249,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-stage\"}[28d])) or vector(0))\n/\nsum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-stage\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-metrics-stage\"}[28d])) or vector(0))\n/\nsum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-metrics-stage\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2321,7 +2321,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-metrics-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-metrics-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2408,7 +2408,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-stage\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-stage\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-metrics-stage\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-metrics-stage\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2480,7 +2480,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-metrics-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-metrics-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
@@ -1748,7 +1748,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-stage\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-stage\",code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-stage\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-stage\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1820,7 +1820,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-stage\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-stage\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-stage\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",container=\"thanos-rule-syncer\",namespace=\"observatorium-stage\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
@@ -1581,7 +1581,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\",method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\",method=~\"PUT\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1653,7 +1653,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\",method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\",method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
@@ -102,7 +102,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0))\n/\nsum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\", code!=\"4xx\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0))\n/\nsum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code!=\"4xx\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -174,7 +174,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0))\n        /\n        sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\", code!=\"4xx\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code=\"5xx\"}[28d])) or vector(0))\n        /\n        sum(rate(haproxy_server_http_responses_total{route=~\"telemeter-server-upload|telemeter-server-metrics-v1-receive\",code!=\"4xx\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -341,7 +341,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"telemeter-server\",handler=~\"upload|receive\", code!~\"4..\", le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"telemeter-server\",code!~\"4..\",handler=~\"upload|receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"telemeter-server\",handler=~\"upload|receive\",code!~\"4..\",le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"telemeter-server\",code!~\"4..\",handler=~\"upload|receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -436,7 +436,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -508,7 +508,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"receive\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -675,7 +675,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\", le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\",le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -770,7 +770,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -842,7 +842,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -929,7 +929,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1001,7 +1001,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\", code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1581,7 +1581,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1653,7 +1653,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1668,7 +1668,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Rules Write > Availability",
+                "title": "API > Rules Sync > Availability",
                 "type": "row"
             },
             {
@@ -1748,7 +1748,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-stage\"}) < 0 or vector(0))\n/\nsum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-stage\"})\n",
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-stage\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-stage\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1820,7 +1820,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-stage\"}) < 0 or vector(0))\n        /\n        sum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-stage\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-stage\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"oauth\",namespace=\"observatorium-stage\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -1915,7 +1915,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1987,7 +1987,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\",code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2082,7 +2082,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2154,7 +2154,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",
@@ -2408,7 +2408,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}[28d]))\n",
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-stage\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-stage\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2480,7 +2480,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
@@ -1495,6 +1495,1000 @@ data:
                 ],
                 "title": "Error Budget (28d)",
                 "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Write (/rules/raw) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid write requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 18,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 19,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\", method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\", method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Write > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of rules are successfully synced to Thanos Ruler</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 20,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-stage\"}) < 0 or vector(0))\n/\nsum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-stage\"})\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 21,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(thanos_rule_loaded_rules{container=\"thanos-rule\",namespace=\"observatorium-stage\"}) < 0 or vector(0))\n        /\n        sum(prometheus_rule_group_rules{job=\"observatorium-thanos-rule\",namespace=\"observatorium-stage\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Read (/rules) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 22,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 23,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Read (/rules/raw) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 24,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 25,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-api\",group=\"metricsv1\",handler=~\"rules-raw\", code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Alerting > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of alerts are successfully delivered to Alertmanager</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 26,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-stage\"}[28d])) or vector(0))\n/\nsum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-stage\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 27,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of alerts are successfully delivered to upstream targets</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 28,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}) or vector(0))\n/\nsum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"})\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 29,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}) or vector(0))\n        /\n        sum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
             }
         ],
         "refresh": false,

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
@@ -2408,7 +2408,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "1-\n(sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}) or vector(0))\n/\nsum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"})\n",
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}[28d]))\n",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -2480,7 +2480,7 @@ data:
                 "targets": [
                     {
                         "exemplar": true,
-                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}) or vector(0))\n        /\n        sum(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"})\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\", namespace=\"observatorium-stage\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",


### PR DESCRIPTION
This PR adds availability SLOs for Rules (/rules and /rules/raw) and Observatorium Alertmanager, for Telemeter and MST instances. Ticket: https://issues.redhat.com/browse/MON-2474 

~~The panels for /rules/raw have no data yet, because it depends on the handler label added in https://github.com/observatorium/api/pull/361 to be deployed.~~
I think also we'll have better measurements once we have more data (provided by synthetic data generation)

I'll add a separate PR for alerts to make it easier to review.
