### PR TITLE
OSD-13619: Defining obsctl-reloader credentials variables for new hypershift-platform-staging tenant

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -274,6 +274,12 @@ objects:
                 key: client-id
                 name: ${OSD_RELOADER_SECRET_NAME}
                 optional: true
+          - name: HYPERSHIFT-PLATFORM-STAGING_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: client-id
+                name: ${HYPERSHIFT_PLATFORM_STAGING_RELOADER_SECRET_NAME}
+                optional: true
           - name: HYPERSHIFT-PLATFORM_CLIENT_ID
             valueFrom:
               secretKeyRef:
@@ -302,6 +308,12 @@ objects:
               secretKeyRef:
                 key: client-secret
                 name: ${OSD_RELOADER_SECRET_NAME}
+                optional: true
+          - name: HYPERSHIFT-PLATFORM-STAGING_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: client-secret
+                name: ${HYPERSHIFT_PLATFORM_STAGING_RELOADER_SECRET_NAME}
                 optional: true
           - name: HYPERSHIFT-PLATFORM_CLIENT_SECRET
             valueFrom:
@@ -1713,6 +1725,8 @@ parameters:
   value: rhobs-tenant
 - name: OSD_RELOADER_SECRET_NAME
   value: observatorium-observatorium-mst-api
+- name: HYPERSHIFT_PLATFORM_STAGING_RELOADER_SECRET_NAME
+  value: rhobs-hypershift-platform-staging-tenant
 - name: HYPERSHIFT_PLATFORM_RELOADER_SECRET_NAME
   value: rhobs-hypershift-platform-tenant
 - name: APPSRE_RELOADER_SECRET_NAME

--- a/services/observatorium-template.jsonnet
+++ b/services/observatorium-template.jsonnet
@@ -93,6 +93,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'MANAGED_TENANTS', value: 'rhobs,osd,appsre,rhoc' },
     { name: 'RHOBS_RELOADER_SECRET_NAME', value: 'rhobs-tenant' },
     { name: 'OSD_RELOADER_SECRET_NAME', value: 'observatorium-observatorium-mst-api' },
+    { name: 'HYPERSHIFT_PLATFORM_STAGING_RELOADER_SECRET_NAME', value: 'rhobs-hypershift-platform-staging-tenant' },
     { name: 'HYPERSHIFT_PLATFORM_RELOADER_SECRET_NAME', value: 'rhobs-hypershift-platform-tenant' },
     { name: 'APPSRE_RELOADER_SECRET_NAME', value: 'observatorium-appsre' },
     { name: 'RHOC_RELOADER_SECRET_NAME', value: 'observatorium-rhoc-staging' },

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -187,6 +187,15 @@ local obsctlReloader = (import 'github.com/rhobs/obsctl-reloader/jsonnet/lib/obs
         optional: true,
       },
       {
+        tenant: 'HYPERSHIFT-PLATFORM-STAGING',
+        secret: '${HYPERSHIFT_PLATFORM_STAGING_RELOADER_SECRET_NAME}',
+        idKey: 'client-id',
+        secretKey: 'client-secret',
+        // Marking as optional here, as hypershift-platform-staging tenant only exists on mst,
+        // so this should not block pod start.
+        optional: true,
+      },
+      {
         tenant: 'HYPERSHIFT-PLATFORM',
         secret: '${HYPERSHIFT_PLATFORM_RELOADER_SECRET_NAME}',
         idKey: 'client-id',


### PR DESCRIPTION
This is needed because `obsctl-reloader` is not yet auto discovering the secrets containings the credentials to authenticate on the considered tenants:
https://issues.redhat.com/browse/RHOBS-481