### PR TITLE
Remove recycle annotations for loki rules

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -2248,8 +2248,6 @@ objects:
             "severity": "warn"
   kind: ConfigMap
   metadata:
-    annotations:
-      qontract.recycle: "true"
     labels:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: loki

--- a/services/observatorium-logs-template-overwrites.libsonnet
+++ b/services/observatorium-logs-template-overwrites.libsonnet
@@ -59,7 +59,7 @@ local jaegerAgentSidecar = (import 'sidecars/jaeger-agent.libsonnet')({
     manifests+:: {
       [name]+:
         local m = super[name];
-        if m.kind == 'ConfigMap' then
+        if m.kind == 'ConfigMap' && std.length(std.findSubstr('rules', name)) == 0 then
           m {
             metadata+: {
               annotations+: {


### PR DESCRIPTION
The recycle annotations is not needed for the Loki Rules ConfigMap because the Loki Ruler has a built-in file watcher. In extend restarting the ruler pods on rules updates is pushing the internal wal to create checkpoints and flush w/o need. This increases ruler restart times for no reason.