### PR TITLE
Sync telemeter rules to include new vCPU-hours rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ $(JSONNET_VENDOR_DIR): $(JB) jsonnetfile.json jsonnetfile.lock.json
 
 .PHONY: update
 update: $(JB) jsonnetfile.json jsonnetfile.lock.json
-	@$(JB) update --jsonnetpkg-home="$(JSONNET_VENDOR_DIR)" https://github.com/saswatamcode/slo-libsonnet/slo-libsonnet@special-selector
+	@$(JB) update --jsonnetpkg-home="$(JSONNET_VENDOR_DIR)" https://github.com/openshift/telemeter/jsonnet/telemeter@master
 
 .PHONY: format
 format: $(JSONNET_SRC) $(JSONNETFMT)

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -223,8 +223,8 @@
           "subdir": "jsonnet/telemeter"
         }
       },
-      "version": "8e8125ea5d66d71b4fdd1b75a45268128b4d36d3",
-      "sum": "VlXNOw0i2l5GD8UDfNX647jaiVxRlA1leACAxFw15WQ="
+      "version": "28be8d07dc63a9e4c778c063f5531bf8b898faa7",
+      "sum": "ija4yqWaf7s4mr90euiwIP1cZZtsPwp4fpMYEhVRFag="
     },
     {
       "source": {

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -547,6 +547,11 @@ objects:
           "labels":
             "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
           "record": "cluster:usage:workload:capacity_physical_instance_hours"
+        - "expr": |
+            sum(sum_over_time(cluster:capacity_cpu_cores:sum{label_node_role_kubernetes_io = ''}[1h:5m])) by (_id) / scalar(count_over_time(vector(1)[1h:5m]))
+          "labels":
+            "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "record": "cluster:usage:workload:capacity_virtual_cpu_hours"
   kind: ConfigMap
   metadata:
     annotations:


### PR DESCRIPTION
This updates telemeter lib to roll out new rule added in https://github.com/openshift/telemeter/pull/435