### PR TITLE
SLOs: Prune unsupported labels

### DIFF
--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -126,6 +126,8 @@ local appSREOverwrites(environment) = {
     // Prune selector label because not allowed by AppSRE
     labels: std.prune(labels {
       group: null,
+      container: null,
+      client: null,
     }),
   },
 

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -1052,9 +1052,7 @@ spec:
         sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
@@ -1069,9 +1067,7 @@ spec:
         sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
@@ -1086,9 +1082,7 @@ spec:
         sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: telemeter
         severity: medium
@@ -1103,9 +1097,7 @@ spec:
         sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: telemeter
         severity: medium
@@ -1114,9 +1106,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate1d
     - expr: |
@@ -1124,9 +1114,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate1h
     - expr: |
@@ -1134,9 +1122,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate2h
     - expr: |
@@ -1144,9 +1130,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate30m
     - expr: |
@@ -1154,9 +1138,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate3d
     - expr: |
@@ -1164,9 +1146,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate5m
     - expr: |
@@ -1174,9 +1154,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate6h
   - name: rhobs-mst-api-rules-read-availability.slo
@@ -1450,7 +1428,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-mst-production"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
@@ -1465,7 +1442,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-mst-production"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
@@ -1480,7 +1456,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-mst-production"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
         service: telemeter
         severity: medium
@@ -1495,7 +1470,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-mst-production"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
         service: telemeter
         severity: medium
@@ -1504,7 +1478,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[1d]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate1d
     - expr: |
@@ -1512,7 +1485,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[1h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate1h
     - expr: |
@@ -1520,7 +1492,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[2h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate2h
     - expr: |
@@ -1528,7 +1499,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[30m]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate30m
     - expr: |
@@ -1536,7 +1506,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[3d]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate3d
     - expr: |
@@ -1544,7 +1513,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[5m]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate5m
     - expr: |
@@ -1552,7 +1520,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[6h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate6h
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -1052,9 +1052,7 @@ spec:
         sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
         service: telemeter
         severity: high
@@ -1069,9 +1067,7 @@ spec:
         sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
         service: telemeter
         severity: high
@@ -1086,9 +1082,7 @@ spec:
         sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
@@ -1103,9 +1097,7 @@ spec:
         sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
@@ -1114,9 +1106,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate1d
     - expr: |
@@ -1124,9 +1114,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate1h
     - expr: |
@@ -1134,9 +1122,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate2h
     - expr: |
@@ -1144,9 +1130,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate30m
     - expr: |
@@ -1154,9 +1138,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate3d
     - expr: |
@@ -1164,9 +1146,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate5m
     - expr: |
@@ -1174,9 +1154,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate6h
   - name: rhobs-mst-api-rules-read-availability.slo
@@ -1450,7 +1428,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-mst-stage"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
         service: telemeter
         severity: high
@@ -1465,7 +1442,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-mst-stage"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
         service: telemeter
         severity: high
@@ -1480,7 +1456,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-mst-stage"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
@@ -1495,7 +1470,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-mst-stage"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
@@ -1504,7 +1478,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[1d]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate1d
     - expr: |
@@ -1512,7 +1485,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[1h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate1h
     - expr: |
@@ -1520,7 +1492,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[2h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate2h
     - expr: |
@@ -1528,7 +1499,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[30m]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate30m
     - expr: |
@@ -1536,7 +1506,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[3d]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate3d
     - expr: |
@@ -1544,7 +1513,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[5m]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate5m
     - expr: |
@@ -1552,7 +1520,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[6h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate6h
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -1304,9 +1304,7 @@ spec:
         sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
@@ -1321,9 +1319,7 @@ spec:
         sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
@@ -1338,9 +1334,7 @@ spec:
         sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
@@ -1355,9 +1349,7 @@ spec:
         sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
@@ -1366,9 +1358,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate1d
     - expr: |
@@ -1376,9 +1366,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate1h
     - expr: |
@@ -1386,9 +1374,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate2h
     - expr: |
@@ -1396,9 +1382,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate30m
     - expr: |
@@ -1406,9 +1390,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate3d
     - expr: |
@@ -1416,9 +1398,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate5m
     - expr: |
@@ -1426,9 +1406,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate6h
   - name: rhobs-telemeter-api-rules-read-availability.slo
@@ -1702,7 +1680,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-metrics-production"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
@@ -1717,7 +1694,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-metrics-production"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
@@ -1732,7 +1708,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-metrics-production"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
@@ -1747,7 +1722,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-metrics-production"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
@@ -1756,7 +1730,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[1d]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate1d
     - expr: |
@@ -1764,7 +1737,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[1h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate1h
     - expr: |
@@ -1772,7 +1744,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[2h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate2h
     - expr: |
@@ -1780,7 +1751,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[30m]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate30m
     - expr: |
@@ -1788,7 +1758,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[3d]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate3d
     - expr: |
@@ -1796,7 +1765,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[5m]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate5m
     - expr: |
@@ -1804,7 +1772,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[6h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate6h
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -1304,9 +1304,7 @@ spec:
         sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
@@ -1321,9 +1319,7 @@ spec:
         sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
@@ -1338,9 +1334,7 @@ spec:
         sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
@@ -1355,9 +1349,7 @@ spec:
         sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
@@ -1366,9 +1358,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[1d]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate1d
     - expr: |
@@ -1376,9 +1366,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[1h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate1h
     - expr: |
@@ -1386,9 +1374,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[2h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate2h
     - expr: |
@@ -1396,9 +1382,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[30m]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate30m
     - expr: |
@@ -1406,9 +1390,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[3d]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate3d
     - expr: |
@@ -1416,9 +1398,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[5m]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate5m
     - expr: |
@@ -1426,9 +1406,7 @@ spec:
         /
         sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[6h]))
       labels:
-        client: reload
         code: ^(2..|3..|5..)$
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate6h
   - name: rhobs-telemeter-api-rules-read-availability.slo
@@ -1702,7 +1680,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate1h{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
@@ -1717,7 +1694,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate6h{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
@@ -1732,7 +1708,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate1d{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
@@ -1747,7 +1722,6 @@ spec:
         sum(thanos_alert_sender_alerts_dropped_total:burnrate3d{container="thanos-rule",namespace="observatorium-metrics-stage"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
@@ -1756,7 +1730,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[1d]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate1d
     - expr: |
@@ -1764,7 +1737,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[1h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate1h
     - expr: |
@@ -1772,7 +1744,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[2h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate2h
     - expr: |
@@ -1780,7 +1751,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[30m]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate30m
     - expr: |
@@ -1788,7 +1758,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[3d]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate3d
     - expr: |
@@ -1796,7 +1765,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[5m]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate5m
     - expr: |
@@ -1804,7 +1772,6 @@ spec:
         /
         sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[6h]))
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate6h
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning


### PR DESCRIPTION
Our rules must conform with the app-sre prometheus schema defined in https://github.com/app-sre/qontract-schemas/blob/main/schemas/openshift/prometheus-rule-1.yml . Currently when trying to deploy the alerts defined in https://github.com/rhobs/configuration/pull/300 we get a validation error in the pipeline.

This PR removes the labels that are not in the schema, with exception of the `method` label - it should help us to better group alerts by method. I've added a PR to qocontract schemas adding this label there: https://github.com/app-sre/qontract-schemas/pull/254


Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>