### PR TITLE
[rhobs-logs] Add tenant appsre to production

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -262,7 +262,7 @@ func GenerateRBAC(gen *mimic.Generator) {
 		tenant:  appsreTenant,
 		signals: []signal{logsSignal},
 		perms:   []rbac.Permission{rbac.Read, rbac.Write},
-		envs:    []env{stagingEnv},
+		envs:    []env{stagingEnv, productionEnv},
 	})
 
 	// Use JSON because we want to have jsonnet using that in configmaps/secrets.

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -892,6 +892,8 @@ objects:
         "subjects":
         - "kind": "user"
           "name": "service-account-observatorium-appsre-staging"
+        - "kind": "user"
+          "name": "service-account-observatorium-appsre"
       "roles":
       - "name": "cnvqe-metrics-write"
         "permissions":


### PR DESCRIPTION
This PR adds the tenant `appsre` to production.

@periklis 
[LOG-3545](https://issues.redhat.com/browse/LOG-3545)