### PR TITLE
Querier concurrency limit configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include .bingo/Variables.mk
 
-SED ?= sed
-XARGS ?= xargs
+SED ?= $(shell which gsed 2>/dev/null || which sed)
+XARGS ?= $(shell which gxargs 2>/dev/null || which xargs)
 
 CRD_DIR := $(shell pwd)/crds
 TMP_DIR := $(shell pwd)/tmp

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1362,6 +1362,7 @@ objects:
           - --store.sd-files=/etc/thanos/sd/file_sd.yaml
           - --grpc.proxy-strategy=${THANOS_QUERIER_PROXY_STRATEGY}
           - --query.promql-engine=${THANOS_QUERIER_ENGINE}
+          - --query.max-concurrent=${THANOS_QUERIER_MAX_CONCURRENT}
           env:
           - name: HOST_IP_ADDRESS
             valueFrom:
@@ -4593,6 +4594,8 @@ parameters:
   value: eager
 - name: THANOS_QUERIER_ENGINE
   value: prometheus
+- name: THANOS_QUERIER_MAX_CONCURRENT
+  value: "20"
 - name: THANOS_QUERY_FRONTEND_CPU_LIMIT
   value: "1"
 - name: THANOS_QUERY_FRONTEND_CPU_REQUEST

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -316,6 +316,7 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                   args+: [
                     '--grpc.proxy-strategy=${THANOS_QUERIER_PROXY_STRATEGY}',
                     '--query.promql-engine=${THANOS_QUERIER_ENGINE}',
+                    '--query.max-concurrent=${THANOS_QUERIER_MAX_CONCURRENT}',
                   ],
                 } else c
                 for c in super.containers

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -67,6 +67,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_QUERIER_FILE_SD_TARGETS', value: '[]' },
     { name: 'THANOS_QUERIER_PROXY_STRATEGY', value: 'eager' },
     { name: 'THANOS_QUERIER_ENGINE', value: 'prometheus' },
+    { name: 'THANOS_QUERIER_MAX_CONCURRENT', value: '20' },
     { name: 'THANOS_QUERY_FRONTEND_CPU_LIMIT', value: '1' },
     { name: 'THANOS_QUERY_FRONTEND_CPU_REQUEST', value: '100m' },
     { name: 'THANOS_QUERY_FRONTEND_LOG_QUERIES_LONGER_THAN', value: '5s' },


### PR DESCRIPTION
This PR allows configuration of the Thanos Query `--query.max-concurrent` CLI arg. The default value used by the OpenShift template is 20, matching Thanos' own default value.