### PR TITLE
Update Hypershift RBAC to read only

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -208,7 +208,7 @@ func GenerateRBAC(gen *mimic.Generator) {
 		name:    "observatorium-hypershift-platform",
 		tenant:  hypershiftTenant,
 		signals: []signal{metricsSignal},
-		perms:   []rbac.Permission{rbac.Write, rbac.Read},
+		perms:   []rbac.Permission{rbac.Read}, // Read only.
 		envs:    []env{stagingEnv, productionEnv},
 	})
 

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -1000,13 +1000,6 @@ objects:
         - "metrics"
         "tenants":
         - "reference-addon"
-      - "name": "hypershift-platform-metrics-write"
-        "permissions":
-        - "write"
-        "resources":
-        - "metrics"
-        "tenants":
-        - "hypershift-platform"
       - "name": "hypershift-platform-metrics-read"
         "permissions":
         - "read"

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -802,7 +802,6 @@ objects:
           "name": "service-account-observatorium-reference-addon"
       - "name": "observatorium-hypershift-platform"
         "roles":
-        - "hypershift-platform-metrics-write"
         - "hypershift-platform-metrics-read"
         "subjects":
         - "kind": "user"


### PR DESCRIPTION
Updating hypershift-platform RBAC to read only to prevent unexpected writes.

OSD-13206