### PR TITLE
Add alerts for Rules and Alerting SLOs

### DIFF
--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -1,3 +1,5 @@
+local utils = import '../utils.jsonnet';
+
 function(instanceName, environment, dashboardName) {
   // Validate our inputs.
   assert std.member(['telemeter', 'mst'], instanceName),
@@ -23,16 +25,17 @@ function(instanceName, environment, dashboardName) {
         datasource: 'telemeter-prod-01-prometheus',
         upNamespace: 'observatorium-mst-production',
         apiJob: 'observatorium-observatorium-mst-api',
+        metricsNamespace: 'observatorium-metrics-production',
       },
       stage: {
         datasource: 'app-sre-stage-01-prometheus',
         upNamespace: 'observatorium-mst-stage',
         apiJob: 'observatorium-observatorium-mst-api',
+        metricsNamespace: 'observatorium-metrics-stage',
       },
     },
   },
   local instance = instanceConfig[instanceName][environment],
-  local instanceNamespace(name) = if name == 'telemeter' then instance.metricsNamespace else instance.upNamespace,
   // This is part of a dirty hack because I can't figure out how to do an auto-incrementing counter in Jsonnet.
   // Each grafana dashboard that requests data needs a unique ID, we use the panels per row + a unqiue index per panel
   // to generate a continuous stream of integers from 0...
@@ -482,8 +485,8 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of rules are successfully synced to Thanos Ruler',
       0.95,
-      'sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="%s",code=~"5.+"}[28d]))' % instanceNamespace(instanceName),
-      'sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="%s",code!~"4.+"}[28d]))' % instanceNamespace(instanceName),
+      'sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="%s",code=~"5.+"}[28d]))' % utils.instanceNamespace(instanceName, instance.metricsNamespace, instance.upNamespace),
+      'sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="%s",code!~"4.+"}[28d]))' % utils.instanceNamespace(instanceName, instance.metricsNamespace, instance.upNamespace),
       10
     ) +
     titleRow('API > Rules Read (/rules) > Availability') +
@@ -506,15 +509,15 @@ function(instanceName, environment, dashboardName) {
     availabilityRow(
       '95% of alerts are successfully delivered to Alertmanager',
       0.95,
-      'sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="%s"}[28d]))' % instanceNamespace(instanceName),
-      'sum(rate(thanos_alert_sender_alerts_sent_total{container="thanos-rule",namespace="%s"}[28d]))' % instanceNamespace(instanceName),
+      'sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="%s"}[28d]))' % utils.instanceNamespace(instanceName, instance.metricsNamespace, instance.upNamespace),
+      'sum(rate(thanos_alert_sender_alerts_sent_total{container="thanos-rule",namespace="%s"}[28d]))' % utils.instanceNamespace(instanceName, instance.metricsNamespace, instance.upNamespace),
       13
     ) +
     availabilityRow(
       '95% of alerts are successfully delivered to upstream targets',
       0.95,
-      'sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="%s"}[28d]))' % instanceNamespace(instanceName),
-      'sum(rate(alertmanager_notifications_total{service="observatorium-alertmanager",namespace="%s"}[28d]))' % instanceNamespace(instanceName),
+      'sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="%s"}[28d]))' % utils.instanceNamespace(instanceName, instance.metricsNamespace, instance.upNamespace),
+      'sum(rate(alertmanager_notifications_total{service="observatorium-alertmanager",namespace="%s"}[28d]))' % utils.instanceNamespace(instanceName, instance.metricsNamespace, instance.upNamespace),
       14
     ),
   local apiLogsPanels =

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -370,6 +370,78 @@ local renderAlerts(name, environment, mixin) = {
           }),
         ],
       },
