### PR TITLE
Make long and short labels in alerts more descriptive

### DIFF
--- a/configuration/observatorium/slo.go
+++ b/configuration/observatorium/slo.go
@@ -665,6 +665,20 @@ func makePrometheusRule(envName rhobsInstanceEnv, objs []pyrrav1alpha1.ServiceLe
 		grp = append(grp, generic)
 	}
 
+	// Make long/short labels more descriptive.
+	for i := range grp {
+		for j := range grp[i].Rules {
+			if v, ok := grp[i].Rules[j].Labels["long"]; ok {
+				grp[i].Rules[j].Labels["long_burnrate_window"] = v
+				delete(grp[i].Rules[j].Labels, "long")
+			}
+
+			if v, ok := grp[i].Rules[j].Labels["short"]; ok {
+				grp[i].Rules[j].Labels["short_burnrate_window"] = v
+				delete(grp[i].Rules[j].Labels, "short")
+			}
+		}
+	}
 	// We do not want to page on staging environments, i.e, no "critical" alerts.
 	// There isn't a way to control the alert severity in Pyrra configs yet, but ideally should be.
 	// Pending PR: https://github.com/pyrra-dev/pyrra/pull/617

--- a/resources/observability/prometheusrules/rhobs-slos-logs-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-logs-mst-production.prometheusrules.yaml
@@ -108,9 +108,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-write-availability-slo
     - alert: APILogsPushAvailabilityErrorBudgetBurning
       annotations:
@@ -126,9 +126,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-write-availability-slo
     - alert: APILogsPushAvailabilityErrorBudgetBurning
       annotations:
@@ -144,9 +144,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-write-availability-slo
     - alert: APILogsPushAvailabilityErrorBudgetBurning
       annotations:
@@ -162,9 +162,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-write-availability-slo
   - interval: 30s
     name: api-logs-write-availability-slo-generic
@@ -279,9 +279,9 @@ spec:
       labels:
         group: logsv1
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-query-availability-slo
     - alert: APILogsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -296,9 +296,9 @@ spec:
       labels:
         group: logsv1
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-query-availability-slo
     - alert: APILogsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -313,9 +313,9 @@ spec:
       labels:
         group: logsv1
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-query-availability-slo
     - alert: APILogsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -330,9 +330,9 @@ spec:
       labels:
         group: logsv1
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-query-availability-slo
   - interval: 30s
     name: api-logs-query-availability-slo-generic
@@ -457,9 +457,9 @@ spec:
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-query-range-availability-slo
     - alert: APILogsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -475,9 +475,9 @@ spec:
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-query-range-availability-slo
     - alert: APILogsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -493,9 +493,9 @@ spec:
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-query-range-availability-slo
     - alert: APILogsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -511,9 +511,9 @@ spec:
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-query-range-availability-slo
   - interval: 30s
     name: api-logs-query-range-availability-slo-generic
@@ -638,9 +638,9 @@ spec:
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-tail-availability-slo
     - alert: APILogsTailAvailabilityErrorBudgetBurning
       annotations:
@@ -656,9 +656,9 @@ spec:
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-tail-availability-slo
     - alert: APILogsTailAvailabilityErrorBudgetBurning
       annotations:
@@ -674,9 +674,9 @@ spec:
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-tail-availability-slo
     - alert: APILogsTailAvailabilityErrorBudgetBurning
       annotations:
@@ -692,9 +692,9 @@ spec:
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-tail-availability-slo
   - interval: 30s
     name: api-logs-tail-availability-slo-generic
@@ -819,9 +819,9 @@ spec:
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-prom-tail-availability-slo
     - alert: APILogsPromTailAvailabilityErrorBudgetBurning
       annotations:
@@ -837,9 +837,9 @@ spec:
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-prom-tail-availability-slo
     - alert: APILogsPromTailAvailabilityErrorBudgetBurning
       annotations:
@@ -855,9 +855,9 @@ spec:
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-prom-tail-availability-slo
     - alert: APILogsPromTailAvailabilityErrorBudgetBurning
       annotations:
@@ -873,9 +873,9 @@ spec:
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-prom-tail-availability-slo
   - interval: 30s
     name: api-logs-prom-tail-availability-slo-generic
@@ -1031,9 +1031,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-write-latency-slo
     - alert: APILogsPushLatencyErrorBudgetBurning
       annotations:
@@ -1049,9 +1049,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-write-latency-slo
     - alert: APILogsPushLatencyErrorBudgetBurning
       annotations:
