### PR TITLE
Expose max-time for SGW as param

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -3104,6 +3104,7 @@ objects:
                 regex: 0
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
+          - --max-time=${THANOS_STORE_MAX_TIME}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3354,6 +3355,7 @@ objects:
                 regex: 1
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
+          - --max-time=${THANOS_STORE_MAX_TIME}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3604,6 +3606,7 @@ objects:
                 regex: 2
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
+          - --max-time=${THANOS_STORE_MAX_TIME}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3854,6 +3857,7 @@ objects:
                 regex: 3
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
+          - --max-time=${THANOS_STORE_MAX_TIME}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -4104,6 +4108,7 @@ objects:
                 regex: 4
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
+          - --max-time=${THANOS_STORE_MAX_TIME}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -4354,6 +4359,7 @@ objects:
                 regex: 5
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
+          - --max-time=${THANOS_STORE_MAX_TIME}
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -4722,6 +4728,8 @@ parameters:
   value: 1Gi
 - name: THANOS_STORE_REPLICAS
   value: "5"
+- name: THANOS_STORE_MAX_TIME
+  value: "9999-12-31T23:59:59Z"
 - name: CONFIGMAP_RELOADER_IMAGE
   value: quay.io/openshift/origin-configmap-reloader
 - name: CONFIGMAP_RELOADER_IMAGE_TAG

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -221,6 +221,7 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                       args+: [
                         '--store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}',
                         '--store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}',
+                        '--max-time=${THANOS_STORE_MAX_TIME}',
                       ],
                     } else c
                     for c in super.containers

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -128,6 +128,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_STORE_MEMORY_LIMIT', value: '8Gi' },
     { name: 'THANOS_STORE_MEMORY_REQUEST', value: '1Gi' },
     { name: 'THANOS_STORE_REPLICAS', value: '5' },
+    { name: 'THANOS_STORE_MAX_TIME', value: '9999-12-31T23:59:59Z' },
     { name: 'CONFIGMAP_RELOADER_IMAGE', value: 'quay.io/openshift/origin-configmap-reloader' },
     { name: 'CONFIGMAP_RELOADER_IMAGE_TAG', value: '4.5.0' },
     { name: 'THANOS_VOLCANO_IMAGE_TAG', value: 'main-2022-10-07-a4e33415' },


### PR DESCRIPTION
From Thanos docs

```
      --max-time=9999-12-31T23:59:59Z
                                 End of time range limit to serve. Thanos Store
                                 will serve only blocks, which happened earlier
                                 than this value. Option can be a constant time
                                 in RFC3339 format or time duration relative
                                 to current time, such as -1d or 2h45m. Valid
                                 duration units are ms, s, m, h, d, w, y.
```