### PR TITLE
Enable configuring receiver service name via params for query

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1047,7 +1047,7 @@ objects:
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-3.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-4.${NAMESPACE}.svc.cluster.local
           - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-5.${NAMESPACE}.svc.cluster.local
-          - --store=dnssrv+_grpc._tcp.observatorium-thanos-receive-default.${NAMESPACE}.svc.cluster.local
+          - --store=dnssrv+_grpc._tcp.${THANOS_RECEIVE_HASHRING_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local
           - --rule=dnssrv+_grpc._tcp.observatorium-thanos-rule.${NAMESPACE}.svc.cluster.local
           - --rule=dnssrv+_grpc._tcp.observatorium-thanos-stateless-rule.${NAMESPACE}.svc.cluster.local
           - --web.prefix-header=X-Forwarded-Prefix
@@ -4312,6 +4312,8 @@ parameters:
   value: /var/thanos/receive
 - name: THANOS_RECEIVE_TSDB_RETENTION
   value: 4d
+- name: THANOS_RECEIVE_HASHRING_SERVICE_NAME
+  value: observatorium-thanos-receive-default
 - name: THANOS_RULE_SYNCER_IMAGE
   value: quay.io/observatorium/thanos-rule-syncer
 - name: THANOS_RULE_SYNCER_IMAGE_TAG

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -91,6 +91,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_RECEIVE_REPLICAS', value: '5' },
     { name: 'THANOS_RECEIVE_TSDB_PATH', value: '/var/thanos/receive' },
     { name: 'THANOS_RECEIVE_TSDB_RETENTION', value: '4d' },
+    { name: 'THANOS_RECEIVE_HASHRING_SERVICE_NAME', value: 'observatorium-thanos-receive-default' },
     { name: 'THANOS_RULE_SYNCER_IMAGE', value: 'quay.io/observatorium/thanos-rule-syncer' },
     { name: 'THANOS_RULE_SYNCER_IMAGE_TAG', value: 'main-2022-01-11-1290656' },
     { name: 'THANOS_RULER_CPU_LIMIT', value: '1' },

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -566,8 +566,10 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       stores: [
         'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
         for service in
-          [thanos.stores.shards[shard].service for shard in std.objectFields(thanos.stores.shards)] +
-          [thanos.receivers.hashrings[hashring].service for hashring in std.objectFields(thanos.receivers.hashrings)]
+          [thanos.stores.shards[shard].service for shard in std.objectFields(thanos.stores.shards)]
+      ] + [
+        // todo - @pgough revert after https://issues.redhat.com/browse/RHOBS-112
+        'dnssrv+_grpc._tcp.${THANOS_RECEIVE_HASHRING_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local',
       ],
       rules: [
         'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]


### PR DESCRIPTION
In order to support migration between two distinct StatefulSets, we want to be able to configure the Service name via param in the Thanos Query 