+      {
+        name: 'rhobs-' + instance + '-api-rules-raw-write-availability.slo',
+        slos: [
+          slo.errorburn({
+            alertName: 'APIRulesRawWriteAvailabilityErrorBudgetBurning',
+            alertMessage: 'API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs',
+            metric: 'http_requests_total',
+            selectors: [apiJobSelector, 'group="metricsv1"', 'handler="rules-raw"', 'code=~"^(2..|3..|5..)$"', 'method=~"PUT"'],
+            errorSelectors: ['code=~"5.+"'],
+            target: 0.95,
+          }),
+        ],
+      },
+      {
+        name: 'rhobs-' + instance + '-api-rules-sync-availability.slo',
+        slos: [
+          slo.errorburn({
+            alertName: 'APIRulesSyncAvailabilityErrorBudgetBurning',
+            alertMessage: 'API /reload endpoint is burning too much error budget to guarantee availability SLOs',
+            metric: 'client_api_requests_total',
+            selectors: ['client="oauth"', upNamespaceSelector, 'code=~"^(2..|3..|5..)$"'],
+            errorSelectors: ['code=~"5.+"'],
+            target: 0.95,
+          }),
+        ],
+      },
+      {
+        name: 'rhobs-' + instance + '-api-rules-read-availability.slo',
+        slos: [
+          slo.errorburn({
+            alertName: 'APIRulesReadAvailabilityErrorBudgetBurning',
+            alertMessage: 'API /rules endpoint is burning too much error budget to guarantee availability SLOs',
+            metric: 'http_requests_total',
+            selectors: [apiJobSelector, 'group="metricsv1"', 'handler=~"rules"', 'code=~"^(2..|3..|5..)$"'],
+            errorSelectors: ['code=~"5.+"'],
+            target: 0.90,
+          }),
+        ],
+      },
+      {
+
+        name: 'rhobs-' + instance + '-api-rules-raw-read-availability.slo',
+        slos: [
+          slo.errorburn({
+            alertName: 'APIRulesRawReadAvailabilityErrorBudgetBurning',
+            alertMessage: 'API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs',
+            metric: 'http_requests_total',
+            selectors: [apiJobSelector, 'group="metricsv1"', 'handler=~"rules-raw"', 'code=~"^(2..|3..|5..)$"'],
+            errorSelectors: ['code=~"5.+"'],
+            target: 0.90,
+          }),
+        ],
+      },
+      {
+        name: 'rhobs-' + instance + '-api-alerting-availability.slo',
+        slos: [
+          slo.errorburn({
+            alertName: 'APIAlertmanagerAvailabilityErrorBudgetBurning',
+            alertMessage: 'API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs',
+            metric: 'thanos_alert_sender_alerts_dropped_total',
+            selectors: ['container="thanos-rule"', upNamespaceSelector],
+            target: 0.95,
+          }),
+          slo.errorburn({
+            alertName: 'APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning',
+            alertMessage: 'API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs',
+            metric: 'alertmanager_notifications_failed_total',
+            selectors: ['service="observatorium-alertmanager"', upNamespaceSelector],
+            target: 0.95,
+          }),
+        ],
+      },
     ],
   },
 

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -390,7 +390,7 @@ local renderAlerts(name, environment, mixin) = {
             alertName: 'APIRulesSyncAvailabilityErrorBudgetBurning',
             alertMessage: 'API /reload endpoint is burning too much error budget to guarantee availability SLOs',
             metric: 'client_api_requests_total',
-            selectors: ['client="oauth"', upNamespaceSelector, 'code=~"^(2..|3..|5..)$"'],
+            selectors: ['client="oauth"', 'container="thanos-rule-syncer"', upNamespaceSelector, 'code=~"^(2..|3..|5..)$"'],
             errorSelectors: ['code=~"5.+"'],
             target: 0.95,
           }),

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -288,9 +288,12 @@ local renderAlerts(name, environment, mixin) = {
     },
   ],
 
-  local apiSLOs = function(instance, upNamespace, apiJob) {
+  local apiSLOs = function(instance, upNamespace, metricsNamespace, apiJob) {
     local apiJobSelector = 'job="' + apiJob + '"',
     local upNamespaceSelector = 'namespace="' + upNamespace + '"',
+    local metricsNamespaceSelector = 'namespace="' + metricsNamespace + '"',
+    local instanceNamespace(name) = if instance == 'telemeter' then metricsNamespaceSelector else upNamespaceSelector,
+
     slos: [
       {
         name: 'rhobs-' + instance + '-api-metrics-write-availability.slo',
@@ -390,7 +393,7 @@ local renderAlerts(name, environment, mixin) = {
             alertName: 'APIRulesSyncAvailabilityErrorBudgetBurning',
             alertMessage: 'API /reload endpoint is burning too much error budget to guarantee availability SLOs',
             metric: 'client_api_requests_total',
-            selectors: ['client="oauth"', 'container="thanos-rule-syncer"', upNamespaceSelector, 'code=~"^(2..|3..|5..)$"'],
+            selectors: ['client="reload"', 'container="thanos-rule-syncer"', instanceNamespace(instance), 'code=~"^(2..|3..|5..)$"'],
             errorSelectors: ['code=~"5.+"'],
             target: 0.95,
           }),
@@ -430,14 +433,14 @@ local renderAlerts(name, environment, mixin) = {
             alertName: 'APIAlertmanagerAvailabilityErrorBudgetBurning',
             alertMessage: 'API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs',
             metric: 'thanos_alert_sender_alerts_dropped_total',
-            selectors: ['container="thanos-rule"', upNamespaceSelector],
+            selectors: ['container="thanos-rule"', instanceNamespace(instance)],
             target: 0.95,
           }),
           slo.errorburn({
             alertName: 'APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning',
             alertMessage: 'API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs',
             metric: 'alertmanager_notifications_failed_total',
-            selectors: ['service="observatorium-alertmanager"', upNamespaceSelector],
+            selectors: ['service="observatorium-alertmanager"', instanceNamespace(instance)],
             target: 0.95,
           }),
         ],
@@ -445,14 +448,14 @@ local renderAlerts(name, environment, mixin) = {
     ],
   },
 
