### PR TITLE
Fix SLO alerting for metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(JSONNET_VENDOR_DIR): $(JB) jsonnetfile.json jsonnetfile.lock.json
 
 .PHONY: update
 update: $(JB) jsonnetfile.json jsonnetfile.lock.json
-	@$(JB) update --jsonnetpkg-home="$(JSONNET_VENDOR_DIR)" https://github.com/metalmatze/slo-libsonnet/slo-libsonnet@master
+	@$(JB) update --jsonnetpkg-home="$(JSONNET_VENDOR_DIR)" https://github.com/saswatamcode/slo-libsonnet/slo-libsonnet@special-selector
 
 .PHONY: format
 format: $(JSONNET_SRC) $(JSONNETFMT)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(JSONNET_VENDOR_DIR): $(JB) jsonnetfile.json jsonnetfile.lock.json
 
 .PHONY: update
 update: $(JB) jsonnetfile.json jsonnetfile.lock.json
-	@$(JB) update --jsonnetpkg-home="$(JSONNET_VENDOR_DIR)" https://github.com/thanos-io/kube-thanos/jsonnet/kube-thanos@main
+	@$(JB) update --jsonnetpkg-home="$(JSONNET_VENDOR_DIR)" https://github.com/metalmatze/slo-libsonnet/slo-libsonnet@master
 
 .PHONY: format
 format: $(JSONNET_SRC) $(JSONNETFMT)

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -40,11 +40,11 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/metalmatze/slo-libsonnet.git",
+          "remote": "https://github.com/saswatamcode/slo-libsonnet.git",
           "subdir": "slo-libsonnet"
         }
       },
-      "version": "master"
+      "version": "special-selector"
     },
     {
       "source": {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -149,8 +149,8 @@
           "subdir": "slo-libsonnet"
         }
       },