@@ -1067,9 +1067,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-write-latency-slo
     - alert: APILogsPushLatencyErrorBudgetBurning
       annotations:
@@ -1085,9 +1085,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-write-latency-slo
   - interval: 30s
     name: api-logs-write-latency-slo-generic

--- a/resources/observability/prometheusrules/rhobs-slos-logs-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-logs-mst-stage.prometheusrules.yaml
@@ -108,9 +108,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-write-availability-slo
     - alert: APILogsPushAvailabilityErrorBudgetBurning
       annotations:
@@ -126,9 +126,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-write-availability-slo
     - alert: APILogsPushAvailabilityErrorBudgetBurning
       annotations:
@@ -144,9 +144,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-write-availability-slo
     - alert: APILogsPushAvailabilityErrorBudgetBurning
       annotations:
@@ -162,9 +162,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-write-availability-slo
   - interval: 30s
     name: api-logs-write-availability-slo-generic
@@ -279,9 +279,9 @@ spec:
       labels:
         group: logsv1
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-query-availability-slo
     - alert: APILogsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -296,9 +296,9 @@ spec:
       labels:
         group: logsv1
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-query-availability-slo
     - alert: APILogsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -313,9 +313,9 @@ spec:
       labels:
         group: logsv1
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-query-availability-slo
     - alert: APILogsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -330,9 +330,9 @@ spec:
       labels:
         group: logsv1
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-query-availability-slo
   - interval: 30s
     name: api-logs-query-availability-slo-generic
@@ -457,9 +457,9 @@ spec:
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-query-range-availability-slo
     - alert: APILogsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -475,9 +475,9 @@ spec:
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-query-range-availability-slo
     - alert: APILogsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -493,9 +493,9 @@ spec:
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-query-range-availability-slo
     - alert: APILogsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -511,9 +511,9 @@ spec:
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-query-range-availability-slo
   - interval: 30s
     name: api-logs-query-range-availability-slo-generic
@@ -638,9 +638,9 @@ spec:
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-tail-availability-slo
     - alert: APILogsTailAvailabilityErrorBudgetBurning
       annotations:
@@ -656,9 +656,9 @@ spec:
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-tail-availability-slo
     - alert: APILogsTailAvailabilityErrorBudgetBurning
       annotations:
@@ -674,9 +674,9 @@ spec:
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-tail-availability-slo
     - alert: APILogsTailAvailabilityErrorBudgetBurning
       annotations:
@@ -692,9 +692,9 @@ spec:
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-tail-availability-slo
   - interval: 30s
     name: api-logs-tail-availability-slo-generic
@@ -819,9 +819,9 @@ spec:
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-prom-tail-availability-slo
     - alert: APILogsPromTailAvailabilityErrorBudgetBurning
       annotations:
@@ -837,9 +837,9 @@ spec:
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-prom-tail-availability-slo
     - alert: APILogsPromTailAvailabilityErrorBudgetBurning
       annotations:
@@ -855,9 +855,9 @@ spec:
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-prom-tail-availability-slo
     - alert: APILogsPromTailAvailabilityErrorBudgetBurning
       annotations:
@@ -873,9 +873,9 @@ spec:
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-prom-tail-availability-slo
   - interval: 30s
     name: api-logs-prom-tail-availability-slo-generic
@@ -1031,9 +1031,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-logs-write-latency-slo
     - alert: APILogsPushLatencyErrorBudgetBurning
       annotations:
@@ -1049,9 +1049,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-logs-write-latency-slo
     - alert: APILogsPushLatencyErrorBudgetBurning
       annotations:
@@ -1067,9 +1067,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-logs-write-latency-slo
     - alert: APILogsPushLatencyErrorBudgetBurning
       annotations:
@@ -1085,9 +1085,9 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-logs-write-latency-slo
   - interval: 30s
     name: api-logs-write-latency-slo-generic

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -108,9 +108,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -126,9 +126,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -144,9 +144,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -162,9 +162,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
   - interval: 30s
     name: api-metrics-write-availability-slo-generic
@@ -289,9 +289,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -307,9 +307,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -325,9 +325,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -343,9 +343,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
   - interval: 30s
     name: api-metrics-query-availability-slo-generic
@@ -470,9 +470,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -488,9 +488,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -506,9 +506,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -524,9 +524,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
     name: api-metrics-query-range-availability-slo-generic
