### PR TITLE
[rhobs-logs] Disable Alerts for Loki cache memory limits

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -60,6 +60,8 @@ objects:
 - apiVersion: apps/v1
   kind: StatefulSet
   metadata:
+    annotations:
+      ignore-check.kube-linter.io/memory-requirements: This is a cache, minimal memory required
     labels:
       app.kubernetes.io/component: chunk-cache
       app.kubernetes.io/instance: observatorium
@@ -208,6 +210,8 @@ objects:
 - apiVersion: apps/v1
   kind: StatefulSet
   metadata:
+    annotations:
+      ignore-check.kube-linter.io/memory-requirements: This is a cache, minimal memory required
     labels:
       app.kubernetes.io/component: index-query-cache
       app.kubernetes.io/instance: observatorium
@@ -356,6 +360,8 @@ objects:
 - apiVersion: apps/v1
   kind: StatefulSet
   metadata:
+    annotations:
+      ignore-check.kube-linter.io/memory-requirements: This is a cache, minimal memory required
     labels:
       app.kubernetes.io/component: results-cache
       app.kubernetes.io/instance: observatorium

--- a/services/observatorium-logs-template-overwrites.libsonnet
+++ b/services/observatorium-logs-template-overwrites.libsonnet
@@ -28,6 +28,11 @@ local jaegerAgentSidecar = (import 'sidecars/jaeger-agent.libsonnet')({
   } + {
     manifests+:: {
       [name]+: {
+        metadata+: {
+          annotations+: {
+            'ignore-check.kube-linter.io/memory-requirements': 'This is a cache, minimal memory required',
+          },
+        },
         spec+: {
           replicas: replicas[name],
           template+: {


### PR DESCRIPTION
This PR disable the alerts from the deployment_validation_operator that the loki cache containers do not have memory requests and limits set. This is not required since all the containers are caches. 

@periklis 
[LOG-2502](https://issues.redhat.com/browse/LOG-2502)