### PR TITLE
[rhobs-logs] Load namespace variable from selected datasource

### DIFF
--- a/observability/config.libsonnet
+++ b/observability/config.libsonnet
@@ -44,14 +44,23 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
     } else {}
   ),
 
-  local withLokiMetricsNamespace = function(ns, value) ns + (
+  local withLokiMetricsNamespace = function(ns, ds, value) ns + (
     if ns.label == value then {
-      query: '${OBSERVATORIUM_NAMESPACE_OPTIONS}',
+      datasource: {
+        type: 'prometheus',
+        uid: '${%s}' % ds,
+      },
       current: {
         selected: true,
         text: '${OBSERVATORIUM_API_NAMESPACE}',
         value: '${OBSERVATORIUM_API_NAMESPACE}',
       },
+      definition: 'label_values(kube_pod_info, namespace)',
+      query: {
+        query: 'label_values(kube_pod_info, namespace)',
+        refId: 'StandardVariableQuery',
+      },
+      regex: 'observatorium-logs|mst-.+',
     } else {}
   ),
 
@@ -64,8 +73,8 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
         uid: 'GtCujSHzC8gd9i5fck9a3v9n2EvTzA',
         tags: defaultLokiTags(super.tags),
         showMultiCluster:: false,
-        namespaceQuery:: '${OBSERVATORIUM_API_NAMESPACE}',
-        namespaceType:: 'custom',
+        namespaceQuery:: 'label_values(kube_pod_info, namespace)',
+        namespaceType:: 'query',
         matchers:: {
           ingester:: [utils.selector.eq('job', 'observatorium-loki-ingester-http')],
         },
@@ -93,7 +102,7 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
             std.map(
               function(e) withLokiMetricsDatasource(e, 'datasource'),
               std.map(
-                function(e) withLokiMetricsNamespace(e, 'namespace'),
+                function(e) withLokiMetricsNamespace(e, 'datasource', 'namespace'),
                 super.list
               )
             ),
@@ -105,8 +114,8 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
         showAnnotations:: false,
         showLinks:: false,
         showMultiCluster:: false,
-        namespaceQuery:: '${OBSERVATORIUM_API_NAMESPACE}',
-        namespaceType:: 'custom',
+        namespaceQuery:: 'label_values(kube_pod_info, namespace)',
+        namespaceType:: 'query',
         matchers:: {
           cortexgateway:: [],
           distributor:: [utils.selector.eq('job', 'observatorium-loki-distributor-http')],
@@ -169,7 +178,7 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
             std.map(
               function(e) withLokiMetricsDatasource(e, 'metrics'),
               std.map(
-                function(e) withLokiMetricsNamespace(e, 'namespace'),
+                function(e) withLokiMetricsNamespace(e, 'metrics', 'namespace'),
                 super.list
               )
             ),
@@ -179,8 +188,8 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
         uid: '62q5jjYwhVSaz4Mcrm8tV3My3gcKED',
         tags: defaultLokiTags(super.tags),
         showMultiCluster:: false,
-        namespaceQuery:: '${OBSERVATORIUM_API_NAMESPACE}',
-        namespaceType:: 'custom',
+        namespaceQuery:: 'label_values(kube_pod_info, namespace)',
+        namespaceType:: 'query',
         matchers:: {
           cortexgateway:: [],
           queryFrontend:: [utils.selector.eq('job', 'observatorium-loki-query-frontend-http')],
@@ -199,7 +208,7 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
             std.map(
               function(e) withLokiMetricsDatasource(e, 'datasource'),
               std.map(
-                function(e) withLokiMetricsNamespace(e, 'namespace'),
+                function(e) withLokiMetricsNamespace(e, 'datasource', 'namespace'),
                 super.list
               )
             ),
@@ -209,8 +218,8 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
         uid: 'F6nRYKuXmFVpVSFQmXr7cgXy5j7UNr',
         tags: defaultLokiTags(super.tags),
         showMultiCluster:: false,
-        namespaceQuery:: '${OBSERVATORIUM_API_NAMESPACE}',
-        namespaceType:: 'custom',
+        namespaceQuery:: 'label_values(kube_pod_info, namespace)',
+        namespaceType:: 'query',
         matchers:: {
           cortexgateway:: [],
           distributor:: [utils.selector.eq('job', 'observatorium-loki-distributor-http')],
@@ -228,7 +237,7 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
             std.map(
               function(e) withLokiMetricsDatasource(e, 'datasource'),
               std.map(
-                function(e) withLokiMetricsNamespace(e, 'namespace'),
+                function(e) withLokiMetricsNamespace(e, 'datasource', 'namespace'),
                 super.list
               )
             ),

--- a/observability/grafana-obs-logs.jsonnet
+++ b/observability/grafana-obs-logs.jsonnet
@@ -42,7 +42,6 @@ local dashboardsTemplate = {
     { name: 'OBSERVATORIUM_API_DATASOURCE', value: 'telemeter-prod-01-prometheus' },
     { name: 'OBSERVATORIUM_API_NAMESPACE', value: 'observatorium-mst-production' },
     { name: 'OBSERVATORIUM_DATASOURCE_REGEX', value: '(app-sre-stage-01|rhobs-testing|rhobsp02ue1|telemeter-prod-01)-prometheus' },
-    { name: 'OBSERVATORIUM_NAMESPACE_OPTIONS', value: 'observatorium-logs-testing,observatorium-mst-stage,observatorium-mst-production' },
   ],
 };
 

--- a/resources/observability/grafana/observatorium-logs/grafana-dashboards-template.yaml
+++ b/resources/observability/grafana/observatorium-logs/grafana-dashboards-template.yaml
@@ -3034,7 +3034,11 @@ objects:
                 "text": "${OBSERVATORIUM_API_NAMESPACE}",
                 "value": "${OBSERVATORIUM_API_NAMESPACE}"
               },
-              "datasource": "$datasource",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "definition": "label_values(kube_pod_info, namespace)",
               "hide": 0,
               "includeAll": false,
               "label": "namespace",
@@ -3043,16 +3047,19 @@ objects:
               "options": [
 
               ],
-              "query": "${OBSERVATORIUM_NAMESPACE_OPTIONS}",
+              "query": {
+                "query": "label_values(kube_pod_info, namespace)",
+                "refId": "StandardVariableQuery"
+              },
               "refresh": 1,
-              "regex": "",
+              "regex": "observatorium-logs|mst-.+",
               "sort": 2,
               "tagValuesQuery": "",
               "tags": [
 
               ],
               "tagsQuery": "",
-              "type": "custom",
+              "type": "query",
               "useTags": false
             }
           ]
