### PR TITLE
Fix OpenShift templating for Thanos Store limits

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -3101,7 +3101,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 0
-          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
+          - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3350,7 +3350,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 1
-          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
+          - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3599,7 +3599,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 2
-          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
+          - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3848,7 +3848,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 3
-          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
+          - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -4097,7 +4097,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 4
-          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
+          - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -4346,7 +4346,7 @@ objects:
               - action: keep
                 source_labels: ["shard"]
                 regex: 5
-          - --store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}
+          - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -219,7 +219,7 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                     if c.name == 'thanos-store' then c {
                       env+: s3EnvVars,
                       args+: [
-                        '--store.grpc.touched-series-limit=${{THANOS_STORE_SERIES_TOUCHED_LIMIT}}',
+                        '--store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}',
                       ],
                     } else c
                     for c in super.containers


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

The code has a problem with the double curly braces. Moving to a single one should fix the issue.

It's worth noting that the OpenShift template validation in the CI builds didn't catch this.