-      "version": "e238df4fac957357d78a405966c51523ef151cbc",
-      "sum": "5XrxbGgMFMHnKGeE++fiduDlDEiDunM2ZMTYCmPbWgA="
+      "version": "3db7d7d58aac44fee4006760594bce1995bed779",
+      "sum": "k0zWHfAEz6/8cRnsqQo00m7y+noku0iOr1EM/QSo6kc="
     },
     {
       "source": {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -145,16 +145,6 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/metalmatze/slo-libsonnet.git",
-          "subdir": "slo-libsonnet"
-        }
-      },
-      "version": "3db7d7d58aac44fee4006760594bce1995bed779",
-      "sum": "k0zWHfAEz6/8cRnsqQo00m7y+noku0iOr1EM/QSo6kc="
-    },
-    {
-      "source": {
-        "git": {
           "remote": "https://github.com/observatorium/api.git",
           "subdir": "jsonnet/lib"
         }
@@ -328,6 +318,16 @@
       },
       "version": "a6a0ff74be63dabac0a1562a364a3a1ccc8f985d",
       "sum": "vdcovQefbNENJcAlNTojsUldmCF0QIBUB5zSwB7wF4s="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/saswatamcode/slo-libsonnet.git",
+          "subdir": "slo-libsonnet"
+        }
+      },
+      "version": "1c00866cc4a5d26139f7a7fcccd1752e9d5ea87e",
+      "sum": "vF3rkKtymiGbpH2r+vinAdp1RsLCUdgBNhsacZjFgQY="
     },
     {
       "source": {

--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -1,4 +1,8 @@
 local loki = (import 'github.com/grafana/loki/production/loki-mixin/mixin.libsonnet');
+// We use a fork of https://github.com/metalmatze/slo-libsonnet to allow for ONLY_BASE_IN selectors,
+// which are selectors, that when specified, are only used with the provided metric names and not
+// the generated recording/alerting rules.
+// This fork also adds support for !~ operator in label selectors.
 local slo = import 'github.com/saswatamcode/slo-libsonnet/slo-libsonnet/slo.libsonnet';
 local lokiTenants = import './observatorium-logs/loki-tenant-alerts.libsonnet';
 local utils = import './utils.jsonnet';

--- a/resources/observability/prometheusrules/observatorium-api-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-api-production.prometheusrules.yaml
@@ -130,118 +130,236 @@ spec:
   - name: observatorium-api-query-metrics-errors.slo
     rules:
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[1d]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[1d]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[1d]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1d]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[1h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[1h]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[1h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1h]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[2h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[2h]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[2h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[2h]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[30m]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[30m]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[30m]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[30m]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[3d]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[3d]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[3d]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[3d]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[5m]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[5m]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[5m]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[5m]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[6h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[6h]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[6h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[6h]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
     - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High error budget burn for group=metricsv1,handler=~query|query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        message: 'High error budget burn for group=metricsv1,handler=query,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
       expr: |
-        sum(http_requests_total:burnrate5m{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
         service: telemeter
         severity: critical
     - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High error budget burn for group=metricsv1,handler=~query|query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        message: 'High error budget burn for group=metricsv1,handler=query,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
       expr: |
-        sum(http_requests_total:burnrate30m{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
         service: telemeter
         severity: critical
     - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High error budget burn for group=metricsv1,handler=~query|query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        message: 'High error budget burn for group=metricsv1,handler=query,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
       expr: |
-        sum(http_requests_total:burnrate2h{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High error budget burn for group=metricsv1,handler=~query|query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        message: 'High error budget burn for group=metricsv1,handler=query,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
       expr: |
-        sum(http_requests_total:burnrate6h{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        handler: query|query_legacy
+        handler: query
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+  - name: observatorium-api-query-legacy-metrics-errors.slo
+    rules:
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[1d]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[1d]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[1h]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[1h]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[2h]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[2h]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[30m]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[30m]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[3d]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[3d]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[5m]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[5m]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[6h]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[6h]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate6h
+    - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-legacy-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High error budget burn for group=metricsv1,handler=query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
+      expr: |
+        sum(http_requests_total:burnrate5m{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: critical
+    - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-legacy-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High error budget burn for group=metricsv1,handler=query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
+      expr: |
+        sum(http_requests_total:burnrate30m{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: critical
+    - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-legacy-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High error budget burn for group=metricsv1,handler=query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
+      expr: |
+        sum(http_requests_total:burnrate2h{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+    - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-legacy-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High error budget burn for group=metricsv1,handler=query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
+      expr: |
+        sum(http_requests_total:burnrate6h{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        handler: query_legacy
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium

--- a/resources/observability/prometheusrules/observatorium-api-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-api-stage.prometheusrules.yaml
@@ -130,118 +130,236 @@ spec:
   - name: observatorium-api-query-metrics-errors.slo
     rules:
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[1d]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[1d]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[1d]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1d]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[1h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[1h]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[1h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1h]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[2h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[2h]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[2h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[2h]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[30m]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[30m]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[30m]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[30m]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[3d]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[3d]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[3d]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[3d]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[5m]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[5m]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[5m]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[5m]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api",code=~"5.."}[6h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api",code=~"5.."}[6h]))
         /
-        sum(rate(http_requests_total{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}[6h]))
+        sum(rate(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[6h]))
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
     - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High error budget burn for group=metricsv1,handler=~query|query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        message: 'High error budget burn for group=metricsv1,handler=query,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
       expr: |
-        sum(http_requests_total:burnrate5m{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
         service: telemeter
         severity: high
     - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High error budget burn for group=metricsv1,handler=~query|query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        message: 'High error budget burn for group=metricsv1,handler=query,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
       expr: |
-        sum(http_requests_total:burnrate30m{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
         service: telemeter
         severity: high
     - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High error budget burn for group=metricsv1,handler=~query|query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        message: 'High error budget burn for group=metricsv1,handler=query,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
       expr: |
-        sum(http_requests_total:burnrate2h{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        handler: query|query_legacy
+        handler: query
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High error budget burn for group=metricsv1,handler=~query|query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        message: 'High error budget burn for group=metricsv1,handler=query,job=observatorium-observatorium-api (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
       expr: |
-        sum(http_requests_total:burnrate6h{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{group="metricsv1",handler=~"query|query_legacy",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{group="metricsv1",handler="query",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        handler: query|query_legacy
+        handler: query
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+  - name: observatorium-api-query-legacy-metrics-errors.slo
+    rules:
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[1d]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[1d]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1d
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[1h]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[1h]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate1h
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[2h]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[2h]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate2h
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[30m]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[30m]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate30m
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[3d]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[3d]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate3d
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[5m]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[5m]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate5m
+    - expr: |
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api",code=~"5.."}[6h]))
+        /
+        sum(rate(http_requests_total{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}[6h]))
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+      record: http_requests_total:burnrate6h
+    - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-legacy-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High error budget burn for group=metricsv1,handler=query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
+      expr: |
+        sum(http_requests_total:burnrate5m{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1h{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: high
+    - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-legacy-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High error budget burn for group=metricsv1,handler=query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
+      expr: |
+        sum(http_requests_total:burnrate30m{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate6h{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: high
+    - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-legacy-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High error budget burn for group=metricsv1,handler=query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
+      expr: |
+        sum(http_requests_total:burnrate2h{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate1d{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        handler: query_legacy
+        job: observatorium-observatorium-api
+        service: telemeter
+        severity: medium
+    - alert: ObservatoriumAPIMetricsErrorsSLOBudgetBurn
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/Tg-mH0rizaSJDKSADX/observatorium-api-query-legacy-metrics-errors.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High error budget burn for group=metricsv1,handler=query_legacy,job=observatorium-observatorium-api (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#observatoriumapimetricserrorsslobudgetburn
+      expr: |
+        sum(http_requests_total:burnrate6h{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
+        and
+        sum(http_requests_total:burnrate3d{group="metricsv1",handler="query_legacy",job="observatorium-observatorium-api"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        handler: query_legacy
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -72,57 +72,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[1d]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[1h]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[2h]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[30m]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[3d]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[5m]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[6h]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -132,7 +132,7 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
@@ -155,7 +155,7 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
@@ -177,9 +177,9 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[5m]))
         )
       labels:
         handler: receive
@@ -188,9 +188,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[30m]))
         )
       labels:
         handler: receive
@@ -199,9 +199,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[1h]))
         )
       labels:
         handler: receive
@@ -210,9 +210,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[2h]))
         )
       labels:
         handler: receive
@@ -221,9 +221,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[6h]))
         )
       labels:
         handler: receive
@@ -232,9 +232,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[1d]))
         )
       labels:
         handler: receive
@@ -243,9 +243,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[3d]))
         )
       labels:
         handler: receive
@@ -315,57 +315,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[1d]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[1h]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[2h]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[30m]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[3d]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[5m]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[6h]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
@@ -431,57 +431,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[1d]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[1h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[2h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[30m]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[3d]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[5m]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[6h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -924,63 +924,63 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[1d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[1h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[2h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[30m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[3d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[5m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[6h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -1045,51 +1045,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate6h
@@ -1156,57 +1156,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[1d]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[1h]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[2h]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[30m]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[3d]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[5m]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[6h]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1274,57 +1274,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[1d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[1h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[2h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[30m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[3d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[5m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[6h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -1388,51 +1388,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[1d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate1d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[1h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate1h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[2h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate2h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[30m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate30m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[3d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate3d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[5m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate5m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code=~"5.."}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[6h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production"}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-production",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-mst-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate6h
@@ -1493,57 +1493,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[1d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[1h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[2h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate2h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[30m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate30m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[3d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate3d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[5m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate5m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code=~"5.."}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$",code=~"5.."}[6h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production"}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-production",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-mst-production
         service: observatorium-alertmanager

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -17,12 +17,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="receive"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="receive"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -33,12 +32,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="receive"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="receive"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -49,12 +47,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="receive"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="receive"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -65,76 +62,68 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="receive"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="receive"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
@@ -143,22 +132,21 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (6*0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
@@ -167,22 +155,21 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
@@ -190,84 +177,77 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[5m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[30m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[1h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[2h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[6h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[1d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[3d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
@@ -280,12 +260,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -296,12 +275,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -312,12 +290,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -328,76 +305,68 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
@@ -407,12 +376,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query_range"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -423,12 +391,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -439,12 +406,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query_range"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -455,76 +421,68 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query_range"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
@@ -907,12 +865,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
@@ -924,12 +881,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
@@ -941,12 +897,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
@@ -958,83 +913,75 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
@@ -1047,12 +994,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
@@ -1062,12 +1008,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
         service: telemeter
         severity: critical
@@ -1077,12 +1022,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
         service: telemeter
         severity: medium
@@ -1092,69 +1036,61 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-production
       record: client_api_requests_total:burnrate6h
   - name: rhobs-mst-api-rules-read-availability.slo
@@ -1165,12 +1101,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (14.40 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (14.40 * (1-0.90000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1181,12 +1116,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (6.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (6.00 * (1-0.90000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1197,12 +1131,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (3.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (3.00 * (1-0.90000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1213,76 +1146,68 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (1.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (1.00 * (1-0.90000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
@@ -1294,12 +1219,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (14.40 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (14.40 * (1-0.90000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1310,12 +1234,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (6.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (6.00 * (1-0.90000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1326,12 +1249,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (3.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (3.00 * (1-0.90000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1342,76 +1264,68 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (1.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (1.00 * (1-0.90000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -72,57 +72,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[1d]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[1h]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[2h]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[30m]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[3d]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[5m]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[6h]))
       labels:
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -132,7 +132,7 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
@@ -155,7 +155,7 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
@@ -177,9 +177,9 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[5m]))
         )
       labels:
         handler: receive
@@ -188,9 +188,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[30m]))
         )
       labels:
         handler: receive
@@ -199,9 +199,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[1h]))
         )
       labels:
         handler: receive
@@ -210,9 +210,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[2h]))
         )
       labels:
         handler: receive
@@ -221,9 +221,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[6h]))
         )
       labels:
         handler: receive
@@ -232,9 +232,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[1d]))
         )
       labels:
         handler: receive
@@ -243,9 +243,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code!~"^4..$"}[3d]))
         )
       labels:
         handler: receive
@@ -315,57 +315,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[1d]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[1h]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[2h]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[30m]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[3d]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[5m]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code!~"^4..$"}[6h]))
       labels:
         handler: query
         job: observatorium-observatorium-mst-api
@@ -431,57 +431,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[1d]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[1h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[2h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[30m]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[3d]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[5m]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code!~"^4..$"}[6h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -924,63 +924,63 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[1d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[1h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[2h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[30m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[3d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[5m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[6h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -1045,51 +1045,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate6h
@@ -1156,57 +1156,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[1d]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[1h]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[2h]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[30m]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[3d]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[5m]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code!~"^4..$"}[6h]))
       labels:
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1274,57 +1274,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[1d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[1h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[2h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[30m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[3d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[5m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[6h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -1388,51 +1388,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[1d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate1d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[1h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate1h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[2h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate2h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[30m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate30m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[3d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate3d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[5m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate5m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code=~"5.."}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[6h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage"}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-mst-stage",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-mst-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate6h
@@ -1493,57 +1493,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[1d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[1h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[2h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate2h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[30m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate30m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[3d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate3d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[5m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate5m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code=~"5.."}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$",code=~"5.."}[6h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage"}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-mst-stage",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -17,12 +17,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="receive"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="receive"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -33,12 +32,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="receive"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="receive"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -49,12 +47,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="receive"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="receive"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -65,76 +62,68 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="receive"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="receive"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="receive"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
@@ -143,22 +132,21 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (6*0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
@@ -167,22 +155,21 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/rhobs-mst-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-mst-api,handler=receive,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-mst-api",handler="receive",latency="5"} > (0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
@@ -190,84 +177,77 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[5m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[30m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[1h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[2h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[6h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[1d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-mst-api",handler="receive",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive",code=~"^(2..|3..|5..)$"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-mst-api",handler="receive"}[3d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-mst-api
         latency: "5"
@@ -280,12 +260,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -296,12 +275,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -312,12 +290,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -328,76 +305,68 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
@@ -407,12 +376,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",handler="query_range"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",handler="query_range"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -423,12 +391,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",handler="query_range"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -439,12 +406,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",handler="query_range"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",handler="query_range"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -455,76 +421,68 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",handler="query_range"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",handler="query_range"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",handler="query_range"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
@@ -907,12 +865,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
@@ -924,12 +881,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
@@ -941,12 +897,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
@@ -958,83 +913,75 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",method="PUT"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
@@ -1047,12 +994,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
         service: telemeter
         severity: high
@@ -1062,12 +1008,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
         service: telemeter
         severity: high
@@ -1077,12 +1022,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
@@ -1092,69 +1036,61 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-mst-stage
       record: client_api_requests_total:burnrate6h
   - name: rhobs-mst-api-rules-read-availability.slo
@@ -1165,12 +1101,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (14.40 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (14.40 * (1-0.90000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1181,12 +1116,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (6.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (6.00 * (1-0.90000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1197,12 +1131,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (3.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (3.00 * (1-0.90000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1213,76 +1146,68 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (1.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}) > (1.00 * (1-0.90000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h
@@ -1294,12 +1219,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (14.40 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (14.40 * (1-0.90000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1310,12 +1234,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (6.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (6.00 * (1-0.90000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1326,12 +1249,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (3.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (3.00 * (1-0.90000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         service: telemeter
@@ -1342,76 +1264,68 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (1.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}) > (1.00 * (1-0.90000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-mst-api",group="metricsv1",handler="rules-raw"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-mst-api
       record: http_requests_total:burnrate6h

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -11,253 +11,461 @@ spec:
   groups:
   - name: rhobs-telemeter-telemeter-server-metrics-write-availability.slo
     rules:
-    - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
+        message: Telemeter Server /upload is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwriteavailabilityerrorbudgetburning
       expr: |
-        sum(haproxy_server_http_responses_total:burnrate5m{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate5m{route="telemeter-server-upload"}) > (14.40 * (1-0.95000))
         and
-        sum(haproxy_server_http_responses_total:burnrate1h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate1h{route="telemeter-server-upload"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
         service: telemeter
         severity: critical
-    - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
+        message: Telemeter Server /upload is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwriteavailabilityerrorbudgetburning
       expr: |
-        sum(haproxy_server_http_responses_total:burnrate30m{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate30m{route="telemeter-server-upload"}) > (6.00 * (1-0.95000))
         and
-        sum(haproxy_server_http_responses_total:burnrate6h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate6h{route="telemeter-server-upload"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
         service: telemeter
         severity: critical
-    - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
+        message: Telemeter Server /upload is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwriteavailabilityerrorbudgetburning
       expr: |
-        sum(haproxy_server_http_responses_total:burnrate2h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate2h{route="telemeter-server-upload"}) > (3.00 * (1-0.95000))
         and
-        sum(haproxy_server_http_responses_total:burnrate1d{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate1d{route="telemeter-server-upload"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
         service: telemeter
         severity: medium
-    - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
+        message: Telemeter Server /upload is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwriteavailabilityerrorbudgetburning
       expr: |
-        sum(haproxy_server_http_responses_total:burnrate6h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate6h{route="telemeter-server-upload"}) > (1.00 * (1-0.95000))
         and
-        sum(haproxy_server_http_responses_total:burnrate3d{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate3d{route="telemeter-server-upload"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[1d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate1d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[1h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate1h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[2h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate2h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[30m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate30m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[3d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate3d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[5m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate5m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[6h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
+      record: haproxy_server_http_responses_total:burnrate6h
+    - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: Telemeter Server /receive is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewriteavailabilityerrorbudgetburning
+      expr: |
+        sum(haproxy_server_http_responses_total:burnrate5m{route="telemeter-server-metrics-v1-receive"}) > (14.40 * (1-0.95000))
+        and
+        sum(haproxy_server_http_responses_total:burnrate1h{route="telemeter-server-metrics-v1-receive"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        route: telemeter-server-metrics-v1-receive
+        service: telemeter
+        severity: critical
+    - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: Telemeter Server /receive is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewriteavailabilityerrorbudgetburning
+      expr: |
+        sum(haproxy_server_http_responses_total:burnrate30m{route="telemeter-server-metrics-v1-receive"}) > (6.00 * (1-0.95000))
+        and
+        sum(haproxy_server_http_responses_total:burnrate6h{route="telemeter-server-metrics-v1-receive"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        route: telemeter-server-metrics-v1-receive
+        service: telemeter
+        severity: critical
+    - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: Telemeter Server /receive is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewriteavailabilityerrorbudgetburning
+      expr: |
+        sum(haproxy_server_http_responses_total:burnrate2h{route="telemeter-server-metrics-v1-receive"}) > (3.00 * (1-0.95000))
+        and
+        sum(haproxy_server_http_responses_total:burnrate1d{route="telemeter-server-metrics-v1-receive"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        route: telemeter-server-metrics-v1-receive
+        service: telemeter
+        severity: medium
+    - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: Telemeter Server /receive is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewriteavailabilityerrorbudgetburning
+      expr: |
+        sum(haproxy_server_http_responses_total:burnrate6h{route="telemeter-server-metrics-v1-receive"}) > (1.00 * (1-0.95000))
+        and
+        sum(haproxy_server_http_responses_total:burnrate3d{route="telemeter-server-metrics-v1-receive"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        route: telemeter-server-metrics-v1-receive
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[1d]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[1d]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate1d
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[1h]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[1h]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate1h
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[2h]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[2h]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate2h
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[30m]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[30m]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate30m
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[3d]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[3d]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate3d
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[5m]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[5m]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate5m
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[6h]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[6h]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate6h
   - name: rhobs-telemeter-telemeter-server-metrics-write-latency.slo
     rules:
-    - alert: TelemeterServerMetricsWriteLatencyErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=~upload|receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswritelatencyerrorbudgetburning
+        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate1h{job="telemeter-server",handler="upload",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate5m{job="telemeter-server",handler="upload",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler="upload",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate30m{job="telemeter-server",handler="upload",latency="5"} > (6*0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
         service: telemeter
         severity: critical
-    - alert: TelemeterServerMetricsWriteLatencyErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=~upload|receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswritelatencyerrorbudgetburning
+        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate1d{job="telemeter-server",handler="upload",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate2h{job="telemeter-server",handler="upload",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate3d{job="telemeter-server",handler="upload",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler="upload",latency="5"} > (0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[5m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[30m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[1h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[2h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[6h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[1d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[3d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate3d
+    - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewritelatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:http_request_duration_seconds:rate1h{job="telemeter-server",handler="receive",latency="5"} > (14.4*0.100000)
+          and
+          latencytarget:http_request_duration_seconds:rate5m{job="telemeter-server",handler="receive",latency="5"} > (14.4*0.100000)
+        )
+        or
+        (
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler="receive",latency="5"} > (6*0.100000)
+          and
+          latencytarget:http_request_duration_seconds:rate30m{job="telemeter-server",handler="receive",latency="5"} > (6*0.100000)
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+        service: telemeter
+        severity: critical
+    - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewritelatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:http_request_duration_seconds:rate1d{job="telemeter-server",handler="receive",latency="5"} > (3*0.100000)
+          and
+          latencytarget:http_request_duration_seconds:rate2h{job="telemeter-server",handler="receive",latency="5"} > (3*0.100000)
+        )
+        or
+        (
+          latencytarget:http_request_duration_seconds:rate3d{job="telemeter-server",handler="receive",latency="5"} > (0.100000)
+          and
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler="receive",latency="5"} > (0.100000)
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+        service: telemeter
+        severity: medium
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[5m]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[5m]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate5m
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[30m]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[30m]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate30m
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[1h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[1h]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate1h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[2h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[2h]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate2h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[6h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[6h]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate6h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[1d]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[1d]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate1d
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[3d]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[3d]))
+        )
+      labels:
+        handler: receive
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate3d
@@ -269,12 +477,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="receive"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler="receive"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         service: telemeter
@@ -285,12 +492,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="receive"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="receive"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         service: telemeter
@@ -301,12 +507,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="receive"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler="receive"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         service: telemeter
@@ -317,76 +522,68 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="receive"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler="receive"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
@@ -395,22 +592,21 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-api",handler="receive",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-api",handler="receive",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-api",handler="receive",latency="5"} > (6*0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
@@ -419,22 +615,21 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-api",handler="receive",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-api",handler="receive",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-api",handler="receive",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",latency="5"} > (0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
@@ -442,84 +637,77 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[5m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[30m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[1h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[2h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[6h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[1d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[3d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
@@ -532,12 +720,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler="query"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
         service: telemeter
@@ -548,12 +735,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
         service: telemeter
@@ -564,12 +750,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler="query"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
         service: telemeter
@@ -580,76 +765,68 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler="query"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
@@ -659,12 +836,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query_range"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler="query_range"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
         service: telemeter
@@ -675,12 +851,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query_range"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
         service: telemeter
@@ -691,12 +866,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query_range"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler="query_range"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
         service: telemeter
@@ -707,76 +881,68 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler="query_range"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
@@ -1159,12 +1325,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
@@ -1176,12 +1341,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
@@ -1193,12 +1357,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
@@ -1210,83 +1373,75 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
@@ -1299,12 +1454,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
@@ -1314,12 +1468,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
         service: telemeter
         severity: critical
@@ -1329,12 +1482,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
@@ -1344,69 +1496,61 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate6h
   - name: rhobs-telemeter-api-rules-read-availability.slo
@@ -1417,12 +1561,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (14.40 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (14.40 * (1-0.90000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
         service: telemeter
@@ -1433,12 +1576,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (6.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (6.00 * (1-0.90000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
         service: telemeter
@@ -1449,12 +1591,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (3.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (3.00 * (1-0.90000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
         service: telemeter
@@ -1465,76 +1606,68 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (1.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (1.00 * (1-0.90000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
@@ -1546,12 +1679,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (14.40 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (14.40 * (1-0.90000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         service: telemeter
@@ -1562,12 +1694,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (6.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (6.00 * (1-0.90000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         service: telemeter
@@ -1578,12 +1709,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (3.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (3.00 * (1-0.90000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         service: telemeter
@@ -1594,76 +1724,68 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (1.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (1.00 * (1-0.90000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -68,51 +68,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[1d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[1d]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate1d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[1h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[1h]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate1h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[2h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[2h]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate2h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[30m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[30m]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate30m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[3d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[3d]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate3d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[5m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[5m]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate5m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[6h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[6h]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate6h
@@ -173,51 +173,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[1d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[1d]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate1d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[1h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[1h]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate1h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[2h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[2h]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate2h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[30m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[30m]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate30m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[3d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[3d]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate3d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[5m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[5m]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate5m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[6h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[6h]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate6h
@@ -226,7 +226,7 @@ spec:
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwritelatencyerrorbudgetburning
       expr: |
         (
@@ -249,7 +249,7 @@ spec:
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwritelatencyerrorbudgetburning
       expr: |
         (
@@ -271,9 +271,9 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[5m]))
         )
       labels:
         handler: upload
@@ -282,9 +282,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[30m]))
         )
       labels:
         handler: upload
@@ -293,9 +293,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[1h]))
         )
       labels:
         handler: upload
@@ -304,9 +304,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[2h]))
         )
       labels:
         handler: upload
@@ -315,9 +315,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[6h]))
         )
       labels:
         handler: upload
@@ -326,9 +326,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[1d]))
         )
       labels:
         handler: upload
@@ -337,9 +337,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[3d]))
         )
       labels:
         handler: upload
@@ -349,7 +349,7 @@ spec:
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewritelatencyerrorbudgetburning
       expr: |
         (
@@ -372,7 +372,7 @@ spec:
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewritelatencyerrorbudgetburning
       expr: |
         (
@@ -394,9 +394,9 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[5m]))
         )
       labels:
         handler: receive
@@ -405,9 +405,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[30m]))
         )
       labels:
         handler: receive
@@ -416,9 +416,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[1h]))
         )
       labels:
         handler: receive
@@ -427,9 +427,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[2h]))
         )
       labels:
         handler: receive
@@ -438,9 +438,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[6h]))
         )
       labels:
         handler: receive
@@ -449,9 +449,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[1d]))
         )
       labels:
         handler: receive
@@ -460,9 +460,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[3d]))
         )
       labels:
         handler: receive
@@ -532,57 +532,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[1d]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[1h]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[2h]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[30m]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[3d]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[5m]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[6h]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
@@ -592,7 +592,7 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
@@ -615,7 +615,7 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
@@ -637,9 +637,9 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[5m]))
         )
       labels:
         handler: receive
@@ -648,9 +648,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[30m]))
         )
       labels:
         handler: receive
@@ -659,9 +659,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[1h]))
         )
       labels:
         handler: receive
@@ -670,9 +670,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[2h]))
         )
       labels:
         handler: receive
@@ -681,9 +681,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[6h]))
         )
       labels:
         handler: receive
@@ -692,9 +692,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[1d]))
         )
       labels:
         handler: receive
@@ -703,9 +703,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[3d]))
         )
       labels:
         handler: receive
@@ -775,57 +775,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[1d]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[1h]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[2h]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[30m]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[3d]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[5m]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[6h]))
       labels:
         handler: query
         job: observatorium-observatorium-api
@@ -891,57 +891,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[1d]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[1h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[2h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[30m]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[3d]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[5m]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[6h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
@@ -1384,63 +1384,63 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[1d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[1h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[2h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[30m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[3d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[5m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[6h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1505,51 +1505,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-production",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-metrics-production
       record: client_api_requests_total:burnrate6h
@@ -1616,57 +1616,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[1d]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[1h]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[2h]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[30m]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[3d]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[5m]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[6h]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
@@ -1734,57 +1734,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[1d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[1h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[2h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[30m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[3d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[5m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[6h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1848,51 +1848,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[1d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate1d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[1h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate1h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[2h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate2h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[30m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate30m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[3d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate3d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[5m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate5m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code=~"5.."}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[6h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production"}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-production",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-metrics-production
       record: thanos_alert_sender_alerts_dropped_total:burnrate6h
@@ -1953,57 +1953,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[1d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[1h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[2h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate2h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[30m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate30m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[3d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate3d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[5m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate5m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code=~"5.."}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$",code=~"5.."}[6h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production"}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-production",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -68,51 +68,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[1d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[1d]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate1d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[1h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[1h]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate1h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[2h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[2h]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate2h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[30m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[30m]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate30m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[3d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[3d]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate3d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[5m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[5m]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate5m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$",code="5xx"}[6h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code!~"^4..$"}[6h]))
       labels:
         route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate6h
@@ -173,51 +173,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[1d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[1d]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate1d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[1h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[1h]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate1h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[2h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[2h]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate2h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[30m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[30m]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate30m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[3d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[3d]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate3d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[5m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[5m]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate5m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$",code="5xx"}[6h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code!~"^4..$"}[6h]))
       labels:
         route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate6h
@@ -226,7 +226,7 @@ spec:
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwritelatencyerrorbudgetburning
       expr: |
         (
@@ -249,7 +249,7 @@ spec:
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwritelatencyerrorbudgetburning
       expr: |
         (
@@ -271,9 +271,9 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[5m]))
         )
       labels:
         handler: upload
@@ -282,9 +282,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[30m]))
         )
       labels:
         handler: upload
@@ -293,9 +293,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[1h]))
         )
       labels:
         handler: upload
@@ -304,9 +304,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[2h]))
         )
       labels:
         handler: upload
@@ -315,9 +315,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[6h]))
         )
       labels:
         handler: upload
@@ -326,9 +326,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[1d]))
         )
       labels:
         handler: upload
@@ -337,9 +337,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",code!~"^4..$",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload",code!~"^4..$"}[3d]))
         )
       labels:
         handler: upload
@@ -349,7 +349,7 @@ spec:
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewritelatencyerrorbudgetburning
       expr: |
         (
@@ -372,7 +372,7 @@ spec:
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewritelatencyerrorbudgetburning
       expr: |
         (
@@ -394,9 +394,9 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[5m]))
         )
       labels:
         handler: receive
@@ -405,9 +405,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[30m]))
         )
       labels:
         handler: receive
@@ -416,9 +416,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[1h]))
         )
       labels:
         handler: receive
@@ -427,9 +427,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[2h]))
         )
       labels:
         handler: receive
@@ -438,9 +438,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[6h]))
         )
       labels:
         handler: receive
@@ -449,9 +449,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[1d]))
         )
       labels:
         handler: receive
@@ -460,9 +460,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",code!~"^4..$",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive",code!~"^4..$"}[3d]))
         )
       labels:
         handler: receive
@@ -532,57 +532,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[1d]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[1h]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[2h]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[30m]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[3d]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[5m]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[6h]))
       labels:
         handler: receive
         job: observatorium-observatorium-api
@@ -592,7 +592,7 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
@@ -615,7 +615,7 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code!~^4..$,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
@@ -637,9 +637,9 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[5m]))
         )
       labels:
         handler: receive
@@ -648,9 +648,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[30m]))
         )
       labels:
         handler: receive
@@ -659,9 +659,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[1h]))
         )
       labels:
         handler: receive
@@ -670,9 +670,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[2h]))
         )
       labels:
         handler: receive
@@ -681,9 +681,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[6h]))
         )
       labels:
         handler: receive
@@ -692,9 +692,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[1d]))
         )
       labels:
         handler: receive
@@ -703,9 +703,9 @@ spec:
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code!~"^4..$",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code!~"^4..$"}[3d]))
         )
       labels:
         handler: receive
@@ -775,57 +775,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[1d]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[1h]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[2h]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[30m]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[3d]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[5m]))
       labels:
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code!~"^4..$"}[6h]))
       labels:
         handler: query
         job: observatorium-observatorium-api
@@ -891,57 +891,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[1d]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[1h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[2h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[30m]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[3d]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[5m]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code!~"^4..$"}[6h]))
       labels:
         handler: query_range
         job: observatorium-observatorium-api
@@ -1384,63 +1384,63 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[1d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[1h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[2h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[30m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[3d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[5m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code!~"^4..$"}[6h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1505,51 +1505,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate6h
@@ -1616,57 +1616,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[1d]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[1h]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[2h]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[30m]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[3d]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[5m]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code!~"^4..$"}[6h]))
       labels:
         handler: rules
         job: observatorium-observatorium-api
@@ -1734,57 +1734,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[1d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[1h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[2h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[30m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[3d]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[5m]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code!~"^4..$"}[6h]))
       labels:
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1848,51 +1848,51 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[1d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[1d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate1d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[1h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[1h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate1h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[2h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[2h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate2h
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[30m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[30m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate30m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[3d]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[3d]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate3d
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[5m]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[5m]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate5m
     - expr: |
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code=~"5.."}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[6h]))
         /
-        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage"}[6h]))
+        sum(rate(thanos_alert_sender_alerts_dropped_total{container="thanos-rule",namespace="observatorium-metrics-stage",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-metrics-stage
       record: thanos_alert_sender_alerts_dropped_total:burnrate6h
@@ -1953,57 +1953,57 @@ spec:
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[1d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[1d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$"}[1d]))
       labels:
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[1h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[1h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$"}[1h]))
       labels:
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate1h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[2h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[2h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$"}[2h]))
       labels:
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate2h
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[30m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[30m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$"}[30m]))
       labels:
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate30m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[3d]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[3d]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$"}[3d]))
       labels:
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate3d
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[5m]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[5m]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$"}[5m]))
       labels:
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
       record: alertmanager_notifications_failed_total:burnrate5m
     - expr: |
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code=~"5.."}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$",code=~"5.."}[6h]))
         /
-        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage"}[6h]))
+        sum(rate(alertmanager_notifications_failed_total{service="observatorium-alertmanager",namespace="observatorium-metrics-stage",code!~"^4..$"}[6h]))
       labels:
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -11,253 +11,461 @@ spec:
   groups:
   - name: rhobs-telemeter-telemeter-server-metrics-write-availability.slo
     rules:
-    - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
+        message: Telemeter Server /upload is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwriteavailabilityerrorbudgetburning
       expr: |
-        sum(haproxy_server_http_responses_total:burnrate5m{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate5m{route="telemeter-server-upload"}) > (14.40 * (1-0.95000))
         and
-        sum(haproxy_server_http_responses_total:burnrate1h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate1h{route="telemeter-server-upload"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
         service: telemeter
         severity: high
-    - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
+        message: Telemeter Server /upload is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwriteavailabilityerrorbudgetburning
       expr: |
-        sum(haproxy_server_http_responses_total:burnrate30m{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate30m{route="telemeter-server-upload"}) > (6.00 * (1-0.95000))
         and
-        sum(haproxy_server_http_responses_total:burnrate6h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate6h{route="telemeter-server-upload"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
         service: telemeter
         severity: high
-    - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
+        message: Telemeter Server /upload is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwriteavailabilityerrorbudgetburning
       expr: |
-        sum(haproxy_server_http_responses_total:burnrate2h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate2h{route="telemeter-server-upload"}) > (3.00 * (1-0.95000))
         and
-        sum(haproxy_server_http_responses_total:burnrate1d{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate1d{route="telemeter-server-upload"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
         service: telemeter
         severity: medium
-    - alert: TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: Telemeter Server /upload or /receive is burning too much error budget to guarantee availability SLOs
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswriteavailabilityerrorbudgetburning
+        message: Telemeter Server /upload is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwriteavailabilityerrorbudgetburning
       expr: |
-        sum(haproxy_server_http_responses_total:burnrate6h{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate6h{route="telemeter-server-upload"}) > (1.00 * (1-0.95000))
         and
-        sum(haproxy_server_http_responses_total:burnrate3d{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(haproxy_server_http_responses_total:burnrate3d{route="telemeter-server-upload"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[1d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate1d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[1h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate1h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[2h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate2h
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[30m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate30m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[3d]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate3d
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[5m]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
       record: haproxy_server_http_responses_total:burnrate5m
     - expr: |
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$",code="5xx"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload",code="5xx"}[6h]))
         /
-        sum(rate(haproxy_server_http_responses_total{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-upload"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
-        route: telemeter-server-upload|telemeter-server-metrics-v1-receive
+        route: telemeter-server-upload
+      record: haproxy_server_http_responses_total:burnrate6h
+    - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: Telemeter Server /receive is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewriteavailabilityerrorbudgetburning
+      expr: |
+        sum(haproxy_server_http_responses_total:burnrate5m{route="telemeter-server-metrics-v1-receive"}) > (14.40 * (1-0.95000))
+        and
+        sum(haproxy_server_http_responses_total:burnrate1h{route="telemeter-server-metrics-v1-receive"}) > (14.40 * (1-0.95000))
+      for: 2m
+      labels:
+        route: telemeter-server-metrics-v1-receive
+        service: telemeter
+        severity: high
+    - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: Telemeter Server /receive is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewriteavailabilityerrorbudgetburning
+      expr: |
+        sum(haproxy_server_http_responses_total:burnrate30m{route="telemeter-server-metrics-v1-receive"}) > (6.00 * (1-0.95000))
+        and
+        sum(haproxy_server_http_responses_total:burnrate6h{route="telemeter-server-metrics-v1-receive"}) > (6.00 * (1-0.95000))
+      for: 15m
+      labels:
+        route: telemeter-server-metrics-v1-receive
+        service: telemeter
+        severity: high
+    - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: Telemeter Server /receive is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewriteavailabilityerrorbudgetburning
+      expr: |
+        sum(haproxy_server_http_responses_total:burnrate2h{route="telemeter-server-metrics-v1-receive"}) > (3.00 * (1-0.95000))
+        and
+        sum(haproxy_server_http_responses_total:burnrate1d{route="telemeter-server-metrics-v1-receive"}) > (3.00 * (1-0.95000))
+      for: 1h
+      labels:
+        route: telemeter-server-metrics-v1-receive
+        service: telemeter
+        severity: medium
+    - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-availability.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: Telemeter Server /receive is burning too much error budget to guarantee availability SLOs
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewriteavailabilityerrorbudgetburning
+      expr: |
+        sum(haproxy_server_http_responses_total:burnrate6h{route="telemeter-server-metrics-v1-receive"}) > (1.00 * (1-0.95000))
+        and
+        sum(haproxy_server_http_responses_total:burnrate3d{route="telemeter-server-metrics-v1-receive"}) > (1.00 * (1-0.95000))
+      for: 3h
+      labels:
+        route: telemeter-server-metrics-v1-receive
+        service: telemeter
+        severity: medium
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[1d]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[1d]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate1d
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[1h]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[1h]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate1h
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[2h]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[2h]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate2h
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[30m]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[30m]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate30m
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[3d]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[3d]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate3d
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[5m]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[5m]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
+      record: haproxy_server_http_responses_total:burnrate5m
+    - expr: |
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",code="5xx"}[6h]))
+        /
+        sum(rate(haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive"}[6h]))
+      labels:
+        route: telemeter-server-metrics-v1-receive
       record: haproxy_server_http_responses_total:burnrate6h
   - name: rhobs-telemeter-telemeter-server-metrics-write-latency.slo
     rules:
-    - alert: TelemeterServerMetricsWriteLatencyErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=~upload|receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswritelatencyerrorbudgetburning
+        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate1h{job="telemeter-server",handler="upload",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate5m{job="telemeter-server",handler="upload",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler="upload",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate30m{job="telemeter-server",handler="upload",latency="5"} > (6*0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
         service: telemeter
         severity: high
-    - alert: TelemeterServerMetricsWriteLatencyErrorBudgetBurning
+    - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=telemeter-server,handler=~upload|receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricswritelatencyerrorbudgetburning
+        message: 'High requests latency budget burn for job=telemeter-server,handler=upload,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsuploadwritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate1d{job="telemeter-server",handler="upload",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate2h{job="telemeter-server",handler="upload",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate3d{job="telemeter-server",handler="upload",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler="upload",latency="5"} > (0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
         service: telemeter
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[5m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[30m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[1h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[2h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[6h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[1d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="upload",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler=~"upload|receive",code=~"^(2..|3..|5..)$"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="upload"}[3d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
-        handler: upload|receive
+        handler: upload
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate3d
+    - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewritelatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:http_request_duration_seconds:rate1h{job="telemeter-server",handler="receive",latency="5"} > (14.4*0.100000)
+          and
+          latencytarget:http_request_duration_seconds:rate5m{job="telemeter-server",handler="receive",latency="5"} > (14.4*0.100000)
+        )
+        or
+        (
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler="receive",latency="5"} > (6*0.100000)
+          and
+          latencytarget:http_request_duration_seconds:rate30m{job="telemeter-server",handler="receive",latency="5"} > (6*0.100000)
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+        service: telemeter
+        severity: high
+    - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-telemeter-server-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: 'High requests latency budget burn for job=telemeter-server,handler=receive,latency=5 (current value: {{ $value }})'
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#telemeterservermetricsreceivewritelatencyerrorbudgetburning
+      expr: |
+        (
+          latencytarget:http_request_duration_seconds:rate1d{job="telemeter-server",handler="receive",latency="5"} > (3*0.100000)
+          and
+          latencytarget:http_request_duration_seconds:rate2h{job="telemeter-server",handler="receive",latency="5"} > (3*0.100000)
+        )
+        or
+        (
+          latencytarget:http_request_duration_seconds:rate3d{job="telemeter-server",handler="receive",latency="5"} > (0.100000)
+          and
+          latencytarget:http_request_duration_seconds:rate6h{job="telemeter-server",handler="receive",latency="5"} > (0.100000)
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+        service: telemeter
+        severity: medium
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[5m]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[5m]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate5m
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[30m]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[30m]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate30m
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[1h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[1h]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate1h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[2h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[2h]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate2h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[6h]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[6h]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate6h
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[1d]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[1d]))
+        )
+      labels:
+        handler: receive
+        job: telemeter-server
+        latency: "5"
+      record: latencytarget:http_request_duration_seconds:rate1d
+    - expr: |
+        1 - (
+          sum(rate(http_request_duration_seconds_bucket{job="telemeter-server",handler="receive",le="5",code!~"5.."}[3d]))
+          /
+          sum(rate(http_request_duration_seconds_count{job="telemeter-server",handler="receive"}[3d]))
+        )
+      labels:
+        handler: receive
         job: telemeter-server
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate3d
@@ -269,12 +477,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="receive"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler="receive"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         service: telemeter
@@ -285,12 +492,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="receive"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="receive"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         service: telemeter
@@ -301,12 +507,11 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="receive"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler="receive"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         service: telemeter
@@ -317,76 +522,68 @@ spec:
         message: API /receive handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="receive"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler="receive"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler=~"receive",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="receive"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
@@ -395,22 +592,21 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate1h{job="observatorium-observatorium-api",handler="receive",latency="5"} > (14.4*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (14.4*0.100000)
+          latencytarget:http_request_duration_seconds:rate5m{job="observatorium-observatorium-api",handler="receive",latency="5"} > (14.4*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",latency="5"} > (6*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (6*0.100000)
+          latencytarget:http_request_duration_seconds:rate30m{job="observatorium-observatorium-api",handler="receive",latency="5"} > (6*0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
@@ -419,22 +615,21 @@ spec:
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/rhobs-telemeter-api-metrics-write-latency.slo?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,code=~^(2..|3..|5..)$,latency=5 (current value: {{ $value }})'
+        message: 'High requests latency budget burn for job=observatorium-observatorium-api,handler=receive,latency=5 (current value: {{ $value }})'
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricswritelatencyerrorbudgetburning
       expr: |
         (
-          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate1d{job="observatorium-observatorium-api",handler="receive",latency="5"} > (3*0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (3*0.100000)
+          latencytarget:http_request_duration_seconds:rate2h{job="observatorium-observatorium-api",handler="receive",latency="5"} > (3*0.100000)
         )
         or
         (
-          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate3d{job="observatorium-observatorium-api",handler="receive",latency="5"} > (0.100000)
           and
-          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",latency="5"} > (0.100000)
+          latencytarget:http_request_duration_seconds:rate6h{job="observatorium-observatorium-api",handler="receive",latency="5"} > (0.100000)
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
@@ -442,84 +637,77 @@ spec:
         severity: medium
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[5m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[5m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[5m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[5m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate5m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[30m]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[30m]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[30m]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[30m]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate30m
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[1h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[1h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[1h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[2h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[2h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[2h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[2h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate2h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[6h]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[6h]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[6h]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[6h]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate6h
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[1d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[1d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[1d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[1d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
       record: latencytarget:http_request_duration_seconds:rate1d
     - expr: |
         1 - (
-          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$",le="5",code!~"5.."}[3d]))
+          sum(rate(http_request_duration_seconds_bucket{job="observatorium-observatorium-api",handler="receive",le="5",code!~"5.."}[3d]))
           /
-          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive",code=~"^(2..|3..|5..)$"}[3d]))
+          sum(rate(http_request_duration_seconds_count{job="observatorium-observatorium-api",handler="receive"}[3d]))
         )
       labels:
-        code: ^(2..|3..|5..)$
         handler: receive
         job: observatorium-observatorium-api
         latency: "5"
@@ -532,12 +720,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler="query"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
         service: telemeter
@@ -548,12 +735,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
         service: telemeter
@@ -564,12 +750,11 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler="query"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
         service: telemeter
@@ -580,76 +765,68 @@ spec:
         message: API /query handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler="query"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
@@ -659,12 +836,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",handler="query_range"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",handler="query_range"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
         service: telemeter
@@ -675,12 +851,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",handler="query_range"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
         service: telemeter
@@ -691,12 +866,11 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",handler="query_range"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",handler="query_range"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
         service: telemeter
@@ -707,76 +881,68 @@ spec:
         message: API /query_range handler is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apimetricsreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",handler="query_range"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",handler="query_range"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",handler="query_range"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: query_range
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
@@ -1159,12 +1325,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (14.40 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (14.40 * (1-0.95000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
@@ -1176,12 +1341,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (6.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (6.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
@@ -1193,12 +1357,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (3.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (3.00 * (1-0.95000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
@@ -1210,83 +1373,75 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawwriteavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (1.00 * (1-0.95000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}) > (1.00 * (1-0.95000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"^(2..|3..|5..)$",method=~"PUT"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",method="PUT"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
@@ -1299,12 +1454,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate5m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}) > (14.40 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}) > (14.40 * (1-0.95000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
@@ -1314,12 +1468,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate30m{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}) > (6.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}) > (6.00 * (1-0.95000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: high
@@ -1329,12 +1482,11 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate2h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}) > (3.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate1d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}) > (3.00 * (1-0.95000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
@@ -1344,69 +1496,61 @@ spec:
         message: API /reload endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulessyncavailabilityerrorbudgetburning
       expr: |
-        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate6h{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}) > (1.00 * (1-0.95000))
         and
-        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.95000))
+        sum(client_api_requests_total:burnrate3d{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}) > (1.00 * (1-0.95000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[1d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate1d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[1h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate1h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[2h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate2h
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[30m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate30m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[3d]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate3d
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[5m]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate5m
     - expr: |
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"5.+"}[6h]))
         /
-        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(client_api_requests_total{client="reload",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         namespace: observatorium-metrics-stage
       record: client_api_requests_total:burnrate6h
   - name: rhobs-telemeter-api-rules-read-availability.slo
@@ -1417,12 +1561,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (14.40 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (14.40 * (1-0.90000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
         service: telemeter
@@ -1433,12 +1576,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (6.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (6.00 * (1-0.90000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
         service: telemeter
@@ -1449,12 +1591,11 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (3.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (3.00 * (1-0.90000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
         service: telemeter
@@ -1465,76 +1606,68 @@ spec:
         message: API /rules endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (1.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}) > (1.00 * (1-0.90000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h
@@ -1546,12 +1679,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate5m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (14.40 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (14.40 * (1-0.90000))
+        sum(http_requests_total:burnrate1h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (14.40 * (1-0.90000))
       for: 2m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         service: telemeter
@@ -1562,12 +1694,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate30m{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (6.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (6.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (6.00 * (1-0.90000))
       for: 15m
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         service: telemeter
@@ -1578,12 +1709,11 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate2h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (3.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (3.00 * (1-0.90000))
+        sum(http_requests_total:burnrate1d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (3.00 * (1-0.90000))
       for: 1h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         service: telemeter
@@ -1594,76 +1724,68 @@ spec:
         message: API /rules/raw endpoint is burning too much error budget to guarantee availability SLOs
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#apirulesrawreadavailabilityerrorbudgetburning
       expr: |
-        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate6h{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (1.00 * (1-0.90000))
         and
-        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}) > (1.00 * (1-0.90000))
+        sum(http_requests_total:burnrate3d{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}) > (1.00 * (1-0.90000))
       for: 3h
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
         service: telemeter
         severity: medium
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[1d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[1h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[1h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[1h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate1h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[2h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[2h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[2h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate2h
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[30m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[30m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[30m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate30m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[3d]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[3d]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[3d]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate3d
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[5m]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[5m]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[5m]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate5m
     - expr: |
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$",code=~"5.+"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw",code=~"5.+"}[6h]))
         /
-        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler=~"rules-raw",code=~"^(2..|3..|5..)$"}[6h]))
+        sum(rate(http_requests_total{job="observatorium-observatorium-api",group="metricsv1",handler="rules-raw"}[6h]))
       labels:
-        code: ^(2..|3..|5..)$
         handler: rules-raw
         job: observatorium-observatorium-api
       record: http_requests_total:burnrate6h


### PR DESCRIPTION
This PR attempts to fix the alerts for SLOs that do not work currently as mentioned in https://issues.redhat.com/browse/RHOBS-453 and [slack thread](https://coreos.slack.com/archives/G79AW9Q7R/p1663937832667149).  This removes the `code` label completely and splits up regex label selectors. This does not touch logging SLO alerts. 

This currently isn't working due to the [SLO jsonnet library](https://github.com/metalmatze/slo-libsonnet) that we use, which converts all selectors to labels for rule configs. 

At some point, we might consider migrating off of the lib, as it is now also deprecated!

A few examples of how this is broken, 

For `code` label, take the [`TelemeterServerMetricsWriteAvailabilityErrorBudgetBurning`](https://github.com/rhobs/configuration/blob/main/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml#L20) alert which uses expression like `haproxy_server_http_responses_total:burnrate5m{route=~"telemeter-server-upload|telemeter-server-metrics-v1-receive",code=~"^(2..|3..|5..)$"}`. This would only select code labels like `code="200"`, `code="300"` or `code="500"`.
But this is a recording rule as defined [here](https://github.com/rhobs/configuration/blob/main/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml#L115) and the code label [added](https://github.com/rhobs/configuration/blob/main/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml#L119) to this rule is just the regex string. So the alert expression would not return data as shown [here](https://prometheus.telemeter-prod-01.devshift.net/graph?g0.expr=sum(haproxy_server_http_responses_total%3Aburnrate5m%7Broute%3D~%22telemeter-server-upload%7Ctelemeter-server-metrics-v1-receive%22%2Ccode%3D~%22%5E(2..%7C3..%7C5..)%24%22%7D)%20%3E%20(14.40%20*%20(1-0.95000))%0Aand%20sum(haproxy_server_http_responses_total%3Aburnrate1h%7Broute%3D~%22telemeter-server-upload%7Ctelemeter-server-metrics-v1-receive%22%2Ccode%3D~%22%5E(2..%7C3..%7C5..)%24%22%7D)%20%3E%20(14.40%20*%20(1-0.95000))&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h) so it never fires.

We can take the same alert but look at the `route` label which is also a regex and is [used](https://github.com/rhobs/configuration/blob/main/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml#L20) as a regex label selector, which matches labels like `route="telemeter-server-upload"` or `route="telemeter-server-metrics-v1-receive"`. But for the recording rule, only the string is [added](https://github.com/rhobs/configuration/blob/main/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml#L120) as the route label. So the alert rule again cannot get data.

In some places `handler` labels also use regex, which can lead to confusing scenarios, so have split them up as well.

Feel free to point out if I'm wrong somewhere.

Also open question, on how code labels can be handled? I've removed them temporarily, but they filtered out any 400 response from all the alerts. I have some jsonnet hack https://github.com/saswatamcode/slo-libsonnet/commit/e230327cfd2bb37d5014e26c58138c3b8ce6536a which uses `ONLY_IN_BASE_` as a prefix to the selectors, to identify which selectors to include while generating rule configs. But this can be iterated on in future PR!