### PR TITLE
Add SLO dashboard for rhobsp02ue1 cluster

### DIFF
--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -3,7 +3,7 @@ local utils = import '../utils.jsonnet';
 function(instanceName, environment, dashboardName) {
   // Validate our inputs.
   assert std.member(['telemeter', 'mst'], instanceName),
-  assert std.member(['production', 'stage'], environment),
+  assert std.member(['production', 'stage', 'rhobsp02ue1'], environment),
 
   local instanceConfig = {
     telemeter: {
@@ -23,6 +23,12 @@ function(instanceName, environment, dashboardName) {
     mst: {
       production: {
         datasource: 'telemeter-prod-01-prometheus',
+        upNamespace: 'observatorium-mst-production',
+        apiJob: 'observatorium-observatorium-mst-api',
+        metricsNamespace: 'observatorium-metrics-production',
+      },
+      rhobsp02ue1: {
+        datasource: 'rhobsp02ue1-prometheus',
         upNamespace: 'observatorium-mst-production',
         apiJob: 'observatorium-observatorium-mst-api',
         metricsNamespace: 'observatorium-metrics-production',

--- a/observability/grafana.jsonnet
+++ b/observability/grafana.jsonnet
@@ -68,6 +68,7 @@ local dashboards =
   { 'grafana-dashboard-slo-telemeter-production.configmap': (import 'dashboards/slo.libsonnet')('telemeter', 'production', 'Telemeter Production SLOs') } +
   { 'grafana-dashboard-slo-telemeter-stage.configmap': (import 'dashboards/slo.libsonnet')('telemeter', 'stage', 'Telemeter Staging SLOs') } +
   { 'grafana-dashboard-slo-mst-production.configmap': (import 'dashboards/slo.libsonnet')('mst', 'production', 'MST Production SLOs') } +
+  { 'grafana-dashboard-slo-rhobsp02ue1-production.configmap': (import 'dashboards/slo.libsonnet')('mst', 'rhobsp02ue1', 'rhobsp02ue1 Production SLOs') } +
   { 'grafana-dashboard-slo-mst-stage.configmap': (import 'dashboards/slo.libsonnet')('mst', 'stage', 'MST Stage SLOs') } +
   { 'grafana-dashboard-tracing-otel.configmap': (import 'dashboards/opentelemetry.libsonnet')(obsDatasource, obsTraces) } +
   { 'grafana-dashboard-tracing-jaeger.configmap': (import 'dashboards/tracing.libsonnet')(obsDatasource, obsTraces) };

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-rhobsp02ue1-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-rhobsp02ue1-production.configmap.yaml
@@ -1,0 +1,2849 @@
+apiVersion: v1
+data:
+  slo.json: |-
+    {
+        "panels": [
+            {
+                "gridPos": {
+                    "h": 3,
+                    "w": 15
+                },
+                "options": {
+                    "content": "This dashboard displays the SLOs as defined in the [RHOBS Service Level Objectives](https://docs.google.com/document/d/1wJjcpgg-r8rlnOtRiqWGv0zwr1MB6WwkQED1XDWXVQs/edit) document.",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "Description",
+                "transparent": true,
+                "type": "text"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Write > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 4,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 5,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"receive\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Write > Latency",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return < 5s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 5,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 6,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\"}[28d]) ))\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 7,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\",le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"metricsv1\",handler=~\"receive\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid /query requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 8,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 9,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid /query_range requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 10,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 11,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Latency",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 1M samples return < 10s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 10,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 12,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"query-path-sli-1M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 13,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"query-path-sli-1M-samples\",le=\"10\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"query-path-sli-1M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 10M samples return < 30s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 30,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 14,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"query-path-sli-10M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 15,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"query-path-sli-10M-samples\",le=\"30\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"query-path-sli-10M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 100M samples return < 120s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 120,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 16,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"query-path-sli-100M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 17,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Write (/rules/raw) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid write requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 18,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\",method=~\"PUT\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\",method=~\"PUT\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 19,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\",method=~\"PUT\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\",method=~\"PUT\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Sync > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of rules are successfully synced to Thanos Ruler</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 20,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 21,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(client_api_requests_total{client=\"reload\",container=\"thanos-rule-syncer\",namespace=\"observatorium-mst-production\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Read (/rules) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 22,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 23,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules\",code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Rules Read (/rules/raw) > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 24,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 25,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"metricsv1\",handler=~\"rules-raw\",code!~\"4.+\"}[28d]))\n    ) - 0.90000000000000002\n)\n/\n(1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Alerting > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of alerts are successfully delivered to Alertmanager</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 26,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n/\nsum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 27,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n        /\n        sum(rate(thanos_alert_sender_alerts_sent_total{container=\"thanos-rule\",namespace=\"observatorium-mst-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of alerts are successfully delivered to upstream targets</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 28,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n/\nsum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-production\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 29,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(alertmanager_notifications_failed_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-production\"}[28d])) or vector(0))\n        /\n        sum(rate(alertmanager_notifications_total{service=\"observatorium-alertmanager\",namespace=\"observatorium-mst-production\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Logs Write > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 4,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 5,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"push\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Logs Write > Latency",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests return < 5s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 5,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 6,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\"}[28d]) ))\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 7,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(http_request_duration_seconds_bucket{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\",le=\"5\"}[28d]))\n            /\n            sum(rate(http_request_duration_seconds_count{job=\"observatorium-observatorium-mst-api\",code!~\"4..\",group=\"logsv1\",handler=~\"push\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Logs Read > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid /query requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 8,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 9,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">95% of valid /query_range requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 10,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n",
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 11,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-observatorium-mst-api\",group=\"logsv1\",handler=~\"query_range\",code!~\"4.+\"}[28d]))\n    ) - 0.94999999999999996\n)\n/\n(1 - 0.94999999999999996), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            }
+        ],
+        "refresh": false,
+        "schemaVersion": 31,
+        "style": "dark",
+        "tags": [
+
+        ],
+        "templating": {
+            "list": [
+
+            ]
+        },
+        "time": {
+            "from": "now-6h",
+            "to": "now"
+        },
+        "timepicker": {
+
+        },
+        "timezone": "",
+        "title": "rhobsp02ue1 Production SLOs",
+        "uid": "7f4df1c2d5518d5c3f2876ca9bb874a8",
+        "version": 2
+    }
+kind: ConfigMap
+metadata:
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/Observatorium
+  labels:
+    grafana_dashboard: "true"
+  name: grafana-dashboard-slo-mst-rhobsp02ue1


### PR DESCRIPTION
This adds a new SLO dashboard for the rhobsp02ue1 cluster in production as per https://issues.redhat.com/browse/RHOBS-483.