### PR TITLE
Add Thanos Store series touched limit configuration

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -336,8 +336,8 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      "version": "c5c9cd256cd91bede770a03fa26ac89154071217",
-      "sum": "sFdq83b0xqzvAREQcYyLKhnd+1MPYzyCxBOfctpiTDA="
+      "version": "6a7455882cf45acfe96768d682bf5d714669c02c",
+      "sum": "Lmo908G1ILvI/a2Y4rsrOi7NmxJeelUS3SlrklrdfWc="
     },
     {
       "source": {

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -3101,6 +3101,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 0
+          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3349,6 +3350,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 1
+          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3597,6 +3599,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 2
+          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3845,6 +3848,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 3
+          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -4093,6 +4097,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 4
+          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -4341,6 +4346,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 5
+          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -4681,6 +4687,8 @@ parameters:
   value: "2"
 - name: THANOS_STORE_CPU_REQUEST
   value: 500m
+- name: THANOS_STORE_SERIES_TOUCHED_LIMIT
+  value: "0"
 - name: THANOS_STORE_INDEX_CACHE_CONNECTION_LIMIT
   value: "3072"
 - name: THANOS_STORE_INDEX_CACHE_MEMCACHED_CPU_LIMIT

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -218,6 +218,9 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                   containers: [
                     if c.name == 'thanos-store' then c {
                       env+: s3EnvVars,
+                      args+: [
+                        '--store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}',
+                      ],
                     } else c
                     for c in super.containers
                   ],

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -114,6 +114,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_STORE_BUCKET_CACHE_REPLICAS', value: '3' },
     { name: 'THANOS_STORE_CPU_LIMIT', value: '2' },
     { name: 'THANOS_STORE_CPU_REQUEST', value: '500m' },
+    { name: 'THANOS_STORE_SERIES_TOUCHED_LIMIT', value: '0' },
     { name: 'THANOS_STORE_INDEX_CACHE_CONNECTION_LIMIT', value: '3072' },
     { name: 'THANOS_STORE_INDEX_CACHE_MEMCACHED_CPU_LIMIT', value: '3' },
     { name: 'THANOS_STORE_INDEX_CACHE_MEMCACHED_CPU_REQUEST', value: '500m' },


### PR DESCRIPTION
Tried to use the nice jsonnet function constructor from https://github.com/thanos-io/kube-thanos/commit/d2cac7b14a147e4c79edd6f02fba7afeafbe9702, but it doesn't work because we use OpenShift Templates parameters to configure most of the things, including limits, and the jsonnet function requires the limits values to be a number.
Because of this, the implementation follows the pattern already set by other components, like the Thanos Query overwrites and others in the same file.

The default value is `0` (zero), which means "no limit".