### PR TITLE
Use OpenShift template var to select query engine

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1359,6 +1359,7 @@ objects:
           - --query.auto-downsampling
           - --store.sd-files=/etc/thanos/sd/file_sd.yaml
           - --grpc.proxy-strategy=${THANOS_QUERIER_PROXY_STRATEGY}
+          - --query.promql-engine=${THANOS_QUERIER_ENGINE}
           env:
           - name: HOST_IP_ADDRESS
             valueFrom:
@@ -4582,6 +4583,8 @@ parameters:
   value: '[]'
 - name: THANOS_QUERIER_PROXY_STRATEGY
   value: eager
+- name: THANOS_QUERIER_ENGINE
+  value: prometheus
 - name: THANOS_QUERY_FRONTEND_CPU_LIMIT
   value: "1"
 - name: THANOS_QUERY_FRONTEND_CPU_REQUEST

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -312,6 +312,7 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                 if c.name == 'thanos-query' then c {
                   args+: [
                     '--grpc.proxy-strategy=${THANOS_QUERIER_PROXY_STRATEGY}',
+                    '--query.promql-engine=${THANOS_QUERIER_ENGINE}',
                   ],
                 } else c
                 for c in super.containers

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -66,6 +66,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_QUERIER_SVC_URL', value: 'http://thanos-querier.observatorium.svc:9090' },
     { name: 'THANOS_QUERIER_FILE_SD_TARGETS', value: '[]' },
     { name: 'THANOS_QUERIER_PROXY_STRATEGY', value: 'eager' },
+    { name: 'THANOS_QUERIER_ENGINE', value: 'prometheus' },
     { name: 'THANOS_QUERY_FRONTEND_CPU_LIMIT', value: '1' },
     { name: 'THANOS_QUERY_FRONTEND_CPU_REQUEST', value: '100m' },
     { name: 'THANOS_QUERY_FRONTEND_LOG_QUERIES_LONGER_THAN', value: '5s' },


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

The default is the `prometheus` PromQL engine, to preserve backwards compatibility. 

This will allow us to start testing with only running the new PromQL engine by setting it to `thanos`. 