### PR TITLE
Add querier with new PromQL engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ $(JSONNET_VENDOR_DIR): $(JB) jsonnetfile.json jsonnetfile.lock.json
 
 .PHONY: update
 update: $(JB) jsonnetfile.json jsonnetfile.lock.json
-	@$(JB) update --jsonnetpkg-home="$(JSONNET_VENDOR_DIR)" https://github.com/rhobs/obsctl-reloader/jsonnet/lib@main
+	@$(JB) update --jsonnetpkg-home="$(JSONNET_VENDOR_DIR)" https://github.com/thanos-io/kube-thanos/jsonnet/kube-thanos@main
 
 .PHONY: format
 format: $(JSONNET_SRC) $(JSONNETFMT)

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -137,7 +137,7 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "2d975ec1b26cd60e861dd464a06b64b079d6b19b"
+      "version": "main"
     },
     {
       "source": {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -336,8 +336,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "2d975ec1b26cd60e861dd464a06b64b079d6b19b",
-      "sum": "Gfr5laSFgc5RputsL52OrZGo09LnaE69k4PzRyT4rsQ="
+      "version": "e57d1530c9eb7acd12d26fd0c5992f6d348e00a6",
+      "sum": "m2n71ym5ftCJGFTnsuDxC3PCxSQoybI9wx1DRElK+Uc="
     },
     {
       "source": {

--- a/resources/services/metric-federation-rule-template.yaml
+++ b/resources/services/metric-federation-rule-template.yaml
@@ -33,6 +33,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    annotations: {}
     labels:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: metric-federation
@@ -496,6 +497,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    annotations: {}
     labels:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: metric-federation

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -45,6 +45,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    annotations: {}
     labels:
       app.kubernetes.io/component: database-compactor
       app.kubernetes.io/instance: observatorium
@@ -749,6 +750,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    annotations: {}
     labels:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: observatorium
@@ -1547,6 +1549,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    annotations: {}
     labels:
       app.kubernetes.io/component: query-cache
       app.kubernetes.io/instance: observatorium
@@ -1625,6 +1628,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    annotations: {}
     labels:
       app.kubernetes.io/component: query-layer
       app.kubernetes.io/instance: observatorium
@@ -1826,7 +1830,7 @@ objects:
         app.kubernetes.io/instance: observatorium
         app.kubernetes.io/name: thanos-receive-controller
         app.kubernetes.io/part-of: observatorium
-- apiVersion: policy/v1beta1
+- apiVersion: policy/v1
   kind: PodDisruptionBudget
   metadata:
     name: observatorium-thanos-receive-default
@@ -2112,6 +2116,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    annotations: {}
     labels:
       app.kubernetes.io/component: database-write-hashring
       app.kubernetes.io/instance: observatorium
@@ -2179,6 +2184,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    annotations: {}
     labels:
       app.kubernetes.io/component: rule-evaluation-engine
       app.kubernetes.io/instance: observatorium
@@ -2662,6 +2668,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
+    annotations: {}
     labels:
       app.kubernetes.io/component: object-store-gateway
       app.kubernetes.io/instance: observatorium

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -992,6 +992,188 @@ objects:
           requests:
             storage: ${THANOS_RULER_PVC_REQUEST}
         storageClassName: ${STORAGE_CLASS}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-query
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_VOLCANO_IMAGE_TAG}
+    name: observatorium-volcano-query
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/part-of: observatorium
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/component: query-layer
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-query
+          app.kubernetes.io/part-of: observatorium
+          app.kubernetes.io/version: ${THANOS_VOLCANO_IMAGE_TAG}
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - thanos-query
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+        containers:
+        - args:
+          - query
+          - --grpc-address=0.0.0.0:10901
+          - --http-address=0.0.0.0:9090
+          - --log.level=${THANOS_VOLCANO_LOG_LEVEL}
+          - --log.format=logfmt
+          - --query.replica-label=replica
+          - --query.replica-label=rule_replica
+          - --query.replica-label=prometheus_replica
+          - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-0.${NAMESPACE}.svc.cluster.local
+          - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-1.${NAMESPACE}.svc.cluster.local
+          - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-2.${NAMESPACE}.svc.cluster.local
+          - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-3.${NAMESPACE}.svc.cluster.local
+          - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-4.${NAMESPACE}.svc.cluster.local
+          - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-5.${NAMESPACE}.svc.cluster.local
+          - --store=dnssrv+_grpc._tcp.${THANOS_RECEIVE_HASHRING_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local
+          - --rule=dnssrv+_grpc._tcp.observatorium-thanos-rule.${NAMESPACE}.svc.cluster.local
+          - --rule=dnssrv+_grpc._tcp.observatorium-thanos-stateless-rule.${NAMESPACE}.svc.cluster.local
+          - --web.prefix-header=X-Forwarded-Prefix
+          - --query.timeout=15m
+          - --query.lookback-delta=15m
+          - |-
+            --tracing.config="config":
+              "sampler_param": 2
+              "sampler_type": "ratelimiting"
+              "service_name": "thanos-query"
+            "type": "JAEGER"
+          - --query.auto-downsampling
+          - --query.promql-engine=thanos
+          - --store.sd-files=/etc/thanos/sd/file_sd.yaml
+          env:
+          - name: HOST_IP_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          image: ${THANOS_VOLCANO_IMAGE}:${THANOS_VOLCANO_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 4
+            httpGet:
+              path: /-/healthy
+              port: 9090
+              scheme: HTTP
+            periodSeconds: 30
+          name: thanos-query
+          ports:
+          - containerPort: 10901
+            name: grpc
+          - containerPort: 9090
+            name: http
+          readinessProbe:
+            failureThreshold: 20
+            httpGet:
+              path: /-/ready
+              port: 9090
+              scheme: HTTP
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: ${THANOS_VOLCANO_CPU_LIMIT}
+              memory: ${THANOS_VOLCANO_MEMORY_LIMIT}
+            requests:
+              cpu: ${THANOS_VOLCANO_CPU_REQUEST}
+              memory: ${THANOS_VOLCANO_MEMORY_REQUEST}
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /etc/thanos/sd
+            name: file-sd
+        nodeSelector:
+          kubernetes.io/os: linux
+        securityContext:
+          fsGroup: 65534
+          runAsUser: 65534
+        serviceAccountName: observatorium-volcano-query
+        terminationGracePeriodSeconds: 120
+        volumes:
+        - configMap:
+            name: thanos-query-file-sd
+          name: file-sd
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-query
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_VOLCANO_IMAGE_TAG}
+    name: observatorium-volcano-query
+  spec:
+    ports:
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+    - name: http
+      port: 9090
+      targetPort: 9090
+    selector:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-query
+      app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    annotations: {}
+    labels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-query
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: ${THANOS_VOLCANO_IMAGE_TAG}
+    name: observatorium-volcano-query
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: thanos-query
+      app.kubernetes.io/part-of: observatorium
+      prometheus: app-sre
+    name: observatorium-volcano-query
+  spec:
+    endpoints:
+    - port: http
+      relabelings:
+      - separator: /
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: instance
+    namespaceSelector:
+      matchNames: ${{NAMESPACES}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/part-of: observatorium
 - apiVersion: v1
   data:
     file_sd.yaml: '- targets: ${THANOS_QUERIER_FILE_SD_TARGETS}'
@@ -4406,3 +4588,17 @@ parameters:
   value: quay.io/openshift/origin-configmap-reloader
 - name: CONFIGMAP_RELOADER_IMAGE_TAG
   value: 4.5.0
+- name: THANOS_VOLCANO_IMAGE_TAG
+  value: main-2022-10-07-a4e33415
+- name: THANOS_VOLCANO_IMAGE
+  value: quay.io/thanos/thanos
+- name: THANOS_VOLCANO_CPU_LIMIT
+  value: "1"
+- name: THANOS_VOLCANO_CPU_REQUEST
+  value: 100m
+- name: THANOS_VOLCANO_LOG_LEVEL
+  value: debug
+- name: THANOS_VOLCANO_MEMORY_LIMIT
+  value: 1Gi
+- name: THANOS_VOLCANO_MEMORY_REQUEST
+  value: 256Mi

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -124,5 +124,12 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_STORE_REPLICAS', value: '5' },
     { name: 'CONFIGMAP_RELOADER_IMAGE', value: 'quay.io/openshift/origin-configmap-reloader' },
     { name: 'CONFIGMAP_RELOADER_IMAGE_TAG', value: '4.5.0' },
+    { name: 'THANOS_VOLCANO_IMAGE_TAG', value: 'main-2022-10-07-a4e33415' },
+    { name: 'THANOS_VOLCANO_IMAGE', value: 'quay.io/thanos/thanos' },
+    { name: 'THANOS_VOLCANO_CPU_LIMIT', value: '1' },
+    { name: 'THANOS_VOLCANO_CPU_REQUEST', value: '100m' },
+    { name: 'THANOS_VOLCANO_LOG_LEVEL', value: 'debug' },
+    { name: 'THANOS_VOLCANO_MEMORY_LIMIT', value: '1Gi' },
+    { name: 'THANOS_VOLCANO_MEMORY_REQUEST', value: '256Mi' },
   ],
 }

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -639,6 +639,81 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       },
     },
 
