### PR TITLE
[rhobs-logs] Add pod AntiAffinity to Loki components

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -170,8 +170,8 @@
           "subdir": "configuration"
         }
       },
-      "version": "37ee741596df29a3f2dbcdebd3a108f8e2ffc1f4",
-      "sum": "eKwMXFj96rXnyXGnA3TZgRpf6b30KGiElEeuVDCKvgU="
+      "version": "361c20e9bbc6533e10e1582fa0e88c378818018b",
+      "sum": "l1Xz/Hs/ba0wdjugaK90fCxqy2DuW8sMY95HuR0/QHI="
     },
     {
       "source": {

--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -495,6 +495,20 @@ objects:
           app.kubernetes.io/part-of: observatorium
           app.kubernetes.io/tracing: jaeger-agent
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - compactor
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -target=compactor
@@ -837,6 +851,20 @@ objects:
           app.kubernetes.io/tracing: jaeger-agent
           loki.grafana.com/gossip: "true"
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - distributor
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -target=distributor
@@ -1128,6 +1156,20 @@ objects:
           app.kubernetes.io/part-of: observatorium
           app.kubernetes.io/tracing: jaeger-agent
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - index-gateway
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -target=index-gateway
@@ -1348,6 +1390,20 @@ objects:
           app.kubernetes.io/tracing: jaeger-agent
           loki.grafana.com/gossip: "true"
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - ingester
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -target=ingester
@@ -1508,6 +1564,20 @@ objects:
           app.kubernetes.io/tracing: jaeger-agent
           loki.grafana.com/gossip: "true"
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - querier
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -target=querier
@@ -1715,6 +1785,20 @@ objects:
           app.kubernetes.io/part-of: observatorium
           app.kubernetes.io/tracing: jaeger-agent
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - query-frontend
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -target=query-frontend
@@ -1920,6 +2004,20 @@ objects:
           app.kubernetes.io/part-of: observatorium
           app.kubernetes.io/tracing: jaeger-agent
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - query-scheduler
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -target=query-scheduler
@@ -2190,6 +2288,20 @@ objects:
           app.kubernetes.io/tracing: jaeger-agent
           loki.grafana.com/gossip: "true"
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - ruler
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -target=ruler

--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -85,6 +85,20 @@ objects:
           app.kubernetes.io/part-of: observatorium
           app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - chunk-cache
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -m 4096
@@ -219,6 +233,20 @@ objects:
           app.kubernetes.io/part-of: observatorium
           app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - index-query-cache
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -m 1024
@@ -353,6 +381,20 @@ objects:
           app.kubernetes.io/part-of: observatorium
           app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
       spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - results-cache
+                namespaces:
+                - ${NAMESPACE}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
         containers:
         - args:
           - -m 1024

--- a/services/components/loki-caches.libsonnet
+++ b/services/components/loki-caches.libsonnet
@@ -16,6 +16,7 @@ local defaults = {
     chunkCache: {
       replicas: 1,
       withServiceMonitor: false,
+      withPodAntiAffinity: false,
       resources: {
         requests: {
           cpu: '500m',
@@ -30,6 +31,7 @@ local defaults = {
     indexQueryCache: {
       replicas: 1,
       withServiceMonitor: false,
+      withPodAntiAffinity: false,
       resources: {
         requests: {
           cpu: '500m',
@@ -44,6 +46,7 @@ local defaults = {
     resultsCache: {
       replicas: 1,
       withServiceMonitor: false,
+      withPodAntiAffinity: false,
       resources: {
         requests: {
           cpu: '500m',
@@ -90,6 +93,7 @@ function(params) {
     exporterImage:: lc.config.exporterImage,
     replicas: lc.config.components.chunkCache.replicas,
     serviceMonitor: lc.config.components.chunkCache.withServiceMonitor,
+    affinity: lc.config.components.chunkCache.withPodAntiAffinity,
     maxItemSize:: '2m',
     memoryLimitMb: 4096,
     resources: {
@@ -122,6 +126,7 @@ function(params) {
     exporterImage:: lc.config.exporterImage,
     replicas: lc.config.components.indexQueryCache.replicas,
     serviceMonitor: lc.config.components.indexQueryCache.withServiceMonitor,
+    affinity: lc.config.components.chunkCache.withPodAntiAffinity,
     maxItemSize:: '5m',
     resources: {
       memcached: {
@@ -153,6 +158,7 @@ function(params) {
     exporterImage:: lc.config.exporterImage,
     replicas: lc.config.components.resultsCache.replicas,
     serviceMonitor: lc.config.components.resultsCache.withServiceMonitor,
+    affinity: lc.config.components.chunkCache.withPodAntiAffinity,
     resources: {
       memcached: {
         requests: {

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -210,14 +210,38 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
       },
     },
     components+: {
-      compactor+: { withServiceMonitor: true },
-      distributor+: { withServiceMonitor: true },
-      ingester+: { withServiceMonitor: true },
-      index_gateway+: { withServiceMonitor: true },
-      querier+: { withServiceMonitor: true },
-      query_scheduler+: { withServiceMonitor: true },
-      query_frontend+: { withServiceMonitor: true },
-      ruler+: { withServiceMonitor: true },
+      compactor+: {
+        withServiceMonitor: true,
+        withPodAntiAffinity: true,
+      },
+      distributor+: {
+        withServiceMonitor: true,
+        withPodAntiAffinity: true,
+      },
+      ingester+: {
+        withServiceMonitor: true,
+        withPodAntiAffinity: true,
+      },
+      index_gateway+: {
+        withServiceMonitor: true,
+        withPodAntiAffinity: true,
+      },
+      querier+: {
+        withServiceMonitor: true,
+        withPodAntiAffinity: true,
+      },
+      query_scheduler+: {
+        withServiceMonitor: true,
+        withPodAntiAffinity: true,
+      },
+      query_frontend+: {
+        withServiceMonitor: true,
+        withPodAntiAffinity: true,
+      },
+      ruler+: {
+        withServiceMonitor: true,
+        withPodAntiAffinity: true,
+      },
     },
     config+: {
       limits_config+: {

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -18,6 +18,7 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
       chunkCache: {
         replicas: 1,  // overwritten in observatorium-logs-template.libsonnet
         withServiceMonitor: true,
+        withPodAntiAffinity: true,
         resources+: {
           requests: {
             cpu: '${LOKI_CHUNK_CACHE_CPU_REQUESTS}',
@@ -32,6 +33,7 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
       indexQueryCache: {
         replicas: 1,  // overwritten in observatorium-logs-template.libsonnet
         withServiceMonitor: true,
+        withPodAntiAffinity: true,
         resources+: {
           requests: {
             cpu: '${LOKI_INDEX_QUERY_CACHE_CPU_REQUESTS}',
@@ -46,6 +48,7 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
       resultsCache: {
         replicas: 1,  // overwritten in observatorium-logs-template.libsonnet
         withServiceMonitor: true,
+        withPodAntiAffinity: true,
         resources+: {
           requests: {
             cpu: '${LOKI_RESULTS_CACHE_CPU_REQUESTS}',


### PR DESCRIPTION
This PR adds pod AntiAffinity to the Loki components including cache pods.

**Related PR**: [Add AntiAffinity to Loki and Memcached](https://github.com/observatorium/observatorium/pull/509)

**JIRA**: [LOG-2500](https://issues.redhat.com/browse/LOG-2500)