### PR TITLE
Bump Thanos Store liveness probe timeout

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -336,8 +336,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "e57d1530c9eb7acd12d26fd0c5992f6d348e00a6",
-      "sum": "m2n71ym5ftCJGFTnsuDxC3PCxSQoybI9wx1DRElK+Uc="
+      "version": "5c8b734dd13edb4b64c71048b74333e9ce2c19b7",
+      "sum": "sFdq83b0xqzvAREQcYyLKhnd+1MPYzyCxBOfctpiTDA="
     },
     {
       "source": {

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -3119,6 +3119,7 @@ objects:
               port: 10902
               scheme: HTTP
             periodSeconds: 30
+            timeoutSeconds: 30
           name: thanos-store
           ports:
           - containerPort: 10901
@@ -3366,6 +3367,7 @@ objects:
               port: 10902
               scheme: HTTP
             periodSeconds: 30
+            timeoutSeconds: 30
           name: thanos-store
           ports:
           - containerPort: 10901
@@ -3613,6 +3615,7 @@ objects:
               port: 10902
               scheme: HTTP
             periodSeconds: 30
+            timeoutSeconds: 30
           name: thanos-store
           ports:
           - containerPort: 10901
@@ -3860,6 +3863,7 @@ objects:
               port: 10902
               scheme: HTTP
             periodSeconds: 30
+            timeoutSeconds: 30
           name: thanos-store
           ports:
           - containerPort: 10901
@@ -4107,6 +4111,7 @@ objects:
               port: 10902
               scheme: HTTP
             periodSeconds: 30
+            timeoutSeconds: 30
           name: thanos-store
           ports:
           - containerPort: 10901
@@ -4354,6 +4359,7 @@ objects:
               port: 10902
               scheme: HTTP
             periodSeconds: 30
+            timeoutSeconds: 30
           name: thanos-store
           ports:
           - containerPort: 10901

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -356,6 +356,9 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
       namespace: '${NAMESPACE}',
       commonLabels+:: thanos.config.commonLabels,
       replicas: 1,  // overwritten in observatorium-metrics-template.libsonnet
+      livenessProbe+: {
+        timeoutSeconds: 30,
+      },
       ignoreDeletionMarksDelay: '24h',
       volumeClaimTemplate: {
         spec: {


### PR DESCRIPTION
This PR bumps the Thanos Store liveness probe timeout from the default 1s to a manually assigned 30s.

This helps liveness probes to fail when the Store is under heavy load.