-  local mstStageSLOs = apiSLOs('mst', 'observatorium-mst-stage', 'observatorium-observatorium-mst-api').slos,
-  local mstProductionSLOs = apiSLOs('mst', 'observatorium-mst-production', 'observatorium-observatorium-mst-api').slos,
+  local mstStageSLOs = apiSLOs('mst', 'observatorium-mst-stage', 'observatorium-mst-stage', 'observatorium-observatorium-mst-api').slos,
+  local mstProductionSLOs = apiSLOs('mst', 'observatorium-mst-production', 'observatorium-mst-production', 'observatorium-observatorium-mst-api').slos,
 
   'rhobs-slos-mst-stage.prometheusrules': renderAlerts('rhobs-slos-mst-stage', 'stage', flatten(mstStageSLOs)),
   'rhobs-slos-mst-production.prometheusrules': renderAlerts('rhobs-slos-mst-production', 'production', flatten(mstProductionSLOs)),
 
-  local telemeterStageSLOs = telemeterServerSLOs + apiSLOs('telemeter', 'observatorium-stage', 'observatorium-observatorium-api').slos,
-  local telemeterProductionSLOs = telemeterServerSLOs + apiSLOs('telemeter', 'observatorium-production', 'observatorium-observatorium-api').slos,
+  local telemeterStageSLOs = telemeterServerSLOs + apiSLOs('telemeter', 'observatorium-stage', 'observatorium-metrics-stage', 'observatorium-observatorium-api').slos,
+  local telemeterProductionSLOs = telemeterServerSLOs + apiSLOs('telemeter', 'observatorium-production', 'observatorium-metrics-production', 'observatorium-observatorium-api').slos,
 
   'rhobs-slos-telemeter-stage.prometheusrules': renderAlerts('rhobs-slos-telemeter-stage', 'stage', flatten(telemeterStageSLOs)),
   'rhobs-slos-telemeter-production.prometheusrules': renderAlerts('rhobs-slos-telemeter-production', 'production', flatten(telemeterProductionSLOs)),

--- a/observability/utils.jsonnet
+++ b/observability/utils.jsonnet
@@ -1,0 +1,3 @@
+{
+  instanceNamespace(name, metricsNamespace, upNamespace): if name == 'telemeter' then metricsNamespace else upNamespace,
+}

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -1047,13 +1047,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
@@ -1063,13 +1064,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
@@ -1079,13 +1081,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: telemeter
         severity: medium
