### PR TITLE
Add CCX Processing to RBAC for telemeter read

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -141,6 +141,15 @@ func GenerateRBAC(gen *mimic.Generator) {
 		envs:    []env{stagingEnv, productionEnv},
 	})
 
+	// CCX Processing
+	attachBinding(&obsRBAC, bindingOpts{
+		name:    "observatorium-ccx-processing",
+		tenant:  telemeterTenant,
+		signals: []signal{metricsSignal},
+		perms:   []rbac.Permission{rbac.Read},
+		envs:    []env{stagingEnv},
+	})
+
 	// Subwatch
 	attachBinding(&obsRBAC, bindingOpts{
 		name:    "observatorium-subwatch",

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -797,6 +797,12 @@ objects:
           "name": "service-account-telemeter-service-staging"
         - "kind": "user"
           "name": "service-account-telemeter-service"
+      - "name": "observatorium-ccx-processing"
+        "roles":
+        - "telemeter-metrics-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-ccx-processing-staging"
       - "name": "observatorium-subwatch"
         "roles":
         - "telemeter-metrics-read"


### PR DESCRIPTION
This PR adds CCX processing's service account to our RBAC, with read permissions to telemeter stage.