### PR TITLE
[rhobs-logs] Enhance http write timeouts and log level settings.

### DIFF
--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -840,7 +840,7 @@ objects:
         "http_listen_port": 3100
         "http_server_idle_timeout": "120s"
         "http_server_write_timeout": "10m"
-        "log_level": "error"
+        "log_level": "${LOKI_LOG_LEVEL}"
       "storage_config":
         "boltdb_shipper":
           "active_index_directory": "/data/loki/index"
@@ -2526,6 +2526,8 @@ parameters:
   value: rules-objstore-stage-s3
 - name: STORAGE_CLASS
   value: gp2
+- name: LOKI_LOG_LEVEL
+  value: error
 - name: LOKI_IMAGE_TAG
   value: 2.7.2
 - name: LOKI_IMAGE

--- a/resources/services/observatorium-logs-template.yaml
+++ b/resources/services/observatorium-logs-template.yaml
@@ -839,7 +839,7 @@ objects:
         "grpc_server_ping_without_stream_allowed": true
         "http_listen_port": 3100
         "http_server_idle_timeout": "120s"
-        "http_server_write_timeout": "1m"
+        "http_server_write_timeout": "10m"
         "log_level": "error"
       "storage_config":
         "boltdb_shipper":

--- a/services/observatorium-logs-template.jsonnet
+++ b/services/observatorium-logs-template.jsonnet
@@ -26,6 +26,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'ALERTMANAGER_EXTERNAL_URL', value: 'https://observatorium-alertmanager-mst.api.stage.openshift.com' },
     { name: 'RULES_OBJSTORE_S3_SECRET', value: 'rules-objstore-stage-s3' },
     { name: 'STORAGE_CLASS', value: 'gp2' },
+    { name: 'LOKI_LOG_LEVEL', value: 'error' },
     { name: 'LOKI_IMAGE_TAG', value: '2.7.2' },
     { name: 'LOKI_IMAGE', value: 'docker.io/grafana/loki' },
     { name: 'LOKI_S3_SECRET', value: 'observatorium-mst-logs-stage-s3' },

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -263,6 +263,7 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
       },
       server+: {
         http_server_write_timeout: '10m',
+        log_level: '${LOKI_LOG_LEVEL}',
       },
       tracing: {
         enabled: true,

--- a/services/observatorium-logs.libsonnet
+++ b/services/observatorium-logs.libsonnet
@@ -261,6 +261,9 @@ local lokiCaches = (import 'components/loki-caches.libsonnet');
         alertmanager_url: 'http://_http._tcp.observatorium-alertmanager.${ALERTMANAGER_NAMESPACE}.svc.cluster.local',
         alertmanager_refresh_interval: '1m',
       },
+      server+: {
+        http_server_write_timeout: '10m',
+      },
       tracing: {
         enabled: true,
       },


### PR DESCRIPTION
1. Aligns the http write timeout with the default of the API (See observatorium/api#493)
2. Adds template parameter to set the loki log level per environment.