@@ -8345,7 +8352,11 @@ objects:
                 "text": "${OBSERVATORIUM_API_NAMESPACE}",
                 "value": "${OBSERVATORIUM_API_NAMESPACE}"
               },
-              "datasource": "$metrics",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${metrics}"
+              },
+              "definition": "label_values(kube_pod_info, namespace)",
               "hide": 0,
               "includeAll": false,
               "label": "namespace",
@@ -8354,16 +8365,19 @@ objects:
               "options": [
 
               ],
-              "query": "${OBSERVATORIUM_NAMESPACE_OPTIONS}",
+              "query": {
+                "query": "label_values(kube_pod_info, namespace)",
+                "refId": "StandardVariableQuery"
+              },
               "refresh": 1,
-              "regex": "",
+              "regex": "observatorium-logs|mst-.+",
               "sort": 2,
               "tagValuesQuery": "",
               "tags": [
 
               ],
               "tagsQuery": "",
-              "type": "custom",
+              "type": "query",
               "useTags": false
             }
           ]
@@ -11479,7 +11493,11 @@ objects:
                 "text": "${OBSERVATORIUM_API_NAMESPACE}",
                 "value": "${OBSERVATORIUM_API_NAMESPACE}"
               },
-              "datasource": "$datasource",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "definition": "label_values(kube_pod_info, namespace)",
               "hide": 0,
               "includeAll": false,
               "label": "namespace",
@@ -11488,16 +11506,19 @@ objects:
               "options": [
 
               ],
-              "query": "${OBSERVATORIUM_NAMESPACE_OPTIONS}",
+              "query": {
+                "query": "label_values(kube_pod_info, namespace)",
+                "refId": "StandardVariableQuery"
+              },
               "refresh": 1,
-              "regex": "",
+              "regex": "observatorium-logs|mst-.+",
               "sort": 2,
               "tagValuesQuery": "",
               "tags": [
 
               ],
               "tagsQuery": "",
-              "type": "custom",
+              "type": "query",
               "useTags": false
             }
           ]
@@ -12418,7 +12439,11 @@ objects:
                 "text": "${OBSERVATORIUM_API_NAMESPACE}",
                 "value": "${OBSERVATORIUM_API_NAMESPACE}"
               },
-              "datasource": "$datasource",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "definition": "label_values(kube_pod_info, namespace)",
               "hide": 0,
               "includeAll": false,
               "label": "namespace",
@@ -12427,16 +12452,19 @@ objects:
               "options": [
 
               ],
-              "query": "${OBSERVATORIUM_NAMESPACE_OPTIONS}",
+              "query": {
+                "query": "label_values(kube_pod_info, namespace)",
+                "refId": "StandardVariableQuery"
+              },
               "refresh": 1,
-              "regex": "",
+              "regex": "observatorium-logs|mst-.+",
               "sort": 2,
               "tagValuesQuery": "",
               "tags": [
 
               ],
               "tagsQuery": "",
-              "type": "custom",
+              "type": "query",
               "useTags": false
             }
           ]
@@ -12489,5 +12517,3 @@ parameters:
   value: observatorium-mst-production
 - name: OBSERVATORIUM_DATASOURCE_REGEX
   value: (app-sre-stage-01|rhobs-testing|rhobsp02ue1|telemeter-prod-01)-prometheus
-- name: OBSERVATORIUM_NAMESPACE_OPTIONS
-  value: observatorium-logs-testing,observatorium-mst-stage,observatorium-mst-production


### PR DESCRIPTION
Follow up on #409 that makes loading the namespace variable based on the selected data-source. This allows inspecting all clusters a lot easier.