### PR TITLE
Thanos Query: Additional telemetry buckets

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1376,6 +1376,19 @@ objects:
               "service_name": "thanos-query"
             "type": "JAEGER"
           - --query.auto-downsampling
+          - --query.telemetry.request-duration-seconds-quantiles=0.1
+          - --query.telemetry.request-duration-seconds-quantiles=0.25
+          - --query.telemetry.request-duration-seconds-quantiles=0.75
+          - --query.telemetry.request-duration-seconds-quantiles=1.25
+          - --query.telemetry.request-duration-seconds-quantiles=1.75
+          - --query.telemetry.request-duration-seconds-quantiles=2.5
+          - --query.telemetry.request-duration-seconds-quantiles=3
+          - --query.telemetry.request-duration-seconds-quantiles=5
+          - --query.telemetry.request-duration-seconds-quantiles=10
+          - --query.telemetry.request-duration-seconds-quantiles=15
+          - --query.telemetry.request-duration-seconds-quantiles=30
+          - --query.telemetry.request-duration-seconds-quantiles=60
+          - --query.telemetry.request-duration-seconds-quantiles=120
           - --store.sd-files=/etc/thanos/sd/file_sd.yaml
           - --grpc.proxy-strategy=${THANOS_QUERIER_PROXY_STRATEGY}
           - --query.promql-engine=${THANOS_QUERIER_ENGINE}

--- a/services/observatorium-metrics.libsonnet
+++ b/services/observatorium-metrics.libsonnet
@@ -591,6 +591,7 @@ local oauthProxy = import './sidecars/oauth-proxy.libsonnet';
           memory: '${THANOS_QUERIER_MEMORY_LIMIT}',
         },
       },
+      telemetryDurationQuantiles: '0.1, 0.25, 0.75, 1.25, 1.75, 2.5, 3, 5, 10, 15, 30, 60, 120',
     }) + {
       // This is a workaround for adding extra store for the metric federation
       // ruler service, which does not exist in the MST instance, so we cannot simply pass it


### PR DESCRIPTION
This commit adds additional `telemetryDurationQuantiles`, to ensure we have buckets for complicated queries that takes a long time to complete. It uses the default values, as defined upstream in Thanos, and adds 15, 30, 60 and 120. 120 is chosen as the upper bound as that is the timeout set in the Observatorium API.