@@ -660,10 +660,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         method: PUT
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -679,10 +679,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         method: PUT
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -698,10 +698,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         method: PUT
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -717,10 +717,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         method: PUT
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
     name: api-rules-raw-write-availability-slo-generic
@@ -854,10 +854,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         method: GET
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -873,10 +873,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         method: GET
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -892,10 +892,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         method: GET
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -911,10 +911,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         method: GET
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
     name: api-rules-raw-read-availability-slo-generic
@@ -1048,10 +1048,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         method: GET
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1067,10 +1067,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         method: GET
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1086,10 +1086,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         method: GET
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1105,10 +1105,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         method: GET
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
   - interval: 30s
     name: api-rules-read-availability-slo-generic
@@ -1232,10 +1232,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1250,10 +1250,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1268,10 +1268,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1286,10 +1286,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
   - interval: 30s
     name: api-rules-sync-availability-slo-generic
@@ -1403,10 +1403,10 @@ spec:
       for: 2m
       labels:
         container: thanos-rule
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -1420,10 +1420,10 @@ spec:
       for: 15m
       labels:
         container: thanos-rule
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -1437,10 +1437,10 @@ spec:
       for: 1h
       labels:
         container: thanos-rule
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -1454,10 +1454,10 @@ spec:
       for: 3h
       labels:
         container: thanos-rule
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-alerting-availability-slo
   - interval: 30s
     name: api-alerting-availability-slo-generic
@@ -1570,11 +1570,11 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1587,11 +1587,11 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1604,11 +1604,11 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1621,11 +1621,11 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-alerting-notif-availability-slo
   - interval: 30s
     name: api-alerting-notif-availability-slo-generic
@@ -1781,9 +1781,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -1799,9 +1799,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -1817,9 +1817,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -1835,9 +1835,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
   - interval: 30s
     name: api-metrics-write-latency-slo-generic
@@ -1979,11 +1979,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -1996,11 +1996,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2013,11 +2013,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2030,11 +2030,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-read-1M-latency-slo-generic
@@ -2176,11 +2176,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2193,11 +2193,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2210,11 +2210,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2227,11 +2227,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-read-10M-latency-slo-generic
@@ -2373,11 +2373,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -2390,11 +2390,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -2407,11 +2407,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -2424,11 +2424,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-read-100M-latency-slo-generic

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -108,9 +108,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -126,9 +126,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -144,9 +144,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -162,9 +162,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
   - interval: 30s
     name: api-metrics-write-availability-slo-generic
@@ -289,9 +289,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -307,9 +307,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -325,9 +325,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -343,9 +343,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
   - interval: 30s
     name: api-metrics-query-availability-slo-generic
@@ -470,9 +470,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -488,9 +488,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -506,9 +506,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -524,9 +524,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
     name: api-metrics-query-range-availability-slo-generic
@@ -660,10 +660,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         method: PUT
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -679,10 +679,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         method: PUT
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -698,10 +698,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         method: PUT
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -717,10 +717,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         method: PUT
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
     name: api-rules-raw-write-availability-slo-generic
@@ -854,10 +854,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         method: GET
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -873,10 +873,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         method: GET
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -892,10 +892,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         method: GET
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -911,10 +911,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         method: GET
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
     name: api-rules-raw-read-availability-slo-generic
@@ -1048,10 +1048,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         method: GET
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1067,10 +1067,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         method: GET
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1086,10 +1086,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         method: GET
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1105,10 +1105,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         method: GET
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
   - interval: 30s
     name: api-rules-read-availability-slo-generic
@@ -1232,10 +1232,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1250,10 +1250,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1268,10 +1268,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1286,10 +1286,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
   - interval: 30s
     name: api-rules-sync-availability-slo-generic
@@ -1403,10 +1403,10 @@ spec:
       for: 2m
       labels:
         container: thanos-rule
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -1420,10 +1420,10 @@ spec:
       for: 15m
       labels:
         container: thanos-rule
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -1437,10 +1437,10 @@ spec:
       for: 1h
       labels:
         container: thanos-rule
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -1454,10 +1454,10 @@ spec:
       for: 3h
       labels:
         container: thanos-rule
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-alerting-availability-slo
   - interval: 30s
     name: api-alerting-availability-slo-generic
@@ -1570,11 +1570,11 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1587,11 +1587,11 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1604,11 +1604,11 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1621,11 +1621,11 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         service: observatorium-alertmanager
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-alerting-notif-availability-slo
   - interval: 30s
     name: api-alerting-notif-availability-slo-generic
