### PR TITLE
Split hypershift RBAC into two tenants

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -335,7 +335,7 @@ func attachBinding(o *observatoriumRBAC, opts bindingOpts) {
 	var subs []rbac.Subject
 	for _, e := range opts.envs {
 		// observatorium-hypershift-platform-staging is the only tenant that does not
-		// follow conventions, due to the being present in a unique environment alongside
+		// follow conventions, due to them being present in an unique environment alongside
 		// their production tenant on rhobsp02ue1.
 		errMsg, ok := tenantNameFollowsConvention(opts.name)
 		if !ok && opts.name != "observatorium-hypershift-platform-staging" {

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -843,9 +843,14 @@ objects:
         - "hypershift-platform-metrics-read"
         "subjects":
         - "kind": "user"
-          "name": "service-account-observatorium-hypershift-platform-staging"
-        - "kind": "user"
           "name": "service-account-observatorium-hypershift-platform"
+      - "name": "observatorium-hypershift-platform-staging"
+        "roles":
+        - "hypershift-platform-staging-metrics-write"
+        - "hypershift-platform-staging-metrics-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-hypershift-platform-staging"
       - "name": "observatorium-dptp-reader"
         "roles":
         - "dptp-logs-read"
@@ -1052,6 +1057,20 @@ objects:
         - "metrics"
         "tenants":
         - "hypershift-platform"
+      - "name": "hypershift-platform-staging-metrics-write"
+        "permissions":
+        - "write"
+        "resources":
+        - "metrics"
+        "tenants":
+        - "hypershift-platform-staging"
+      - "name": "hypershift-platform-staging-metrics-read"
+        "permissions":
+        - "read"
+        "resources":
+        - "metrics"
+        "tenants":
+        - "hypershift-platform-staging"
       - "name": "dptp-logs-read"
         "permissions":
         - "read"


### PR DESCRIPTION
This PR adds a new `hypershift-platform-staging` tenant in the rbac, and splits the rbac SAs across `hypershift-platform` and `hypershift-platform-staging` tenants. (would need to update saas-tenants)

Effectively,

`service-account-observatorium-hypershift-platform` can read/write to `hypershift-platform` &
`service-account-observatorium-hypershift-platform-staging` can read/write to `hypershift-platform-staging`

**Do not merge, until we have new tenant**