### PR TITLE
Add missing UIDs for rhobs logs dashboards

### DIFF
--- a/observability/grafana-obs-logs.jsonnet
+++ b/observability/grafana-obs-logs.jsonnet
@@ -4,6 +4,14 @@ local loki = (import 'github.com/grafana/loki/production/loki-mixin/mixin.libson
 local obsDatasource = 'telemeter-prod-01-prometheus';
 local obsNamespace = 'observatorium-mst-production';
 
+local dashboardUIDs = {
+  'loki-chunks.json': 'GtCujSHzC8gd9i5fck9a3v9n2EvTzA',
+  'loki-logs.json': 'nEhbhXRHDQQBSSWMt9WCpkwyxbwpu4',
+  'loki-operational.json': 'E2CAJBcLcg3NNfd2jLKe4fhQpf2LaU',
+  'loki-reads.json': '62q5jjYwhVSaz4Mcrm8tV3My3gcKED',
+  'loki-writes.json': 'F6nRYKuXmFVpVSFQmXr7cgXy5j7UNr',
+};
+
 local dashboards = {
   ['grafana-dashboard-observatorium-logs-%s.configmap' % std.split(name, '.')[0]]: {
     apiVersion: 'v1',
@@ -12,7 +20,10 @@ local dashboards = {
       name: 'grafana-dashboard-observatorium-logs-%s' % std.split(name, '.')[0],
     },
     data: {
-      [name]: std.manifestJsonEx(loki.grafanaDashboards[name] { tags: std.uniq(super.tags + ['observatorium', 'observatorium-logs']) }, '  '),
+      [name]: std.manifestJsonEx(loki.grafanaDashboards[name] {
+        tags: std.uniq(super.tags + ['observatorium', 'observatorium-logs']),
+        uid: dashboardUIDs[name],
+      }, '  '),
     },
   }
   for name in std.objectFields(loki.grafanaDashboards)

--- a/resources/observability/grafana/observatorium-logs/grafana-dashboards-template.yaml
+++ b/resources/observability/grafana/observatorium-logs/grafana-dashboards-template.yaml
@@ -3086,7 +3086,7 @@ objects:
         },
         "timezone": "utc",
         "title": "Loki / Chunks",
-        "uid": "",
+        "uid": "GtCujSHzC8gd9i5fck9a3v9n2EvTzA",
         "version": 0
       }
   kind: ConfigMap
@@ -4285,7 +4285,7 @@ objects:
         },
         "timezone": "",
         "title": "Logs",
-        "uid": "a7e130cb82be229d6f3edbfd0a438001",
+        "uid": "nEhbhXRHDQQBSSWMt9WCpkwyxbwpu4",
         "version": 1
       }
   kind: ConfigMap
@@ -11945,7 +11945,7 @@ objects:
         },
         "timezone": "",
         "title": "Loki Operational",
-        "uid": "f6fe30815b172c9da7e813c15ddfe607",
+        "uid": "E2CAJBcLcg3NNfd2jLKe4fhQpf2LaU",
         "version": 1
       }
   kind: ConfigMap
@@ -15295,7 +15295,7 @@ objects:
         },
         "timezone": "utc",
         "title": "Loki / Reads",
-        "uid": "",
+        "uid": "62q5jjYwhVSaz4Mcrm8tV3My3gcKED",
         "version": 0
       }
   kind: ConfigMap
@@ -16438,7 +16438,7 @@ objects:
         },
         "timezone": "utc",
         "title": "Loki / Writes",
-        "uid": "",
+        "uid": "F6nRYKuXmFVpVSFQmXr7cgXy5j7UNr",
         "version": 0
       }
   kind: ConfigMap


### PR DESCRIPTION
Some of the mixin-vendored Dashboard from grafana/loki are missing UIDs. This is not a mandatory requirement for Grafana dashboard being provisioned though a ConfigMap. This change makes the `observatorium-logs/grafana-dashboards-template.yaml` deployable again.