### PR TITLE
Add staging test alerts for rhobs logs

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -2246,6 +2246,18 @@ objects:
             "namespace": "uhc-stage"
             "service": "${labels.kubernetes_labels_app}"
             "severity": "warn"
+      - "interval": "1m"
+        "name": "rhobs-logs-stage-alerts"
+        "rules":
+        - "alert": "rhobs-logs-always-firing"
+          "annotations":
+            "summary": "rhobs logs alert that always fires"
+          "expr": "1 > 0"
+          "for": "1m"
+          "labels":
+            "namespace": "observatorium-mst-stage"
+            "service": "observatorium-loki-ruler"
+            "severity": "warn"
   kind: ConfigMap
   metadata:
     annotations:

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -4,6 +4,28 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
 {
   local obs = self,
 
+  local stageTestAlerts = [
+    {
+      interval: '1m',
+      name: 'rhobs-logs-stage-alerts',
+      rules: [
+        {
+          alert: 'rhobs-logs-always-firing',
+          annotations: {
+            summary: 'rhobs logs alert that always fires',
+          },
+          expr: '1 > 0',
+          'for': '1m',
+          labels: {
+            severity: 'warn',
+            namespace: 'observatorium-mst-stage',
+            service: 'observatorium-loki-ruler',
+          },
+        },
+      ],
+    },
+  ],
+
   local ocmAlerts = [
     {
       interval: '1m',
@@ -143,7 +165,7 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
     },
     rules: {
       'rhobs-logs-ocm-alerts': {
-        groups: ocmAlerts,
+        groups: ocmAlerts + stageTestAlerts,
       },
     },
     resources: {


### PR DESCRIPTION
Adds an always firing rhobs logs alert to test the RHOBS alertmanager connectivity from Loki ruler on staging. 