### PR TITLE
Rename thanos-rule-syncer metrics port

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -944,7 +944,7 @@ objects:
           name: thanos-rule-syncer
           ports:
           - containerPort: 8083
-            name: thanos-rule-syncer-metrics
+            name: metrics
           resources:
             limits:
               cpu: 128m
@@ -2157,7 +2157,7 @@ objects:
     - name: reloader
       port: 9533
       targetPort: 9533
-    - name: thanos-rule-syncer-metrics
+    - name: metrics
       port: 8083
       targetPort: 8083
     selector:
@@ -2195,7 +2195,7 @@ objects:
         - pod
         targetLabel: instance
     - port: reloader
-    - port: thanos-rule-syncer-metrics
+    - port: metrics
     namespaceSelector:
       matchNames: ${{NAMESPACES}}
     selector:
@@ -2374,7 +2374,7 @@ objects:
           name: thanos-rule-syncer
           ports:
           - containerPort: 8083
-            name: thanos-rule-syncer-metrics
+            name: metrics
           resources:
             limits:
               cpu: 128m

--- a/services/sidecars/thanos-rule-syncer.libsonnet
+++ b/services/sidecars/thanos-rule-syncer.libsonnet
@@ -41,7 +41,7 @@ function(params) {
           resources: trs.config.resources,
           ports: [
             {
-              name: 'thanos-rule-syncer-' + name,
+              name: name,
               containerPort: trs.config.ports[name],
             }
             for name in std.objectFields(trs.config.ports)
@@ -62,7 +62,7 @@ function(params) {
     spec+: {
       ports+: [
         {
-          name: 'thanos-rule-syncer-' + name,
+          name: name,
           port: trs.config.ports[name],
           targetPort: trs.config.ports[name],
         }
@@ -74,7 +74,7 @@ function(params) {
   serviceMonitor+: {
     spec+: {
       endpoints+: [
-        { port: 'thanos-rule-syncer-metrics' },
+        { port: 'metrics' },
       ],
     },
   },


### PR DESCRIPTION
The thanos-rule pods fail to be created because the metrics port name for `thanos-rule-syncer` is too big:

```bash
Warning  FailedCreate      38s (x28 over 67m)  statefulset-controller  create Pod observatorium-thanos-rule-1 in StatefulSet observatorium-thanos-rule failed error: Pod "observatorium-thanos-rule-1" is invalid: spec.containers[3].ports[0].name: Invalid value: "thanos-rule-syncer-metrics": must be no more than 15 characters
```

This fixes that by simply renaming it to `metrics`.
Follow up from https://github.com/rhobs/configuration/pull/311

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>