@@ -1781,9 +1781,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -1799,9 +1799,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -1817,9 +1817,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -1835,9 +1835,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
   - interval: 30s
     name: api-metrics-write-latency-slo-generic
@@ -1979,11 +1979,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -1996,11 +1996,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2013,11 +2013,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2030,11 +2030,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-read-1M-latency-slo-generic
@@ -2176,11 +2176,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2193,11 +2193,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2210,11 +2210,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2227,11 +2227,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-read-10M-latency-slo-generic
@@ -2373,11 +2373,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -2390,11 +2390,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -2407,11 +2407,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -2424,11 +2424,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-read-100M-latency-slo-generic

--- a/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
@@ -108,9 +108,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -126,9 +126,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -144,9 +144,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -162,9 +162,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
   - interval: 30s
     name: api-metrics-write-availability-slo-generic
@@ -289,9 +289,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -307,9 +307,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -325,9 +325,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -343,9 +343,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
   - interval: 30s
     name: api-metrics-query-availability-slo-generic
@@ -470,9 +470,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -488,9 +488,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -506,9 +506,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -524,9 +524,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
     name: api-metrics-query-range-availability-slo-generic
@@ -660,10 +660,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         method: PUT
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -679,10 +679,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         method: PUT
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -698,10 +698,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         method: PUT
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -717,10 +717,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         method: PUT
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
     name: api-rules-raw-write-availability-slo-generic
@@ -854,10 +854,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         method: GET
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -873,10 +873,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         method: GET
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -892,10 +892,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         method: GET
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -911,10 +911,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         method: GET
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
     name: api-rules-raw-read-availability-slo-generic
@@ -1048,10 +1048,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         method: GET
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1067,10 +1067,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         method: GET
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1086,10 +1086,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         method: GET
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1105,10 +1105,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         method: GET
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
   - interval: 30s
     name: api-rules-read-availability-slo-generic
@@ -1232,10 +1232,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1250,10 +1250,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1268,10 +1268,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1286,10 +1286,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
   - interval: 30s
     name: api-rules-sync-availability-slo-generic
@@ -1403,10 +1403,10 @@ spec:
       for: 2m
       labels:
         container: thanos-rule
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -1420,10 +1420,10 @@ spec:
       for: 15m
       labels:
         container: thanos-rule
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -1437,10 +1437,10 @@ spec:
       for: 1h
       labels:
         container: thanos-rule
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -1454,10 +1454,10 @@ spec:
       for: 3h
       labels:
         container: thanos-rule
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-alerting-availability-slo
   - interval: 30s
     name: api-alerting-availability-slo-generic
@@ -1570,11 +1570,11 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1587,11 +1587,11 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1604,11 +1604,11 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -1621,11 +1621,11 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-alertmanager
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-alerting-notif-availability-slo
   - interval: 30s
     name: api-alerting-notif-availability-slo-generic
@@ -1781,9 +1781,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -1799,9 +1799,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -1817,9 +1817,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -1835,9 +1835,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
   - interval: 30s
     name: api-metrics-write-latency-slo-generic
@@ -1979,11 +1979,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -1996,11 +1996,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2013,11 +2013,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2030,11 +2030,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-read-1M-latency-slo-generic
@@ -2176,11 +2176,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2193,11 +2193,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2210,11 +2210,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2227,11 +2227,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-read-10M-latency-slo-generic
@@ -2373,11 +2373,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -2390,11 +2390,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -2407,11 +2407,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -2424,11 +2424,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-read-100M-latency-slo-generic

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -87,10 +87,10 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         route: telemeter-server-upload
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
     - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -103,10 +103,10 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         route: telemeter-server-upload
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
     - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -119,10 +119,10 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         route: telemeter-server-upload
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
     - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -135,10 +135,10 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         route: telemeter-server-upload
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-upload-availability-slo-generic
@@ -242,10 +242,10 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         route: telemeter-server-metrics-v1-receive
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
     - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -258,10 +258,10 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         route: telemeter-server-metrics-v1-receive
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
     - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -274,10 +274,10 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         route: telemeter-server-metrics-v1-receive
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
     - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -290,10 +290,10 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         route: telemeter-server-metrics-v1-receive
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-receive-availability-slo-generic
@@ -437,9 +437,9 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
@@ -454,9 +454,9 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
@@ -471,9 +471,9 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
@@ -488,9 +488,9 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-upload-latency-slo-generic
@@ -634,9 +634,9 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
       annotations:
