### PR TITLE
Enable configuration of remote write endpoint via params

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -29,7 +29,7 @@ objects:
         - args:
           - --metric-count=1
           - --series-count=8333
-          - --remote-url=http://observatorium-thanos-receive.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291/api/v1/receive
+          - --remote-url=http://${METRICS_WRITE_SERVICE_NAME}.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:${METRICS_WRITE_SERVICE_PORT}/api/v1/receive
           - --remote-write-interval=30s
           - --remote-requests-count=1000000
           - --value-interval=3600
@@ -1014,7 +1014,7 @@ objects:
           - --web.internal.listen=0.0.0.0:8081
           - --log.level=warn
           - --metrics.read.endpoint=http://observatorium-thanos-query-frontend.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:9090
-          - --metrics.write.endpoint=http://observatorium-thanos-receive.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291
+          - --metrics.write.endpoint=http://${METRICS_WRITE_SERVICE_NAME}.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:${METRICS_WRITE_SERVICE_PORT}
           - --metrics.rules.endpoint=http://rules-objstore.${NAMESPACE}.svc.cluster.local:8080
           - --logs.read.endpoint=http://observatorium-loki-query-frontend-http.${OBSERVATORIUM_LOGS_NAMESPACE}.svc.cluster.local:3100
           - --logs.tail.endpoint=http://observatorium-loki-querier-http.${OBSERVATORIUM_LOGS_NAMESPACE}.svc.cluster.local:3100
@@ -1578,3 +1578,7 @@ parameters:
   value: quay.io/app-sre/obsctl-reloader
 - name: OBSCTL_RELOADER_IMAGE_TAG
   value: a6a0ff7
+- name: METRICS_WRITE_SERVICE_NAME
+  value: observatorium-thanos-receive
+- name: METRICS_WRITE_SERVICE_PORT
+  value: "19291"

--- a/services/observatorium-template.jsonnet
+++ b/services/observatorium-template.jsonnet
@@ -93,5 +93,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'OBSCTL_RELOADER_SECRET_NAME', value: 'rhobs-tenant' },
     { name: 'OBSCTL_RELOADER_IMAGE', value: 'quay.io/app-sre/obsctl-reloader' },
     { name: 'OBSCTL_RELOADER_IMAGE_TAG', value: 'a6a0ff7' },
+    { name: 'METRICS_WRITE_SERVICE_NAME', value: obs.thanos.receiversService.metadata.name },
+    { name: 'METRICS_WRITE_SERVICE_PORT', value: std.toString(obs.thanos.receiversService.spec.ports[2].port) },
   ],
 }

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -392,10 +392,10 @@ local obsctlReloader = (import 'github.com/rhobs/obsctl-reloader/jsonnet/lib/obs
         obs.config.namespaces.metrics,
         obs.thanos.queryFrontend.service.spec.ports[0].port,
       ],
-      writeEndpoint: 'http://%s.%s.svc.cluster.local:%d' % [
-        obs.thanos.receiversService.metadata.name,
+      writeEndpoint: 'http://%s.%s.svc.cluster.local:%s' % [
+        '${METRICS_WRITE_SERVICE_NAME}',
         obs.config.namespaces.metrics,
-        obs.thanos.receiversService.spec.ports[2].port,
+        '${METRICS_WRITE_SERVICE_PORT}',
       ],
       rulesEndpoint: 'http://%s.%s.svc.cluster.local:%d' % [
         obs.rulesObjstore.service.metadata.name,
@@ -629,10 +629,10 @@ local obsctlReloader = (import 'github.com/rhobs/obsctl-reloader/jsonnet/lib/obs
               args: [
                 '--metric-count=1',  // we only get one metric __name__
                 '--series-count=8333',  // this is set so that we write 1M samples per hour to our test tenant
-                '--remote-url=http://%s.%s.svc.cluster.local:%d/api/v1/receive' % [
-                  obs.thanos.receiversService.metadata.name,
+                '--remote-url=http://%s.%s.svc.cluster.local:%s/api/v1/receive' % [
+                  '${METRICS_WRITE_SERVICE_NAME}',
                   obs.config.namespaces.metrics,
-                  obs.thanos.receiversService.spec.ports[2].port,
+                  '${METRICS_WRITE_SERVICE_PORT}',
                 ],  // this is the internal cluster url of the thanos receive service
                 '--remote-write-interval=30s',  // how frequently to remote_write data
                 '--remote-requests-count=1000000',  // how many requests we make before exiting - make it a big number


### PR DESCRIPTION
To support writing to an intermediate proxy, we need to be able to configure the service name and the port for the remote write endpoint. 