### PR TITLE
Fix alertmanager discovery for logs ruler

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -675,7 +675,7 @@ objects:
         "max_outstanding_requests_per_tenant": 256
       "ruler":
         "alertmanager_refresh_interval": "1m"
-        "alertmanager_url": "http://_web._tcp.observatorium-alertmanager.${ALERTMANAGER_NAMESPACE}.svc.cluster.local"
+        "alertmanager_url": "http://_http._tcp.observatorium-alertmanager.${ALERTMANAGER_NAMESPACE}.svc.cluster.local"
         "enable_alertmanager_discovery": true
         "enable_alertmanager_v2": true
         "enable_api": true

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -298,7 +298,7 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
       ruler+: {
         enable_alertmanager_discovery: true,
         enable_alertmanager_v2: true,
-        alertmanager_url: 'http://_web._tcp.observatorium-alertmanager.${ALERTMANAGER_NAMESPACE}.svc.cluster.local',
+        alertmanager_url: 'http://_http._tcp.observatorium-alertmanager.${ALERTMANAGER_NAMESPACE}.svc.cluster.local',
         alertmanager_refresh_interval: '1m',
       },
       tracing: {


### PR DESCRIPTION
According to staging deployment the port to look for dns-based discovery is `_http` and not `_web`:
![image](https://user-images.githubusercontent.com/152312/193020607-19cd69e6-da6e-46df-9677-4e78e62f1b6b.png)