@@ -1095,77 +1098,85 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate6h
   - name: rhobs-mst-api-rules-read-availability.slo

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -1047,12 +1047,12 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
@@ -1064,12 +1064,12 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
@@ -1081,12 +1081,12 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
@@ -1098,83 +1098,83 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-production

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -899,3 +899,760 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
+  - name: rhobs-mst-api-rules-raw-write-availability.slo
+    rules:
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+        service: telemeter
+        severity: critical
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+        service: telemeter
+        severity: critical
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+        service: telemeter
+        severity: medium
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate6h
+  - name: rhobs-mst-api-rules-sync-availability.slo
+    rules:
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate5m{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate1h{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: critical
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate30m{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: critical
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate2h{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate1d{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate3d{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+      record: client_api_requests_total:burnrate1d
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+      record: client_api_requests_total:burnrate1h
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+      record: client_api_requests_total:burnrate2h
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+      record: client_api_requests_total:burnrate30m
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+      record: client_api_requests_total:burnrate3d
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+      record: client_api_requests_total:burnrate5m
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-production
+      record: client_api_requests_total:burnrate6h
+  - name: rhobs-mst-api-rules-read-availability.slo
+    rules:
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: critical
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: critical
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-mst-api-rules-raw-read-availability.slo
+    rules:
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: critical
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: critical
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-mst-api-alerting-availability.slo
+    rules:
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate5m{container="thanos-rule",namespace="observatorium-mst-production"}) > (14.40 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-mst-production"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: critical
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate30m{container="thanos-rule",namespace="observatorium-mst-production"}) > (6.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-mst-production"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: critical
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate2h{container="thanos-rule",namespace="observatorium-mst-production"}) > (3.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-mst-production"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-mst-production"}) > (1.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-mst-production"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[1d]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[1d]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate1d
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[1h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[1h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate1h
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[2h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[2h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate2h
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[30m]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[30m]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate30m
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[3d]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[3d]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate3d
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[5m]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[5m]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate5m
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[6h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[6h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate6h
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate5m{service="observatorium-alertmanager",namespace="observatorium-mst-production"}) > (14.40 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate1h{service="observatorium-alertmanager",namespace="observatorium-mst-production"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: critical
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate30m{service="observatorium-alertmanager",namespace="observatorium-mst-production"}) > (6.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-mst-production"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: critical
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate2h{service="observatorium-alertmanager",namespace="observatorium-mst-production"}) > (3.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate1d{service="observatorium-alertmanager",namespace="observatorium-mst-production"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-mst-production"}) > (1.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate3d{service="observatorium-alertmanager",namespace="observatorium-mst-production"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        namespace: observatorium-mst-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[1d]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[1d]))
+      labels:
+        namespace: observatorium-mst-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate1d
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[1h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[1h]))
+      labels:
+        namespace: observatorium-mst-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate1h
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[2h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[2h]))
+      labels:
+        namespace: observatorium-mst-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate2h
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[30m]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[30m]))
+      labels:
+        namespace: observatorium-mst-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate30m
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[3d]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[3d]))
+      labels:
+        namespace: observatorium-mst-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate3d
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[5m]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[5m]))
+      labels:
+        namespace: observatorium-mst-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate5m
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[6h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[6h]))
+      labels:
+        namespace: observatorium-mst-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate6h

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -1047,12 +1047,12 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
@@ -1064,12 +1064,12 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
@@ -1081,12 +1081,12 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
@@ -1098,83 +1098,83 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -899,3 +899,760 @@ spec:
         namespace: observatorium-mst-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
+  - name: rhobs-mst-api-rules-raw-write-availability.slo
+    rules:
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+        service: telemeter
+        severity: high
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+        service: telemeter
+        severity: high
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+        service: telemeter
+        severity: medium
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        method: PUT
+      record: http_requests_total:burnrate6h
+  - name: rhobs-mst-api-rules-sync-availability.slo
+    rules:
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate5m{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate1h{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: high
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate30m{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: high
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate2h{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate1d{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: medium
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate3d{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+      record: client_api_requests_total:burnrate1d
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+      record: client_api_requests_total:burnrate1h
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+      record: client_api_requests_total:burnrate2h
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+      record: client_api_requests_total:burnrate30m
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+      record: client_api_requests_total:burnrate3d
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+      record: client_api_requests_total:burnrate5m
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-mst-stage
+      record: client_api_requests_total:burnrate6h
+  - name: rhobs-mst-api-rules-read-availability.slo
+    rules:
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: high
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: high
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-mst-api-rules-raw-read-availability.slo
+    rules:
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: high
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: high
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-mst-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-mst-api-alerting-availability.slo
+    rules:
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate5m{container="thanos-rule",namespace="observatorium-mst-stage"}) > (14.40 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-mst-stage"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: high
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate30m{container="thanos-rule",namespace="observatorium-mst-stage"}) > (6.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-mst-stage"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: high
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate2h{container="thanos-rule",namespace="observatorium-mst-stage"}) > (3.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-mst-stage"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: medium
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-mst-stage"}) > (1.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-mst-stage"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[1d]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[1d]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate1d
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[1h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[1h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate1h
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[2h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[2h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate2h
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[30m]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[30m]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate30m
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[3d]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[3d]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate3d
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[5m]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[5m]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate5m
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[6h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[6h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-mst-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate6h
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate5m{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}) > (14.40 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate1h{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: high
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate30m{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}) > (6.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: high
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate2h{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}) > (3.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate1d{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: medium
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}) > (1.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate3d{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        namespace: observatorium-mst-stage
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[1d]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[1d]))
+      labels:
+        namespace: observatorium-mst-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate1d
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[1h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[1h]))
+      labels:
+        namespace: observatorium-mst-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate1h
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[2h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[2h]))
+      labels:
+        namespace: observatorium-mst-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate2h
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[30m]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[30m]))
+      labels:
+        namespace: observatorium-mst-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate30m
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[3d]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[3d]))
+      labels:
+        namespace: observatorium-mst-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate3d
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[5m]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[5m]))
+      labels:
+        namespace: observatorium-mst-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate5m
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[6h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[6h]))
+      labels:
+        namespace: observatorium-mst-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate6h

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -1047,13 +1047,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
         service: telemeter
         severity: high
@@ -1063,13 +1064,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
         service: telemeter
         severity: high
@@ -1079,13 +1081,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
@@ -1095,77 +1098,85 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate6h
   - name: rhobs-mst-api-rules-read-availability.slo

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -1151,3 +1151,760 @@ spec:
         namespace: observatorium-production
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
+  - name: rhobs-telemeter-api-rules-raw-write-availability.slo
+    rules:
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+        service: telemeter
+        severity: critical
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+        service: telemeter
+        severity: critical
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+        service: telemeter
+        severity: medium
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate6h
+  - name: rhobs-telemeter-api-rules-sync-availability.slo
+    rules:
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate5m{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate1h{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+        service: telemeter
+        severity: critical
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate30m{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+        service: telemeter
+        severity: critical
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate2h{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate1d{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+        service: telemeter
+        severity: medium
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate3d{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+      record: client_api_requests_total:burnrate1d
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+      record: client_api_requests_total:burnrate1h
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+      record: client_api_requests_total:burnrate2h
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+      record: client_api_requests_total:burnrate30m
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+      record: client_api_requests_total:burnrate3d
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+      record: client_api_requests_total:burnrate5m
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-production
+      record: client_api_requests_total:burnrate6h
+  - name: rhobs-telemeter-api-rules-read-availability.slo
+    rules:
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: critical
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: critical
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-telemeter-api-rules-raw-read-availability.slo
+    rules:
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: critical
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: critical
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-telemeter-api-alerting-availability.slo
+    rules:
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate5m{container="thanos-rule",namespace="observatorium-production"}) > (14.40 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-production"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+        service: telemeter
+        severity: critical
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate30m{container="thanos-rule",namespace="observatorium-production"}) > (6.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-production"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+        service: telemeter
+        severity: critical
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate2h{container="thanos-rule",namespace="observatorium-production"}) > (3.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-production"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+        service: telemeter
+        severity: medium
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-production"}) > (1.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-production"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[1d]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[1d]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate1d
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[1h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[1h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate1h
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[2h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[2h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate2h
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[30m]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[30m]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate30m
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[3d]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[3d]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate3d
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[5m]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[5m]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate5m
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[6h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[6h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-production
+      record: thanos_alert_sender_alerts_dropped_total:burnrate6h
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate5m{service="observatorium-alertmanager",namespace="observatorium-production"}) > (14.40 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate1h{service="observatorium-alertmanager",namespace="observatorium-production"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        namespace: observatorium-production
+        service: telemeter
+        severity: critical
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate30m{service="observatorium-alertmanager",namespace="observatorium-production"}) > (6.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-production"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        namespace: observatorium-production
+        service: telemeter
+        severity: critical
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate2h{service="observatorium-alertmanager",namespace="observatorium-production"}) > (3.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate1d{service="observatorium-alertmanager",namespace="observatorium-production"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        namespace: observatorium-production
+        service: telemeter
+        severity: medium
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-production"}) > (1.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate3d{service="observatorium-alertmanager",namespace="observatorium-production"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        namespace: observatorium-production
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[1d]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[1d]))
+      labels:
+        namespace: observatorium-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate1d
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[1h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[1h]))
+      labels:
+        namespace: observatorium-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate1h
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[2h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[2h]))
+      labels:
+        namespace: observatorium-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate2h
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[30m]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[30m]))
+      labels:
+        namespace: observatorium-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate30m
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[3d]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[3d]))
+      labels:
+        namespace: observatorium-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate3d
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[5m]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[5m]))
+      labels:
+        namespace: observatorium-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate5m
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[6h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[6h]))
+      labels:
+        namespace: observatorium-production
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate6h

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -1299,13 +1299,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
         service: telemeter
         severity: critical
@@ -1315,13 +1316,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
         service: telemeter
         severity: critical
@@ -1331,13 +1333,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
         service: telemeter
         severity: medium
@@ -1347,77 +1350,85 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-production
       record: client_api_requests_total:burnrate6h
   - name: rhobs-telemeter-api-rules-read-availability.slo

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -1299,15 +1299,15 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1316,15 +1316,15 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1333,15 +1333,15 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1350,86 +1350,86 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-production",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate6h
   - name: rhobs-telemeter-api-rules-read-availability.slo
     rules:
@@ -1697,13 +1697,13 @@ spec:
         message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
       expr: |
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate5m{container="thanos-rule",namespace="observatorium-production"}) > (14.40 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate5m{container="thanos-rule",namespace="observatorium-metrics-production"}) > (14.40 * (1-0.95000))
         and
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-production"}) > (14.40 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-metrics-production"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1712,13 +1712,13 @@ spec:
         message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
       expr: |
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate30m{container="thanos-rule",namespace="observatorium-production"}) > (6.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate30m{container="thanos-rule",namespace="observatorium-metrics-production"}) > (6.00 * (1-0.95000))
         and
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-production"}) > (6.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-metrics-production"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1727,13 +1727,13 @@ spec:
         message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
       expr: |
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate2h{container="thanos-rule",namespace="observatorium-production"}) > (3.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate2h{container="thanos-rule",namespace="observatorium-metrics-production"}) > (3.00 * (1-0.95000))
         and
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-production"}) > (3.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-metrics-production"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1742,70 +1742,70 @@ spec:
         message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
       expr: |
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-production"}) > (1.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-metrics-production"}) > (1.00 * (1-0.95000))
         and
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-production"}) > (1.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-metrics-production"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[1d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[1d]))
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate1d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[1h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[1h]))
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate1h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[2h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[2h]))
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate2h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[30m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[30m]))
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate30m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[3d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[3d]))
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate3d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[5m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[5m]))
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate5m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production",code=~"5.."}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[6h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-production"}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[6h]))
       labels:
         container: thanos-rule
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate6h
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1813,12 +1813,12 @@ spec:
         message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
       expr: |
