### PR TITLE
Filter namespaces on Receive Controller dashboard

### DIFF
--- a/observability/config.libsonnet
+++ b/observability/config.libsonnet
@@ -8,6 +8,10 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
     targetGroups+:: {
       namespace: 'thanos_status',
     },
+    // Filter the namespaces in thanos-recieve-controller dashboard
+    hierarcies+:: {
+      namespace: 'thanos_status',
+    },
     overview+:: {
       title: '%(prefix)sOverview' % t.dashboard.prefix,
     },

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-receive-controller.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-thanos-receive-controller.configmap.yaml
@@ -991,7 +991,7 @@ data:
             "options": [
 
             ],
-            "query": "label_values(kube_pod_info, namespace)",
+            "query": "label_values(thanos_status, namespace)",
             "refresh": 1,
             "regex": "",
             "sort": 2,


### PR DESCRIPTION
With this commit we filter the namespaces on the Thanos / Receive Controller dashboard, similar to the rest of the Thanos dashboards.