### PR TITLE
Add ServiceMonitor and expose metrics port to thanos-rule-syncer

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2154,6 +2154,9 @@ objects:
     - name: reloader
       port: 9533
       targetPort: 9533
+    - name: thanos-rule-syncer-metrics
+      port: 8083
+      targetPort: 8083
     selector:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: observatorium
@@ -2189,6 +2192,7 @@ objects:
         - pod
         targetLabel: instance
     - port: reloader
+    - port: thanos-rule-syncer-metrics
     namespaceSelector:
       matchNames: ${{NAMESPACES}}
     selector:

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -731,6 +731,9 @@ objects:
     - name: reloader
       port: 9533
       targetPort: 9533
+    - name: thanos-rule-syncer-metrics
+      port: 8083
+      targetPort: 8083
     selector:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: observatorium
@@ -766,6 +769,7 @@ objects:
         - pod
         targetLabel: instance
     - port: reloader
+    - port: thanos-rule-syncer-metrics
     namespaceSelector:
       matchNames: ${{NAMESPACES}}
     selector:
@@ -942,6 +946,9 @@ objects:
           - -thanos-rule-url=http://localhost:10902
           image: ${THANOS_RULE_SYNCER_IMAGE}:${THANOS_RULE_SYNCER_IMAGE_TAG}
           name: thanos-rule-syncer
+          ports:
+          - containerPort: 8083
+            name: thanos-rule-syncer-metrics
           resources:
             limits:
               cpu: 128m
@@ -2369,6 +2376,9 @@ objects:
           - -thanos-rule-url=http://localhost:10902
           image: ${THANOS_RULE_SYNCER_IMAGE}:${THANOS_RULE_SYNCER_IMAGE_TAG}
           name: thanos-rule-syncer
+          ports:
+          - containerPort: 8083
+            name: thanos-rule-syncer-metrics
           resources:
             limits:
               cpu: 128m

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -731,9 +731,6 @@ objects:
     - name: reloader
       port: 9533
       targetPort: 9533
-    - name: thanos-rule-syncer-metrics
-      port: 8083
-      targetPort: 8083
     selector:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: observatorium
@@ -769,7 +766,6 @@ objects:
         - pod
         targetLabel: instance
     - port: reloader