-        sum(alertmanager_notifications_failed_total:burnrate5m{service="observatorium-alertmanager",namespace="observatorium-production"}) > (14.40 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate5m{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}) > (14.40 * (1-0.95000))
         and
-        sum(alertmanager_notifications_failed_total:burnrate1h{service="observatorium-alertmanager",namespace="observatorium-production"}) > (14.40 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate1h{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
@@ -1827,12 +1827,12 @@ spec:
         message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
       expr: |
-        sum(alertmanager_notifications_failed_total:burnrate30m{service="observatorium-alertmanager",namespace="observatorium-production"}) > (6.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate30m{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}) > (6.00 * (1-0.95000))
         and
-        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-production"}) > (6.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
@@ -1841,12 +1841,12 @@ spec:
         message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
       expr: |
-        sum(alertmanager_notifications_failed_total:burnrate2h{service="observatorium-alertmanager",namespace="observatorium-production"}) > (3.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate2h{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}) > (3.00 * (1-0.95000))
         and
-        sum(alertmanager_notifications_failed_total:burnrate1d{service="observatorium-alertmanager",namespace="observatorium-production"}) > (3.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate1d{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
@@ -1855,67 +1855,67 @@ spec:
         message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
       expr: |
-        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-production"}) > (1.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}) > (1.00 * (1-0.95000))
         and
-        sum(alertmanager_notifications_failed_total:burnrate3d{service="observatorium-alertmanager",namespace="observatorium-production"}) > (1.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate3d{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[1d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[1d]))
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[1h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[1h]))
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[2h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[2h]))
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate2h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[30m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[30m]))
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate30m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[3d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[3d]))
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate3d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[5m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[5m]))
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate5m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production",code=~"5.."}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[6h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-production"}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[6h]))
       labels:
