### PR TITLE
Filter datasources on Thanos / Receive Controller

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -202,8 +202,8 @@
           "subdir": "jsonnet/thanos-receive-controller-mixin"
         }
       },
-      "version": "02aec09ce44b2f26ec9364469c2c6396f58702eb",
-      "sum": "PQPhMFFGY15ATdzHv0L9/cgwhlM4yKUkuljrOQi/Y3g="
+      "version": "1a5357d4bd43d4291a0506ecaf09854ecb5ca6e6",
+      "sum": "nW7Wxior1HcLbIIQ+kYaviEcgQmjcVgvqt06Sp0qjRM="
     },
     {
       "source": {

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-receive-controller.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-receive-controller.configmap.yaml
@@ -974,7 +974,7 @@ data:
             ],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "",
+            "regex": "/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/",
             "type": "datasource"
           },
           {


### PR DESCRIPTION
Following on from: https://github.com/rhobs/configuration/pull/454 we now use the same filter for the receive controller dashboard, which comes from the thanos-receive-controller rather than Thanos itself.

Pulls in the latest mixin from thanos-recieve-controller following: https://github.com/observatorium/thanos-receive-controller/pull/115