### PR TITLE
Reverts changes to GODEBUG env for http2

### DIFF
--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -270,8 +270,6 @@ objects:
               secretKeyRef:
                 key: client_id
                 name: telemeter-server
-          - name: GODEBUG
-            value: http2server=0,http2client=0
           image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             httpGet:
@@ -521,8 +519,6 @@ objects:
               secretKeyRef:
                 key: client_id
                 name: telemeter-server
-          - name: GODEBUG
-            value: http2server=0,http2client=0
           image: ${IMAGE_CANARY}:${IMAGE_CANARY_TAG}
           livenessProbe:
             httpGet:

--- a/services/telemeter.libsonnet
+++ b/services/telemeter.libsonnet
@@ -46,12 +46,6 @@
                   '--limit-bytes=5242880',
                   '--forward-url=' + config.telemeterServer.telemeterForwardURL,
                 ],
-                env+: [
-                  {
-                    name: 'GODEBUG',
-                    value: 'http2server=0,http2client=0',
-                  },
-                ],
               }
               for c in super.containers
             ],


### PR DESCRIPTION
Reverts #430 and #429 

#429 proved effective at removing the culprit log  but we need to figure out if it makes sense to do so
```
caller="http2: server: error reading preface from client x.x.x.x" msg="read tcp x.x.x.x:8443->x.x.x.x:50454: read: connection reset by peer"18
```