-        namespace: observatorium-production
+        namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate6h

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -1299,15 +1299,15 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1316,15 +1316,15 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1333,15 +1333,15 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1350,86 +1350,86 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
-        client: oauth
+        client: reload
         code: ^(2..|3..|5..)$
         container: thanos-rule-syncer
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate6h
   - name: rhobs-telemeter-api-rules-read-availability.slo
     rules:
@@ -1697,13 +1697,13 @@ spec:
         message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
       expr: |
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate5m{container="thanos-rule",namespace="observatorium-stage"}) > (14.40 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate5m{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (14.40 * (1-0.95000))
         and
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-stage"}) > (14.40 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1712,13 +1712,13 @@ spec:
         message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
       expr: |
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate30m{container="thanos-rule",namespace="observatorium-stage"}) > (6.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate30m{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (6.00 * (1-0.95000))
         and
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-stage"}) > (6.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1727,13 +1727,13 @@ spec:
         message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
       expr: |
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate2h{container="thanos-rule",namespace="observatorium-stage"}) > (3.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate2h{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (3.00 * (1-0.95000))
         and
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-stage"}) > (3.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1742,70 +1742,70 @@ spec:
         message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
       expr: |
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-stage"}) > (1.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (1.00 * (1-0.95000))
         and
-        sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-stage"}) > (1.00 * (1-0.95000))
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[1d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[1d]))
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate1d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[1h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[1h]))
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate1h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[2h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[2h]))
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate2h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[30m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[30m]))
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate30m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[3d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[3d]))
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate3d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[5m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[5m]))
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate5m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[6h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[6h]))
       labels:
         container: thanos-rule
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate6h
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1813,12 +1813,12 @@ spec:
         message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
       expr: |