+    // Querier with new PromQL query engine.
+    // This is not linked to anything on critical path.
+    // TODO(saswatamcode): Revert once new PromQL engine is stable.
+    volcanoQuery:: t.query(thanosSharedConfig {
+      image: '${THANOS_VOLCANO_IMAGE}:${THANOS_VOLCANO_IMAGE_TAG}',
+      version: '${THANOS_VOLCANO_IMAGE_TAG}',
+      name: 'observatorium-volcano-query',
+      useThanosEngine: true,
+      commonLabels+:: {
+        'app.kubernetes.io/instance': 'observatorium',
+        'app.kubernetes.io/part-of': 'observatorium',
+      },
+      replicas: 2,
+      logLevel: '${THANOS_VOLCANO_LOG_LEVEL}',
+      lookbackDelta: '15m',
+      queryTimeout: '15m',
+      prefixHeader: 'X-Forwarded-Prefix',
+      stores: [
+        'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
+        for service in
+          [thanos.stores.shards[shard].service for shard in std.objectFields(thanos.stores.shards)]
+      ] + [
+        // todo - @pgough revert after https://issues.redhat.com/browse/RHOBS-112
+        'dnssrv+_grpc._tcp.${THANOS_RECEIVE_HASHRING_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local',
+      ],
+      rules: [
+        'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
+        for service in
+          [thanos.rule.service] +
+          [thanos.statelessRule.service]
+      ],
+      serviceMonitor: true,
+      resources: {
+        requests: {
+          cpu: '${THANOS_VOLCANO_CPU_REQUEST}',
+          memory: '${THANOS_VOLCANO_MEMORY_REQUEST}',
+        },
+        limits: {
+          cpu: '${THANOS_VOLCANO_CPU_LIMIT}',
+          memory: '${THANOS_VOLCANO_MEMORY_LIMIT}',
+        },
+      },
+    }) + {
+      // This is a workaround for adding extra store for the metric federation
+      // ruler service, which does not exist in the MST instance, so we cannot simply pass it
+      // with the --store flag. Instead, we use the file service discovery. The extra store(s)
+      // should be passed as an array string in THANOS_QUERIER_FILE_SD_TARGETS parameter.
+      deployment+: {
+        spec+: {
+          template+: {
+            spec+: {
+              volumes+: [{
+                configMap: {
+                  name: 'thanos-query-file-sd',
+                },
+                name: 'file-sd',
+              }],
+              containers: [
+                if x.name == 'thanos-query'
+                then x {
+                  args+: ['--store.sd-files=/etc/thanos/sd/file_sd.yaml'],
+                  volumeMounts+: [{
+                    mountPath: '/etc/thanos/sd',
+                    name: 'file-sd',
+                  }],
+                }
+                else x
+                for x in super.containers
+              ],
+            },
+          },
+        },
+      },
+    },
+
     queryFrontend:: t.queryFrontend(thanosSharedConfig {
       name: 'observatorium-thanos-query-frontend',
       commonLabels+:: {
@@ -1018,6 +1093,9 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
     } + {
       ['observatorium-alertmanager-' + name]: thanos.alertmanager[name]
       for name in std.objectFields(thanos.alertmanager)
+    } + {
+      ['observatorium-volcano-' + name]: thanos.volcanoQuery[name]
+      for name in std.objectFields(thanos.volcanoQuery)
     },
   },
 }


### PR DESCRIPTION
This PR adds a new `observatorium-volcano-query` deployment which deploys Thanos Querier with the new PromQL engine enabled. This also adds some new params to allow a different Thanos image to be used while deploying these new Queriers. This querier is not exposed to tenants.

I'm not mirroring traffic to this yet, as the new engine still doesn't support many functions, modifiers, or even functions within functions.
Mirroring traffic would lead to several "not implemented" errors right now, but can be enabled soon once some WIP stuff is merged upstream. For now, it would be valuable to process known queries and compare results with old Querier. 🙂 