### PR TITLE
[rhobs-logs] Upgrade Loki to 2.7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor_jsonnet/
 .idea
 .envrc
 resources/.tmp/
+tmp/

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -160,8 +160,8 @@
           "subdir": "configuration"
         }
       },
-      "version": "66634451d91d8872acae19eb15f7377670e6dadc",
-      "sum": "LyJurWxkxdUWx7TDDGSKfQvMaJMBMDpJmkyt3WfgdfE="
+      "version": "37ee741596df29a3f2dbcdebd3a108f8e2ffc1f4",
+      "sum": "eKwMXFj96rXnyXGnA3TZgRpf6b30KGiElEeuVDCKvgU="
     },
     {
       "source": {

--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -2250,7 +2250,7 @@ parameters:
 - name: STORAGE_CLASS
   value: gp2
 - name: LOKI_IMAGE_TAG
-  value: 2.6.1
+  value: 2.7.2
 - name: LOKI_IMAGE
   value: docker.io/grafana/loki
 - name: LOKI_S3_SECRET

--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -575,6 +575,8 @@ objects:
             "timeout": "100ms"
             "update_interval": "1m"
         "max_look_back_period": "0s"
+      "common":
+        "compactor_grpc_address": "observatorium-loki-compactor-grpc.${NAMESPACE}.svc.cluster.local:9095"
       "compactor":
         "compaction_interval": "2h"
         "shared_store": "s3"
@@ -620,6 +622,7 @@ objects:
       "limits_config":
         "cardinality_limit": 100000
         "creation_grace_period": "10m"
+        "deletion_mode": "disabled"
         "enforce_metric_name": false
         "ingestion_burst_size_mb": 20
         "ingestion_rate_mb": 10
@@ -652,7 +655,6 @@ objects:
       "querier":
         "engine":
           "max_look_back_period": "30s"
-          "timeout": "6m"
         "extra_query_delay": "0s"
         "max_concurrent": 2
         "query_ingesters_within": "3h"

--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -658,7 +658,7 @@ objects:
         "extra_query_delay": "0s"
         "max_concurrent": 2
         "query_ingesters_within": "3h"
-        "query_timeout": "1h"
+        "query_timeout": "6m"
         "tail_max_duration": "1h"
       "query_range":
         "align_queries_with_step": true

--- a/services/observatorium-logs-template.jsonnet
+++ b/services/observatorium-logs-template.jsonnet
@@ -26,7 +26,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'ALERTMANAGER_EXTERNAL_URL', value: 'https://observatorium-alertmanager-mst.api.stage.openshift.com' },
     { name: 'RULES_OBJSTORE_S3_SECRET', value: 'rules-objstore-stage-s3' },
     { name: 'STORAGE_CLASS', value: 'gp2' },
-    { name: 'LOKI_IMAGE_TAG', value: '2.6.1' },
+    { name: 'LOKI_IMAGE_TAG', value: '2.7.2' },
     { name: 'LOKI_IMAGE', value: 'docker.io/grafana/loki' },
     { name: 'LOKI_S3_SECRET', value: 'observatorium-mst-logs-stage-s3' },
     { name: 'LOKI_COMPACTOR_CPU_REQUESTS', value: '500m' },

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -223,11 +223,6 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
       limits_config+: {
         max_global_streams_per_user: 25000,
       },
-      querier+: {
-        engine+: {
-          timeout: '6m',
-        },
-      },
       ruler+: {
         enable_alertmanager_discovery: true,
         enable_alertmanager_v2: false,

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -223,6 +223,9 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
       limits_config+: {
         max_global_streams_per_user: 25000,
       },
+      querier+: {
+        query_timeout: '6m',
+      },
       ruler+: {
         enable_alertmanager_discovery: true,
         enable_alertmanager_v2: false,


### PR DESCRIPTION
Upgrade Loki from 2.6.1 to 2.7.2.

**Depends on:** [observatorium/observatorium/pull/506](https://github.com/observatorium/observatorium/pull/506)
**Ticket:** [LOG-3052](https://issues.redhat.com/browse/LOG-3052)