### PR TITLE
Template remote write proxy target port

### DIFF
--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -647,7 +647,7 @@ objects:
 
           location / {
             proxy_set_header THANOS-TENANT FB870BF3-9F3A-44FF-9BF7-D7A047A52F43;
-            proxy_pass http://${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET}.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291;
+            proxy_pass http://${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET}.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_PORT};
           }
         }
       }
@@ -937,6 +937,8 @@ parameters:
   value: quay.io/app-sre/observatorium-receive-proxy
 - name: PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET
   value: observatorium-thanos-receive
+- name: PROMETHEUS_AMS_REMOTE_WRITE_PROXY_PORT
+  value: "19291"
 - name: PROMETHEUS_AMS_REMOTE_WRITE_PROXY_VERSION
   value: 14e844d
 - name: PROMETHEUS_IMAGE

--- a/services/prometheus/remote-write-proxy.libsonnet
+++ b/services/prometheus/remote-write-proxy.libsonnet
@@ -8,6 +8,7 @@ local defaults = {
   version: error 'must provide version',
   image: error 'must set image for proxy',
   target: error 'must provide target',
+  targetPort: error 'must provide target port',
   targetNamespace: error 'must provide target namespace',
   tenantID: error 'must provide tenant ID',
   ports: {
@@ -108,10 +109,10 @@ function(params) {
 
       'nginx.conf': std.format(f, {
         listen_port: rwp.config.ports.proxy,
-        forward_host: 'http://%s.%s.svc.cluster.local:%d' % [
+        forward_host: 'http://%s.%s.svc.cluster.local:%s' % [
           rwp.config.target,
           rwp.config.targetNamespace,
-          rwp.config.ports.target,
+          rwp.config.targetPort,
         ],
         thanos_tenant: rwp.config.tenantID,
       }),

--- a/services/telemeter-template.jsonnet
+++ b/services/telemeter-template.jsonnet
@@ -62,6 +62,7 @@ local prometheusAms = (import 'prometheus/remote-write-proxy.libsonnet')({
   version: '${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_VERSION}',
   image: '${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_IMAGE}:${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_VERSION}',
   target: '${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET}',
+  targetPort: '${PROMETHEUS_AMS_REMOTE_WRITE_PROXY_PORT}',
   targetNamespace: '${OBSERVATORIUM_METRICS_NAMESPACE}',
   tenantID: 'FB870BF3-9F3A-44FF-9BF7-D7A047A52F43',
 });
@@ -171,6 +172,7 @@ local tr = (import 'github.com/observatorium/token-refresher/jsonnet/lib/token-r
     { name: 'OBSERVATORIUM_METRICS_NAMESPACE', value: 'observatorium-metrics' },
     { name: 'PROMETHEUS_AMS_REMOTE_WRITE_PROXY_IMAGE', value: 'quay.io/app-sre/observatorium-receive-proxy' },
     { name: 'PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET', value: 'observatorium-thanos-receive' },
+    { name: 'PROMETHEUS_AMS_REMOTE_WRITE_PROXY_PORT', value: '19291' },
     { name: 'PROMETHEUS_AMS_REMOTE_WRITE_PROXY_VERSION', value: '14e844d' },
     { name: 'PROMETHEUS_IMAGE', value: 'quay.io/prometheus/prometheus' },
     { name: 'PROMETHEUS_VERSION', value: 'v2.12.0' },


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Currently, the port is hardcoded, but we need to have it configurable for our receive migration, since mirror proxy uses different port.