@@ -651,9 +651,9 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
       annotations:
@@ -668,9 +668,9 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
       annotations:
@@ -685,9 +685,9 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-receive-latency-slo-generic
@@ -812,9 +812,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -830,9 +830,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -848,9 +848,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -866,9 +866,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
   - interval: 30s
     name: api-metrics-write-availability-slo-generic
@@ -993,9 +993,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -1011,9 +1011,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -1029,9 +1029,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -1047,9 +1047,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
   - interval: 30s
     name: api-metrics-query-availability-slo-generic
@@ -1174,9 +1174,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -1192,9 +1192,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -1210,9 +1210,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -1228,9 +1228,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
     name: api-metrics-query-range-availability-slo-generic
@@ -1364,10 +1364,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         method: PUT
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -1383,10 +1383,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         method: PUT
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -1402,10 +1402,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         method: PUT
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -1421,10 +1421,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         method: PUT
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
     name: api-rules-raw-write-availability-slo-generic
@@ -1558,10 +1558,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         method: GET
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1577,10 +1577,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         method: GET
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1596,10 +1596,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         method: GET
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1615,10 +1615,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         method: GET
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
     name: api-rules-raw-read-availability-slo-generic
@@ -1752,10 +1752,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         method: GET
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1771,10 +1771,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         method: GET
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1790,10 +1790,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         method: GET
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1809,10 +1809,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         method: GET
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
   - interval: 30s
     name: api-rules-read-availability-slo-generic
@@ -1936,10 +1936,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-metrics-production
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1954,10 +1954,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-metrics-production
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1972,10 +1972,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-metrics-production
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1990,10 +1990,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-metrics-production
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
   - interval: 30s
     name: api-rules-sync-availability-slo-generic
@@ -2107,10 +2107,10 @@ spec:
       for: 2m
       labels:
         container: thanos-rule
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-metrics-production
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -2124,10 +2124,10 @@ spec:
       for: 15m
       labels:
         container: thanos-rule
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-metrics-production
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -2141,10 +2141,10 @@ spec:
       for: 1h
       labels:
         container: thanos-rule
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-metrics-production
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -2158,10 +2158,10 @@ spec:
       for: 3h
       labels:
         container: thanos-rule
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-metrics-production
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-alerting-availability-slo
   - interval: 30s
     name: api-alerting-availability-slo-generic
@@ -2274,11 +2274,11 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -2291,11 +2291,11 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -2308,11 +2308,11 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -2325,11 +2325,11 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-metrics-production
         service: observatorium-alertmanager
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-alerting-notif-availability-slo
   - interval: 30s
     name: api-alerting-notif-availability-slo-generic
@@ -2485,9 +2485,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -2503,9 +2503,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -2521,9 +2521,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -2539,9 +2539,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
   - interval: 30s
     name: api-metrics-write-latency-slo-generic
@@ -2683,11 +2683,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2700,11 +2700,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2717,11 +2717,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2734,11 +2734,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-read-1M-latency-slo-generic
@@ -2880,11 +2880,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-10M-samples
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2897,11 +2897,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-10M-samples
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2914,11 +2914,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-10M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2931,11 +2931,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-10M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-read-10M-latency-slo-generic
@@ -3077,11 +3077,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -3094,11 +3094,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         severity: critical
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -3111,11 +3111,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -3128,11 +3128,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-read-100M-latency-slo-generic

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -87,10 +87,10 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         route: telemeter-server-upload
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
     - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -103,10 +103,10 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         route: telemeter-server-upload
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
     - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -119,10 +119,10 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         route: telemeter-server-upload
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
     - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -135,10 +135,10 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         route: telemeter-server-upload
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-upload-availability-slo-generic
@@ -242,10 +242,10 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         route: telemeter-server-metrics-v1-receive
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
     - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -258,10 +258,10 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         route: telemeter-server-metrics-v1-receive
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
     - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -274,10 +274,10 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         route: telemeter-server-metrics-v1-receive
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
     - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -290,10 +290,10 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         route: telemeter-server-metrics-v1-receive
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-receive-availability-slo-generic
@@ -437,9 +437,9 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
@@ -454,9 +454,9 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
@@ -471,9 +471,9 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
       annotations:
