### PR TITLE
MCO-371: Add os_image_url_override metric to allowlist

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -126,6 +126,7 @@
   "{__name__=\"openshift_csi_share_mount_failures_total\"}",
   "{__name__=\"openshift_csi_share_mount_requests_total\"}",
   "{__name__=\"openshift_csi_share_secret\"}",
+  "{__name__=\"os_image_url_override:sum\"}",
   "{__name__=\"platform:hypershift_hostedclusters:max\"}",
   "{__name__=\"platform:hypershift_nodepools:max\"}",
   "{__name__=\"pod:eo_es_shards_total:max\"}",

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -220,6 +220,7 @@ objects:
           - --whitelist={__name__="openshift_csi_share_mount_failures_total"}
           - --whitelist={__name__="openshift_csi_share_mount_requests_total"}
           - --whitelist={__name__="openshift_csi_share_secret"}
+          - --whitelist={__name__="os_image_url_override:sum"}
           - --whitelist={__name__="platform:hypershift_hostedclusters:max"}
           - --whitelist={__name__="platform:hypershift_nodepools:max"}
           - --whitelist={__name__="pod:eo_es_shards_total:max"}
@@ -456,6 +457,7 @@ objects:
           - --whitelist={__name__="openshift_csi_share_mount_failures_total"}
           - --whitelist={__name__="openshift_csi_share_mount_requests_total"}
           - --whitelist={__name__="openshift_csi_share_secret"}
+          - --whitelist={__name__="os_image_url_override:sum"}
           - --whitelist={__name__="platform:hypershift_hostedclusters:max"}
           - --whitelist={__name__="platform:hypershift_nodepools:max"}
           - --whitelist={__name__="pod:eo_es_shards_total:max"}


### PR DESCRIPTION
os_image_url_override:sum telemetry data will be added as part of https://github.com/openshift/cluster-monitoring-operator/pull/1784