### PR TITLE
Disable compression on receive

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1957,6 +1957,7 @@ objects:
               "service_name": "thanos-receive"
             "type": "JAEGER"
           - --receive.default-tenant-id=FB870BF3-9F3A-44FF-9BF7-D7A047A52F43
+          - --receive.grpc-compression=none
           env:
           - name: NAME
             valueFrom:

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -401,6 +401,7 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                     if c.name == 'thanos-receive' then c {
                       args+: [
                         '--receive.default-tenant-id=FB870BF3-9F3A-44FF-9BF7-D7A047A52F43',
+                        '--receive.grpc-compression=none',
                       ],
                       env+: s3EnvVars + [{
                         name: 'DEBUG',


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Since `0.28.0`, receiver uses snappy compression for gRPC requests by default (https://github.com/thanos-io/thanos/pull/5575#discussion_r939525460). However, we noticed in our case this leads to an increased memory consumption on receiver replicas, especially in Telemeter where the requests are bigger (contain more series). Since we're better of with no compression / less memory overhead in our case, I'm disabling it.