@@ -488,9 +488,9 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-upload-latency-slo-generic
@@ -634,9 +634,9 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
       annotations:
@@ -651,9 +651,9 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
       annotations:
@@ -668,9 +668,9 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
       annotations:
@@ -685,9 +685,9 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-receive-latency-slo-generic
@@ -812,9 +812,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -830,9 +830,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -848,9 +848,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -866,9 +866,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
   - interval: 30s
     name: api-metrics-write-availability-slo-generic
@@ -993,9 +993,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -1011,9 +1011,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -1029,9 +1029,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
       annotations:
@@ -1047,9 +1047,9 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
   - interval: 30s
     name: api-metrics-query-availability-slo-generic
@@ -1174,9 +1174,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -1192,9 +1192,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -1210,9 +1210,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       annotations:
@@ -1228,9 +1228,9 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
     name: api-metrics-query-range-availability-slo-generic
@@ -1364,10 +1364,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         method: PUT
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -1383,10 +1383,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         method: PUT
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -1402,10 +1402,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         method: PUT
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-raw-write-availability-slo
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
       annotations:
@@ -1421,10 +1421,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         method: PUT
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
     name: api-rules-raw-write-availability-slo-generic
@@ -1558,10 +1558,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         method: GET
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1577,10 +1577,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         method: GET
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1596,10 +1596,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         method: GET
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-raw-read-availability-slo
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1615,10 +1615,10 @@ spec:
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         method: GET
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
     name: api-rules-raw-read-availability-slo-generic
@@ -1752,10 +1752,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         method: GET
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1771,10 +1771,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         method: GET
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1790,10 +1790,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         method: GET
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
       annotations:
@@ -1809,10 +1809,10 @@ spec:
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         method: GET
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
   - interval: 30s
     name: api-rules-read-availability-slo-generic
@@ -1936,10 +1936,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1954,10 +1954,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1972,10 +1972,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
       annotations:
@@ -1990,10 +1990,10 @@ spec:
       labels:
         client: reload
         container: thanos-rule-syncer
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
   - interval: 30s
     name: api-rules-sync-availability-slo-generic
@@ -2107,10 +2107,10 @@ spec:
       for: 2m
       labels:
         container: thanos-rule
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -2124,10 +2124,10 @@ spec:
       for: 15m
       labels:
         container: thanos-rule
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -2141,10 +2141,10 @@ spec:
       for: 1h
       labels:
         container: thanos-rule
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-alerting-availability-slo
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
       annotations:
@@ -2158,10 +2158,10 @@ spec:
       for: 3h
       labels:
         container: thanos-rule
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-alerting-availability-slo
   - interval: 30s
     name: api-alerting-availability-slo-generic
@@ -2274,11 +2274,11 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -2291,11 +2291,11 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -2308,11 +2308,11 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-alerting-notif-availability-slo
     - alert: APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       annotations:
@@ -2325,11 +2325,11 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
         service: observatorium-alertmanager
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-alerting-notif-availability-slo
   - interval: 30s
     name: api-alerting-notif-availability-slo-generic
@@ -2485,9 +2485,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 1h
+        long_burnrate_window: 1h
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -2503,9 +2503,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 6h
+        long_burnrate_window: 6h
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -2521,9 +2521,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 1d
+        long_burnrate_window: 1d
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
       annotations:
@@ -2539,9 +2539,9 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        long: 4d
+        long_burnrate_window: 4d
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
   - interval: 30s
     name: api-metrics-write-latency-slo-generic
@@ -2683,11 +2683,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2700,11 +2700,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2717,11 +2717,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
       annotations:
@@ -2734,11 +2734,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-read-1M-latency-slo-generic
@@ -2880,11 +2880,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2897,11 +2897,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2914,11 +2914,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
       annotations:
@@ -2931,11 +2931,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-read-10M-latency-slo-generic
@@ -3077,11 +3077,11 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        long: 1h
+        long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         severity: high
-        short: 5m
+        short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -3094,11 +3094,11 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        long: 6h
+        long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         severity: high
-        short: 30m
+        short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -3111,11 +3111,11 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        long: 1d
+        long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         severity: warning
-        short: 2h
+        short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
       annotations:
@@ -3128,11 +3128,11 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        long: 4d
+        long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         severity: warning
-        short: 6h
+        short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-read-100M-latency-slo-generic


### PR DESCRIPTION
This PR makes the slo alert `long` and `short` labels more descriptive by adding `_burnrate_window` prefix.