### PR TITLE
OSD-13619: Defining obsctl-reloader credentials variables for new hypershift-platform tenant

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -273,6 +273,12 @@ objects:
                 key: client-id
                 name: ${OSD_RELOADER_SECRET_NAME}
                 optional: true
+          - name: HYPERSHIFT-PLATFORM_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: client-id
+                name: ${HYPERSHIFT_PLATFORM_RELOADER_SECRET_NAME}
+                optional: true
           - name: RHOBS_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
@@ -283,6 +289,12 @@ objects:
               secretKeyRef:
                 key: client-secret
                 name: ${OSD_RELOADER_SECRET_NAME}
+                optional: true
+          - name: HYPERSHIFT-PLATFORM_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: client-secret
+                name: ${HYPERSHIFT_PLATFORM_RELOADER_SECRET_NAME}
                 optional: true
           image: ${OBSCTL_RELOADER_IMAGE}:${OBSCTL_RELOADER_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
@@ -1655,6 +1667,8 @@ parameters:
   value: rhobs-tenant
 - name: OSD_RELOADER_SECRET_NAME
   value: observatorium-observatorium-mst-api
+- name: HYPERSHIFT_PLATFORM_RELOADER_SECRET_NAME
+  value: rhobs-hypershift-platform-tenant
 - name: OBSCTL_RELOADER_IMAGE
   value: quay.io/app-sre/obsctl-reloader
 - name: OBSCTL_RELOADER_IMAGE_TAG

--- a/services/observatorium-template.jsonnet
+++ b/services/observatorium-template.jsonnet
@@ -92,6 +92,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'MANAGED_TENANTS', value: 'rhobs,osd' },
     { name: 'RHOBS_RELOADER_SECRET_NAME', value: 'rhobs-tenant' },
     { name: 'OSD_RELOADER_SECRET_NAME', value: 'observatorium-observatorium-mst-api' },
+    { name: 'HYPERSHIFT_PLATFORM_RELOADER_SECRET_NAME', value: 'rhobs-hypershift-platform-tenant' },
     { name: 'OBSCTL_RELOADER_IMAGE', value: 'quay.io/app-sre/obsctl-reloader' },
     { name: 'OBSCTL_RELOADER_IMAGE_TAG', value: 'f021479' },
     { name: 'METRICS_WRITE_SERVICE_NAME', value: obs.thanos.receiversService.metadata.name },

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -167,6 +167,8 @@ local obsctlReloader = (import 'github.com/rhobs/obsctl-reloader/jsonnet/lib/obs
       sleepDurationSeconds: '${SLEEP_DURATION_SECONDS}',
       managedTenants: '${MANAGED_TENANTS}',
     },
+    // Tenants normally follows a lower-case format.
+    // However tenant attribute in below map items need to be uppercase to be the proper prefix for the env variable to create.
     tenantSecretMap: [
       {
         tenant: 'RHOBS',
@@ -179,7 +181,16 @@ local obsctlReloader = (import 'github.com/rhobs/obsctl-reloader/jsonnet/lib/obs
         secret: '${OSD_RELOADER_SECRET_NAME}',
         idKey: 'client-id',
         secretKey: 'client-secret',
-        // Marking as optional here, as OSD only exists on mst,
+        // Marking as optional here, as osd tenant only exists on mst,
+        // so this should not block pod start.
+        optional: true,
+      },
+      {
+        tenant: 'HYPERSHIFT-PLATFORM',
+        secret: '${HYPERSHIFT_PLATFORM_RELOADER_SECRET_NAME}',
+        idKey: 'client-id',
+        secretKey: 'client-secret',
+        // Marking as optional here, as hypershift-platform tenant only exists on mst,
         // so this should not block pod start.
         optional: true,
       },


### PR DESCRIPTION
This indirection is needed this [RHOBS-481](https://issues.redhat.com/browse/RHOBS-481) is implemented.

Parameter `HYPERSHIFT_PLATFORM_RELOADER_SECRET_NAME` hold the secret name.
I opened the secret in vault and on the RHOBS instance and I confirm that the field `client-id` and `client-secret`