### PR TITLE
[rhobs-logs] Bump ingestion rate limit from 10 to 50 MB/s

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -622,7 +622,7 @@ objects:
         "creation_grace_period": "10m"
         "enforce_metric_name": false
         "ingestion_burst_size_mb": 20
-        "ingestion_rate_mb": 10
+        "ingestion_rate_mb": 50
         "ingestion_rate_strategy": "global"
         "max_cache_freshness_per_query": "10m"
         "max_chunks_per_query": 2000000
@@ -636,7 +636,7 @@ objects:
         "max_query_parallelism": 16
         "max_query_series": 500
         "max_streams_per_user": 0
-        "per_stream_rate_limit": "3MB"
+        "per_stream_rate_limit": "5MB"
         "per_stream_rate_limit_burst": "15MB"
         "reject_old_samples": true
         "reject_old_samples_max_age": "24h"

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -221,7 +221,9 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
     },
     config+: {
       limits_config+: {
+        ingestion_rate_mb: 50,
         max_global_streams_per_user: 25000,
+        per_stream_rate_limit: '5MB',
       },
       querier+: {
         engine+: {


### PR DESCRIPTION
Currently the ingestion rate limit per tenant is set to 10 MB/s. Considering the fact that we run 3 distributor/ingester pairs on both staging and production this translates into a 3 MB/s limit. This is too low compared on the log volume get for tenant `appsre`:
```
429 Too Many Requests Ingestion rate limit exceeded for user 3833951d-bede-4a53-85e5-f73f4913973f (limit: 3495253 bytes/sec) while attempting to ingest '132' lines totaling '266313' bytes, reduce log volume or contact your Loki administrator to see if the limit can be increased
```

Increasing the global per tenant limit to 50 MB means a tenant can ingest ~16.67 MB/s. In addition lifting the ingest limit per stream from 3 MB/s to 5 MB/s means that each stream (i.e. a stream applies applies to a stable workload on a namespace for a tenant) will create enough room for the tenant `appsre` and its workload to grow. 