### PR TITLE
receiver: Explicitly set the refresh interval to watch for changes to …

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2275,6 +2275,7 @@ objects:
           - --receive.default-tenant-id=FB870BF3-9F3A-44FF-9BF7-D7A047A52F43
           - --receive.grpc-compression=none
           - --receive.hashrings-algorithm=${THANOS_RECEIVE_HASHRINGS_ALGORITHM}
+          - --receive.hashrings-file-refresh-interval=5s
           env:
           - name: NAME
             valueFrom:

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -458,6 +458,7 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                         '--receive.default-tenant-id=FB870BF3-9F3A-44FF-9BF7-D7A047A52F43',
                         '--receive.grpc-compression=none',
                         '--receive.hashrings-algorithm=${THANOS_RECEIVE_HASHRINGS_ALGORITHM}',
+                        '--receive.hashrings-file-refresh-interval=5s',
                       ],
                       env+: s3EnvVars + [{
                         name: 'DEBUG',


### PR DESCRIPTION
…hashring config

I don't expect any/much impact with this but would like to roll it out in isolation just to be sure. It appears looking from the Thanos codebase that https://github.com/fsnotify/fsnotify will look for FS changes and update but the fallback of 5m in case of a missed event is too large IMHO

```
     --receive.hashrings-file-refresh-interval=5m
                                 Refresh interval to re-read the hashring
                                 configuration file. (used as a fallback)
```