### PR TITLE
Revert "Update Hypershift RBAC to read only (#362)"

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -208,7 +208,7 @@ func GenerateRBAC(gen *mimic.Generator) {
 		name:    "observatorium-hypershift-platform",
 		tenant:  hypershiftTenant,
 		signals: []signal{metricsSignal},
-		perms:   []rbac.Permission{rbac.Read}, // Read only.
+		perms:   []rbac.Permission{rbac.Write, rbac.Read},
 		envs:    []env{stagingEnv, productionEnv},
 	})
 

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -802,6 +802,7 @@ objects:
           "name": "service-account-observatorium-reference-addon"
       - "name": "observatorium-hypershift-platform"
         "roles":
+        - "hypershift-platform-metrics-write"
         - "hypershift-platform-metrics-read"
         "subjects":
         - "kind": "user"
@@ -1000,6 +1001,13 @@ objects:
         - "metrics"
         "tenants":
         - "reference-addon"
+      - "name": "hypershift-platform-metrics-write"
+        "permissions":
+        - "write"
+        "resources":
+        - "metrics"
+        "tenants":
+        - "hypershift-platform"
       - "name": "hypershift-platform-metrics-read"
         "permissions":
         - "read"


### PR DESCRIPTION
There is currently no need for a read-only service account, but there is a need for an account with write access.
This reverts commit f4fd9cc267401daabf849c59149f35664e8353a3.