-        sum(alertmanager_notifications_failed_total:burnrate5m{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (14.40 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate5m{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}) > (14.40 * (1-0.95000))
         and
-        sum(alertmanager_notifications_failed_total:burnrate1h{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (14.40 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate1h{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
@@ -1827,12 +1827,12 @@ spec:
         message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
       expr: |
-        sum(alertmanager_notifications_failed_total:burnrate30m{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (6.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate30m{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}) > (6.00 * (1-0.95000))
         and
-        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (6.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
@@ -1841,12 +1841,12 @@ spec:
         message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
       expr: |
-        sum(alertmanager_notifications_failed_total:burnrate2h{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (3.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate2h{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}) > (3.00 * (1-0.95000))
         and
-        sum(alertmanager_notifications_failed_total:burnrate1d{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (3.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate1d{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
@@ -1855,67 +1855,67 @@ spec:
         message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
       expr: |
-        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (1.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}) > (1.00 * (1-0.95000))
         and
-        sum(alertmanager_notifications_failed_total:burnrate3d{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (1.00 * (1-0.95000))
+        sum(alertmanager_notifications_failed_total:burnrate3d{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[1d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[1d]))
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[1h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[1h]))
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[2h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[2h]))
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate2h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[30m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[30m]))
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate30m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[3d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[3d]))
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate3d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[5m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[5m]))
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate5m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[6h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[6h]))
       labels:
-        namespace: observatorium-stage
+        namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate6h

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -1299,13 +1299,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
         service: telemeter
         severity: high
@@ -1315,13 +1316,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
         service: telemeter
         severity: high
@@ -1331,13 +1333,14 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
         service: telemeter
         severity: medium
@@ -1347,77 +1350,85 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="oauth",container="thanos-rule-syncer",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
         client: oauth
         code: ^(2..|3..|5..)$
+        container: thanos-rule-syncer
         namespace: observatorium-stage
       record: client_api_requests_total:burnrate6h
   - name: rhobs-telemeter-api-rules-read-availability.slo

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -1151,3 +1151,760 @@ spec:
         namespace: observatorium-stage
         query: query-path-sli-100M-samples
       record: latencytarget:up_custom_query_duration_seconds:rate3d
+  - name: rhobs-telemeter-api-rules-raw-write-availability.slo
+    rules:
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+        service: telemeter
+        severity: high
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+        service: telemeter
+        severity: high
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+        service: telemeter
+        severity: medium
+    - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-raw-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        method: PUT
+      record: http_requests_total:burnrate6h
+  - name: rhobs-telemeter-api-rules-sync-availability.slo
+    rules:
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate5m{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate1h{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+        service: telemeter
+        severity: high
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate30m{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+        service: telemeter
+        severity: high
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate2h{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate1d{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+        service: telemeter
+        severity: medium
+    - alert: APIRulesSyncAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-sync-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
+      expr: |
+        sum(client_api_requests_total:burnrate6h{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        and
+        sum(client_api_requests_total:burnrate3d{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+      record: client_api_requests_total:burnrate1d
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+      record: client_api_requests_total:burnrate1h
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+      record: client_api_requests_total:burnrate2h
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+      record: client_api_requests_total:burnrate30m
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+      record: client_api_requests_total:burnrate3d
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+      record: client_api_requests_total:burnrate5m
+    - expr: |
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(client_api_requests_total{client="oauth",namespace="observatorium-stage",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        client: oauth
+        code: ^(2..|3..|5..)$
+        namespace: observatorium-stage
+      record: client_api_requests_total:burnrate6h
+  - name: rhobs-telemeter-api-rules-read-availability.slo
+    rules:
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: high
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: high
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+    - alert: APIRulesReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-telemeter-api-rules-raw-read-availability.slo
+    rules:
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: high
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: high
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+    - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-rules-raw-read-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
+      expr: |
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        and
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[2h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[30m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[3d]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[5m]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        /
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[6h]))
+      labels:
+        code: ^(2..|3..|5..)$
+        handler: rules-raw
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate6h
+  - name: rhobs-telemeter-api-alerting-availability.slo
+    rules:
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate5m{container="thanos-rule",namespace="observatorium-stage"}) > (14.40 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-stage"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+        service: telemeter
+        severity: high
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate30m{container="thanos-rule",namespace="observatorium-stage"}) > (6.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-stage"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+        service: telemeter
+        severity: high
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate2h{container="thanos-rule",namespace="observatorium-stage"}) > (3.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-stage"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+        service: telemeter
+        severity: medium
+    - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanageravailabilityerrorbudgetburning
+      expr: |
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-stage"}) > (1.00 * (1-0.95000))
+        and
+        sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-stage"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[1d]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[1d]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate1d
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[1h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[1h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate1h
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[2h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[2h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate2h
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[30m]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[30m]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate30m
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[3d]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[3d]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate3d
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[5m]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[5m]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate5m
+    - expr: |
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage",code=~"5.."}[6h]))
+        /
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-stage"}[6h]))
+      labels:
+        container: thanos-rule
+        namespace: observatorium-stage
+      record: thanos_alert_sender_alerts_dropped_total:burnrate6h
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate5m{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (14.40 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate1h{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        namespace: observatorium-stage
+        service: telemeter
+        severity: high
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate30m{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (6.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        namespace: observatorium-stage
+        service: telemeter
+        severity: high
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate2h{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (3.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate1d{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        namespace: observatorium-stage
+        service: telemeter
+        severity: medium
+    - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-alerting-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API Alertmanager failing to deliver alerts to upstream targets and is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apialertmanagernotificationsavailabilityerrorbudgetburning
+      expr: |
+        sum(alertmanager_notifications_failed_total:burnrate6h{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (1.00 * (1-0.95000))
+        and
+        sum(alertmanager_notifications_failed_total:burnrate3d{service="observatorium-alertmanager",namespace="observatorium-stage"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        namespace: observatorium-stage
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[1d]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[1d]))
+      labels:
+        namespace: observatorium-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate1d
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[1h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[1h]))
+      labels:
+        namespace: observatorium-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate1h
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[2h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[2h]))
+      labels:
+        namespace: observatorium-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate2h
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[30m]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[30m]))
+      labels:
+        namespace: observatorium-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate30m
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[3d]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[3d]))
+      labels:
+        namespace: observatorium-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate3d
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[5m]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[5m]))
+      labels:
+        namespace: observatorium-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate5m
+    - expr: |
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage",code=~"5.."}[6h]))
+        /
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-stage"}[6h]))
+      labels:
+        namespace: observatorium-stage
+        service: observatorium-alertmanager
+      record: alertmanager_notifications_failed_total:burnrate6h


### PR DESCRIPTION
Adding alerts for the defined SLOs at https://github.com/rhobs/configuration/pull/298 
I think selectors may change slightly as we update https://github.com/rhobs/configuration/pull/298 but I already wanted to open for review. 
I'll then add runbooks in a separate PR, to make easier for review.

I think we can then have this merged after https://github.com/rhobs/configuration/pull/298 to stage, test and just when we have all runbooks in place and alerts are ok, have it deployed to production.

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>