### PR TITLE
Receive-controller hierarchies typo

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -272,8 +272,8 @@
           "subdir": "jsonnet/thanos-receive-controller-mixin"
         }
       },
-      "version": "1a5357d4bd43d4291a0506ecaf09854ecb5ca6e6",
-      "sum": "nW7Wxior1HcLbIIQ+kYaviEcgQmjcVgvqt06Sp0qjRM="
+      "version": "89ba95dea87092d01777e77b5a636ef497b32e86",
+      "sum": "SvBm5veTRA3P8YicTBC0XHjGZ8x867h+4bS6PKWB+Zc="
     },
     {
       "source": {

--- a/observability/config.libsonnet
+++ b/observability/config.libsonnet
@@ -9,7 +9,7 @@ local thanos = (import '../services/observatorium-metrics.libsonnet').thanos;
       namespace: 'thanos_status',
     },
     // Filter the namespaces in thanos-recieve-controller dashboard
-    hierarcies+:: {
+    hierarchies+:: {
       namespace: 'thanos_status',
     },
     overview+:: {


### PR DESCRIPTION
Update the thanos-receive-controller mixin to include [upstream change](https://github.com/observatorium/thanos-receive-controller/pull/116) which fixes a typo in the `hierarchies` variable.