### PR TITLE
Remove ThanosQueryOverloadAlert

### DIFF
--- a/observability/prometheusrules.jsonnet
+++ b/observability/prometheusrules.jsonnet
@@ -191,23 +191,27 @@ local appSREOverwrites(environment) = {
   ],
 } + {
   groups: [
-    g {
+    group {
       rules: std.filter(
-        function(r) !(
-          std.objectHas(r, 'alert') && (
+        function(rule) !(
+          std.objectHas(rule, 'alert') && (
             // Using multi-burnrate SLO alerts for these.
-            r.alert == 'ThanosQueryHttpRequestQueryRangeErrorRateHigh' ||
-            r.alert == 'ThanosQueryRangeLatencyHigh' ||
-            r.alert == 'ThanosStoreSeriesGateLatencyHigh' ||
+            rule.alert == 'ThanosQueryHttpRequestQueryRangeErrorRateHigh' ||
+            rule.alert == 'ThanosQueryRangeLatencyHigh' ||
+            rule.alert == 'ThanosStoreSeriesGateLatencyHigh' ||
             // These components arent' deployed.
-            r.alert == 'ThanosSidecarIsDown' ||
-            r.alert == 'ThanosBucketReplicateIsDown'
+            rule.alert == 'ThanosSidecarIsDown' ||
+            rule.alert == 'ThanosBucketReplicateIsDown' ||
+            // Skipping ThanosQueryOverload alert due to topology of
+            // Queriers with concurrency set to 1, which very frequently
+            // fires this alert.
+            rule.alert == 'ThanosQueryOverload'
           )
         ),
         super.rules,
       ),
     }
-    for g in super.groups
+    for group in super.groups
   ],
 };
 

--- a/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-production.prometheusrules.yaml
@@ -237,21 +237,6 @@ spec:
       labels:
         service: telemeter
         severity: high
-    - alert: ThanosQueryOverload
-      annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/98fde97ddeaf2981041745f1f2ba68c2/thanos-query?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        description: Thanos Query {{$labels.job}} in {{$labels.namespace}} has been overloaded for more than 15 minutes. This may be a symptom of excessive simultanous complex requests, low performance of the Prometheus API, or failures within these components. Assess the health of the Thanos query instances, the connnected Prometheus instances, look for potential senders of these requests and then contact support.
-        message: Thanos Query {{$labels.job}} in {{$labels.namespace}} has been overloaded for more than 15 minutes. This may be a symptom of excessive simultanous complex requests, low performance of the Prometheus API, or failures within these components. Assess the health of the Thanos query instances, the connnected Prometheus instances, look for potential senders of these requests and then contact support.
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosqueryoverload
-        summary: Thanos query reaches its maximum capacity serving concurrent requests.
-      expr: |
-        (
-          max_over_time(thanos_query_concurrent_gate_queries_max[5m]) - avg_over_time(thanos_query_concurrent_gate_queries_in_flight[5m]) < 1
-        )
-      for: 15m
-      labels:
-        service: telemeter
-        severity: medium
   - name: thanos-receive
     rules:
     - alert: ThanosReceiveHttpRequestErrorRateHigh

--- a/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-thanos-stage.prometheusrules.yaml
@@ -237,21 +237,6 @@ spec:
       labels:
         service: telemeter
         severity: high
-    - alert: ThanosQueryOverload
-      annotations:
-        dashboard: https://grafana.app-sre.devshift.net/d/98fde97ddeaf2981041745f1f2ba68c2/thanos-query?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        description: Thanos Query {{$labels.job}} in {{$labels.namespace}} has been overloaded for more than 15 minutes. This may be a symptom of excessive simultanous complex requests, low performance of the Prometheus API, or failures within these components. Assess the health of the Thanos query instances, the connnected Prometheus instances, look for potential senders of these requests and then contact support.
-        message: Thanos Query {{$labels.job}} in {{$labels.namespace}} has been overloaded for more than 15 minutes. This may be a symptom of excessive simultanous complex requests, low performance of the Prometheus API, or failures within these components. Assess the health of the Thanos query instances, the connnected Prometheus instances, look for potential senders of these requests and then contact support.
-        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#thanosqueryoverload
-        summary: Thanos query reaches its maximum capacity serving concurrent requests.
-      expr: |
-        (
-          max_over_time(thanos_query_concurrent_gate_queries_max[5m]) - avg_over_time(thanos_query_concurrent_gate_queries_in_flight[5m]) < 1
-        )
-      for: 15m
-      labels:
-        service: telemeter
-        severity: medium
   - name: thanos-receive
     rules:
     - alert: ThanosReceiveHttpRequestErrorRateHigh


### PR DESCRIPTION
These are being removed for two reasons.

First, given the topology of Querier we have decided to run in our clusers it will be firing all the time, as we decided to configure them with a query concurrency of 1.

Second, this isn't an actionable alert. Our Queriers being overloaded only require an alert in case this is quickly burning our SLO error budget. For this we have a separate alert.