-    - port: thanos-rule-syncer-metrics
     namespaceSelector:
       matchNames: ${{NAMESPACES}}
     selector:

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -103,6 +103,8 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
     },
 
     rule+:: {
+      service+: ruleSyncerSidecar.service,
+      serviceMonitor+: ruleSyncerSidecar.serviceMonitor,
       statefulSet+: jaegerAgentSidecar.statefulSet + ruleSyncerSidecar.statefulSet {
         spec+: {
           replicas: '${{THANOS_RULER_REPLICAS}}',
@@ -135,6 +137,8 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
     },
 
     statelessRule+:: {
+      service+: ruleSyncerSidecar.service,
+      serviceMonitor+: ruleSyncerSidecar.serviceMonitor,
       statefulSet+: jaegerAgentSidecar.statefulSet + ruleSyncerSidecar.statefulSet {
         spec+: {
           replicas: '${{THANOS_RULER_REPLICAS}}',

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -137,8 +137,6 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
     },
 
     statelessRule+:: {
-      service+: ruleSyncerSidecar.service,
-      serviceMonitor+: ruleSyncerSidecar.serviceMonitor,
       statefulSet+: jaegerAgentSidecar.statefulSet + ruleSyncerSidecar.statefulSet {
         spec+: {
           replicas: '${{THANOS_RULER_REPLICAS}}',

--- a/services/sidecars/thanos-rule-syncer.libsonnet
+++ b/services/sidecars/thanos-rule-syncer.libsonnet
@@ -39,6 +39,13 @@ function(params) {
             mountPath: mountPath,
           }],
           resources: trs.config.resources,
+          ports: [
+            {
+              name: 'thanos-rule-syncer-' + name,
+              containerPort: trs.config.ports[name],
+            }
+            for name in std.objectFields(trs.config.ports)
+          ],
         }],
         volumes+: [{
           name: trs.config.volumeName,

--- a/services/sidecars/thanos-rule-syncer.libsonnet
+++ b/services/sidecars/thanos-rule-syncer.libsonnet
@@ -22,27 +22,6 @@ function(params) {
 
   local mountPath = '/etc/thanos-rule-syncer',
 
-  service+: {
-    spec+: {
-      ports+: [
-        {
-          name: 'thanos-rule-syncer-' + name,
-          port: trs.config.ports[name],
-          targetPort: trs.config.ports[name],
-        }
-        for name in std.objectFields(trs.config.ports)
-      ],
-    },
-  },
-
-  serviceMonitor+: {
-    spec+: {
-      endpoints+: [
-        { port: 'thanos-rule-syncer-metrics' },
-      ],
-    },
-  },
-
   local spec = {
     template+: {
       spec+: {
@@ -71,6 +50,27 @@ function(params) {
   },
 
   spec+: spec,
+
+  service+: {
+    spec+: {
+      ports+: [
+        {
+          name: 'thanos-rule-syncer-' + name,
+          port: trs.config.ports[name],
+          targetPort: trs.config.ports[name],
+        }
+        for name in std.objectFields(trs.config.ports)
+      ],
+    },
+  },
+
+  serviceMonitor+: {
+    spec+: {
+      endpoints+: [
+        { port: 'thanos-rule-syncer-metrics' },
+      ],
+    },
+  },
 
   statefulSet+: {
     spec+: spec,

--- a/services/sidecars/thanos-rule-syncer.libsonnet
+++ b/services/sidecars/thanos-rule-syncer.libsonnet
@@ -9,6 +9,9 @@ local defaults = {
     requests: { cpu: '32m', memory: '64Mi' },
     limits: { cpu: '128m', memory: '128Mi' },
   },
+  ports: {
+    metrics: 8083,
+  },
 };
 
 function(params) {
@@ -18,6 +21,27 @@ function(params) {
   assert std.isNumber(trs.config.interval) && trs.config.interval > 0 : 'interval has to be number > 0',
 
   local mountPath = '/etc/thanos-rule-syncer',
+
+  service+: {
+    spec+: {
+      ports+: [
+        {
+          name: 'thanos-rule-syncer-' + name,
+          port: trs.config.ports[name],
+          targetPort: trs.config.ports[name],
+        }
+        for name in std.objectFields(trs.config.ports)
+      ],
+    },
+  },
+
+  serviceMonitor+: {
+    spec+: {
+      endpoints+: [
+        { port: 'thanos-rule-syncer-metrics' },
+      ],
+    },
+  },
 
   local spec = {
     template+: {


### PR DESCRIPTION
I noticed we don't have a metrics port exposed in `thanos-rule-syncer` - so this PR tries to add service monitor + expose metrics.

I followed the same service monitor config we do for `opa-ams` [here](https://github.com/rhobs/configuration/blob/main/services/sidecars/opa-ams.libsonnet), ~~but when running `make all` I don't see any changes in the yaml's.~~

~~I see that the `thanos-rule-syncer.libsonnet` is imported [here](https://github.com/rhobs/configuration/blob/main/services/observatorium-metrics-template-overwrites.libsonnet#L6) though, so I'm trying to understand how to integrate the serviceMonitor there, since we seem to be using just the [ruleSyncerSidecar.statefulSet](https://github.com/rhobs/configuration/blob/main/services/observatorium-metrics-template-overwrites.libsonnet#L106)~~

~~Already opening as a draft PR, to check if this is the right direction to go~~

EDIT: I paired with @moadz (thanks!) and now hopefully is the right config - we've added the servicemonitor and service to thanos rule as well - so marking this as ready for review.

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>