### PR TITLE
Filter datasources on Thanos mixin dashboards

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -356,8 +356,8 @@
           "subdir": "mixin"
         }
       },
-      "version": "96fd6db6942290e1e520d556eed2e89df4e29eea",
-      "sum": "YWi7WSDfTecWr5xnXODfyxGcZUnXSw9Ba6lEanaqLW4=",
+      "version": "650de168c586f20b2dc3e51e3c9f3e54906c4264",
+      "sum": "zSLNV/0bN4DcVKojzCqjmhfjtzTY4pDKZXqbAUzw5R0=",
       "name": "thanos-mixin"
     }
   ],

--- a/observability/config.libsonnet
+++ b/observability/config.libsonnet
@@ -31,6 +31,9 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
     compact+:: {
       selector: 'job="%s"' % thanos.compact.config.name,
     },
+    dashboard+:: {
+      instance_name_filter: '/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/',
+    },
   },
 
   loki: {

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-compact.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-compact.configmap.yaml
@@ -1924,7 +1924,7 @@ data:
             ],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "",
+            "regex": "/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/",
             "type": "datasource"
           },
           {

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-overview.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-overview.configmap.yaml
@@ -1880,7 +1880,7 @@ data:
             ],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "",
+            "regex": "/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/",
             "type": "datasource"
           },
           {

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-query-frontend.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-query-frontend.configmap.yaml
@@ -1149,7 +1149,7 @@ data:
             ],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "",
+            "regex": "/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/",
             "type": "datasource"
           },
           {

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-query.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-query.configmap.yaml
@@ -2048,7 +2048,7 @@ data:
             ],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "",
+            "regex": "/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/",
             "type": "datasource"
           },
           {

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-receive.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-receive.configmap.yaml
@@ -3225,7 +3225,7 @@ data:
             ],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "",
+            "regex": "/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/",
             "type": "datasource"
           },
           {

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-rule.configmap.yaml
@@ -2047,7 +2047,7 @@ data:
             ],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "",
+            "regex": "/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/",
             "type": "datasource"
           },
           {

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-store.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-store.configmap.yaml
@@ -3042,7 +3042,7 @@ data:
             ],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "",
+            "regex": "/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/",
             "type": "datasource"
           },
           {


### PR DESCRIPTION
With this commit we filter the available datasources on the grafana dashboards provided by the bundled thanos mixin dashboards. This should make it significantly easier to find the data needed.

The regex used currently will show the following datasources:
- app-sre-stage-01-prometheus
- rhobs-testing-cluster-prometheus
- rhobs-testing-prometheus
- rhobsp02ue1-cluster-prometheus
- rhobsp02ue1-prometheus
- telemeter-prod-01-prometheus

Any additional datasources starting with `rhobs` will be added if they become available.

Updates Thanos mixin to the latest version, which has the following PR as diff: https://github.com/thanos-io/thanos/pull/6273