### PR TITLE
Add service labels to SLO rules and prune labels

### DIFF
--- a/configuration/observatorium/slo.go
+++ b/configuration/observatorium/slo.go
@@ -665,9 +665,17 @@ func makePrometheusRule(envName rhobsInstanceEnv, objs []pyrrav1alpha1.ServiceLe
 		grp = append(grp, generic)
 	}
 
-	// Make long/short labels more descriptive.
+	// AppSRE customizations.
 	for i := range grp {
 		for j := range grp[i].Rules {
+			// Prune certain alert labels.
+			if grp[i].Rules[j].Alert != "" {
+				delete(grp[i].Rules[j].Labels, "le")
+				delete(grp[i].Rules[j].Labels, "client")
+				delete(grp[i].Rules[j].Labels, "container")
+			}
+
+			// Make long/short labels more descriptive.
 			if v, ok := grp[i].Rules[j].Labels["long"]; ok {
 				grp[i].Rules[j].Labels["long_burnrate_window"] = v
 				delete(grp[i].Rules[j].Labels, "long")

--- a/configuration/observatorium/slo.go
+++ b/configuration/observatorium/slo.go
@@ -235,8 +235,8 @@ func TelemeterSLOs(envName rhobsInstanceEnv) []pyrrav1alpha1.ServiceLevelObjecti
 		{
 			name: "rhobs-telemeter-server-metrics-upload-availability-slo",
 			labels: map[string]string{
-				"route":   "telemeter-server-upload",
-				"service": "telemeter",
+				"route":                                 "telemeter-server-upload",
+				slo.PropagationLabelsPrefix + "service": "telemeter",
 			},
 			description:         "Telemeter Server /upload is burning too much error budget to guarantee availability SLOs.",
 			successOrErrorsExpr: "haproxy_server_http_responses_total{route=\"telemeter-server-upload\", code=~\"5..\"}",
@@ -247,8 +247,8 @@ func TelemeterSLOs(envName rhobsInstanceEnv) []pyrrav1alpha1.ServiceLevelObjecti
 		{
 			name: "rhobs-telemeter-server-metrics-receive-availability-slo",
 			labels: map[string]string{
-				"route":   "telemeter-server-receive",
-				"service": "telemeter",
+				"route":                                 "telemeter-server-receive",
+				slo.PropagationLabelsPrefix + "service": "telemeter",
 			},
 			description:         "Telemeter Server /receive is burning too much error budget to guarantee availability SLOs.",
 			successOrErrorsExpr: "haproxy_server_http_responses_total{route=\"telemeter-server-metrics-v1-receive\", code=~\"5..\"}",
@@ -261,8 +261,8 @@ func TelemeterSLOs(envName rhobsInstanceEnv) []pyrrav1alpha1.ServiceLevelObjecti
 		{
 			name: "rhobs-telemeter-server-metrics-upload-latency-slo",
 			labels: map[string]string{
-				"route":   "telemeter-server-upload",
-				"service": "telemeter",
+				"route":                                 "telemeter-server-upload",
+				slo.PropagationLabelsPrefix + "service": "telemeter",
 			},
 			description:         "Telemeter Server /upload is burning too much error budget to guarantee latency SLOs.",
 			successOrErrorsExpr: "http_request_duration_seconds_bucket{job=\"telemeter-server\", handler=\"upload\", code=~\"^2..$\", le=\"" + genericSLOLatencySeconds + "\"}",
@@ -273,8 +273,8 @@ func TelemeterSLOs(envName rhobsInstanceEnv) []pyrrav1alpha1.ServiceLevelObjecti
 		{
 			name: "rhobs-telemeter-server-metrics-receive-latency-slo",
 			labels: map[string]string{
-				"route":   "telemeter-server-receive",
-				"service": "telemeter",
+				"route":                                 "telemeter-server-receive",
+				slo.PropagationLabelsPrefix + "service": "telemeter",
 			},
 			description:         "Telemeter Server /receive is burning too much error budget to guarantee latency SLOs.",
 			successOrErrorsExpr: "http_request_duration_seconds_bucket{job=\"telemeter-server\", handler=\"receive\", code=~\"^2..$\", le=\"" + genericSLOLatencySeconds + "\"}",
@@ -300,8 +300,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-write-availability-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-receive",
+					"instance":                              string(envName),
 				},
 				description:         "API /receive handler is burning too much error budget to guarantee availability SLOs.",
 				successOrErrorsExpr: "http_requests_total{job=\"" + apiJobSelector[envName] + "\", handler=\"receive\", group=\"metricsv1\", code=~\"^5..$\"}",
@@ -312,8 +312,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-query-availability-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-query",
+					"instance":                              string(envName),
 				},
 				description:         "API /query handler is burning too much error budget to guarantee availability SLOs.",
 				successOrErrorsExpr: "http_requests_total{job=\"" + apiJobSelector[envName] + "\", handler=\"query\", group=\"metricsv1\", code=~\"^5..$\"}",
@@ -324,8 +324,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-query-range-availability-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-query",
+					"instance":                              string(envName),
 				},
 				description:         "API /query_range handler is burning too much error budget to guarantee availability SLOs.",
 				successOrErrorsExpr: "http_requests_total{job=\"" + apiJobSelector[envName] + "\", handler=\"query_range\", group=\"metricsv1\", code=~\"^5..$\"}",
@@ -336,8 +336,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-rules-raw-write-availability-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
+					"instance":                              string(envName),
 				},
 				description:         "API /rules/raw endpoint for writes is burning too much error budget to guarantee availability SLOs.",
 				successOrErrorsExpr: "http_requests_total{job=\"" + apiJobSelector[envName] + "\", handler=\"rules-raw\", method=\"PUT\", group=\"metricsv1\", code=~\"^5..$\"}",
@@ -348,8 +348,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-rules-raw-read-availability-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
+					"instance":                              string(envName),
 				},
 				description:         "API /rules/raw endpoint for reads is burning too much error budget to guarantee availability SLOs.",
 				successOrErrorsExpr: "http_requests_total{job=\"" + apiJobSelector[envName] + "\", handler=\"rules-raw\", method=\"GET\", group=\"metricsv1\", code=~\"^5..$\"}",
@@ -360,8 +360,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-rules-read-availability-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-ruler",
+					"instance":                              string(envName),
 				},
 				description:         "API /rules endpoint is burning too much error budget to guarantee availability SLOs.",
 				successOrErrorsExpr: "http_requests_total{job=\"" + apiJobSelector[envName] + "\", handler=\"rules\", method=\"GET\", group=\"metricsv1\", code=~\"^5..$\"}",
@@ -372,8 +372,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-rules-sync-availability-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-ruler",
+					"instance":                              string(envName),
 				},
 				description:         "Thanos Ruler /reload endpoint is burning too much error budget to guarantee availability SLOs.",
 				successOrErrorsExpr: "client_api_requests_total{client=\"reload\", container=\"thanos-rule-syncer\", namespace=\"" + metricsNS[envName] + "\", code=~\"^5..$\"}",
@@ -384,8 +384,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-alerting-availability-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-ruler",
+					"instance":                              string(envName),
 				},
 				description:         "API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs.",
 				successOrErrorsExpr: "thanos_alert_sender_alerts_dropped_total{container=\"thanos-rule\", namespace=\"" + metricsNS[envName] + "\", code=~\"^5..$\"}",
@@ -410,8 +410,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-write-latency-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-receive",
+					"instance":                              string(envName),
 				},
 				description:         "API /receive handler is burning too much error budget to guarantee latency SLOs.",
 				successOrErrorsExpr: "http_request_duration_seconds_bucket{job=\"" + apiJobSelector[envName] + "\", handler=\"receive\", group=\"metricsv1\", code=~\"^2..$\", le=\"" + genericSLOLatencySeconds + "\"}",
@@ -422,8 +422,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-read-1M-latency-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-query",
+					"instance":                              string(envName),
 				},
 				description:         "API /query endpoint is burning too much error budget for 1M samples, to guarantee latency SLOs.",
 				successOrErrorsExpr: "up_custom_query_duration_seconds_bucket{query=\"query-path-sli-1M-samples\", namespace=\"" + upNS[envName] + "\", code=~\"^2..$\", le=\"10\"}",
@@ -434,8 +434,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-read-10M-latency-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-query",
+					"instance":                              string(envName),
 				},
 				description:         "API /query endpoint is burning too much error budget for 100M samples, to guarantee latency SLOs.",
 				successOrErrorsExpr: "up_custom_query_duration_seconds_bucket{query=\"query-path-sli-10M-samples\", namespace=\"" + upNS[envName] + "\", code=~\"^2..$\", le=\"30\"}",
@@ -446,8 +446,8 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-read-100M-latency-slo",
 				labels: map[string]string{
-					"service":  "observatorium-api",
-					"instance": string(envName),
+					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-query",
+					"instance":                              string(envName),
 				},
 				description:         "API /query endpoint is burning too much error budget for 100M samples, to guarantee latency SLOs.",
 				successOrErrorsExpr: "up_custom_query_duration_seconds_bucket{query=\"query-path-sli-1M-samples\", namespace=\"" + upNS[envName] + "\", code=~\"^2..$\", le=\"120\"}",

--- a/configuration/observatorium/slo.go
+++ b/configuration/observatorium/slo.go
@@ -300,7 +300,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-write-availability-slo",
 				labels: map[string]string{
-					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-receive",
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
 				description:         "API /receive handler is burning too much error budget to guarantee availability SLOs.",
@@ -312,7 +312,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-query-availability-slo",
 				labels: map[string]string{
-					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-query",
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
 				description:         "API /query handler is burning too much error budget to guarantee availability SLOs.",
@@ -324,7 +324,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-query-range-availability-slo",
 				labels: map[string]string{
-					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-query",
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
 				description:         "API /query_range handler is burning too much error budget to guarantee availability SLOs.",
@@ -360,7 +360,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-rules-read-availability-slo",
 				labels: map[string]string{
-					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-ruler",
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
 				description:         "API /rules endpoint is burning too much error budget to guarantee availability SLOs.",
@@ -372,7 +372,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-rules-sync-availability-slo",
 				labels: map[string]string{
-					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-ruler",
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
 				description:         "Thanos Ruler /reload endpoint is burning too much error budget to guarantee availability SLOs.",
@@ -384,7 +384,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-alerting-availability-slo",
 				labels: map[string]string{
-					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-ruler",
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
 				description:         "API Thanos Rule failing to send alerts to Alertmanager and is burning too much error budget to guarantee availability SLOs.",
@@ -410,7 +410,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-write-latency-slo",
 				labels: map[string]string{
-					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-receive",
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
 				description:         "API /receive handler is burning too much error budget to guarantee latency SLOs.",
@@ -422,7 +422,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-read-1M-latency-slo",
 				labels: map[string]string{
-					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-query",
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
 				description:         "API /query endpoint is burning too much error budget for 1M samples, to guarantee latency SLOs.",
@@ -434,7 +434,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-read-10M-latency-slo",
 				labels: map[string]string{
-					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-query",
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
 				description:         "API /query endpoint is burning too much error budget for 100M samples, to guarantee latency SLOs.",
@@ -446,7 +446,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 			{
 				name: "api-metrics-read-100M-latency-slo",
 				labels: map[string]string{
-					slo.PropagationLabelsPrefix + "service": "observatorium-thanos-query",
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
 				description:         "API /query endpoint is burning too much error budget for 100M samples, to guarantee latency SLOs.",
@@ -668,11 +668,16 @@ func makePrometheusRule(envName rhobsInstanceEnv, objs []pyrrav1alpha1.ServiceLe
 	// AppSRE customizations.
 	for i := range grp {
 		for j := range grp[i].Rules {
-			// Prune certain alert labels.
 			if grp[i].Rules[j].Alert != "" {
+				// Prune certain alert labels.
 				delete(grp[i].Rules[j].Labels, "le")
 				delete(grp[i].Rules[j].Labels, "client")
 				delete(grp[i].Rules[j].Labels, "container")
+
+				// Hack for AM alert labels.
+				if v, ok := grp[i].Rules[j].Labels["service"]; ok && v == "observatorium-alertmanager" {
+					grp[i].Rules[j].Labels["service"] = "observatorium-api"
+				}
 			}
 
 			// Make long/short labels more descriptive.

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-alerting-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-alerting-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-alerting-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-alerting-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-query-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-query-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-range-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-query-range-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-range-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-query-range-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-100M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-100M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-100M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-100M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-10M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-10M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-10M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-10M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-1M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-1M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-read-1M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-1M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-receive
   name: api-metrics-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    pyrra.dev/service: observatorium-thanos-receive
+    pyrra.dev/service: observatorium-api
   name: api-metrics-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-write-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-write-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-receive
   name: api-metrics-write-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-write-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-write-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    pyrra.dev/service: observatorium-thanos-receive
+    pyrra.dev/service: observatorium-api
   name: api-metrics-write-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-rules-raw-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-rules-raw-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-api
   name: api-rules-raw-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-rules-raw-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-rules-raw-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-api
   name: api-rules-raw-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-rules-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-rules-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-rules-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-rules-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-rules-sync-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-rules-sync-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-rules-sync-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-rules-sync-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-alerting-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-alerting-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-alerting-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-alerting-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-query-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-query-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-range-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-query-range-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-range-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-query-range-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-100M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-100M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-100M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-100M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-10M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-10M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-10M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-10M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-1M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-1M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-read-1M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-1M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    pyrra.dev/service: observatorium-thanos-receive
+    pyrra.dev/service: observatorium-api
   name: api-metrics-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-receive
   name: api-metrics-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-write-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-write-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-receive
   name: api-metrics-write-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-write-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-write-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    pyrra.dev/service: observatorium-thanos-receive
+    pyrra.dev/service: observatorium-api
   name: api-metrics-write-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-raw-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-raw-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-api
   name: api-rules-raw-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-raw-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-raw-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-api
   name: api-rules-raw-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-rules-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-rules-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-sync-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-rules-sync-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-sync-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: mst-stage
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-rules-sync-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-alerting-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-alerting-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-alerting-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-alerting-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-query-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-query-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-range-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-query-range-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-range-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-query-range-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-100M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-100M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-100M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-100M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-10M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-10M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-10M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-10M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-1M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-1M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-read-1M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-1M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-receive
   name: api-metrics-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    pyrra.dev/service: observatorium-thanos-receive
+    pyrra.dev/service: observatorium-api
   name: api-metrics-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-write-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-write-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    pyrra.dev/service: observatorium-thanos-receive
+    pyrra.dev/service: observatorium-api
   name: api-metrics-write-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-write-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-write-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-receive
   name: api-metrics-write-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-raw-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-raw-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-api
   name: api-rules-raw-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-raw-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-raw-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-api
   name: api-rules-raw-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-rules-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-rules-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-sync-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-rules-sync-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-sync-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: rhobsp02ue1-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-rules-sync-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-alerting-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-alerting-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-alerting-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-alerting-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-query-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-query-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-range-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-query-range-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-range-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-query-range-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-100M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-100M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-100M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-100M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-10M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-10M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-10M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-10M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-1M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-1M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-read-1M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-1M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    pyrra.dev/service: observatorium-thanos-receive
+    pyrra.dev/service: observatorium-api
   name: api-metrics-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-receive
   name: api-metrics-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-write-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-write-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-receive
   name: api-metrics-write-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-write-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-write-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    pyrra.dev/service: observatorium-thanos-receive
+    pyrra.dev/service: observatorium-api
   name: api-metrics-write-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-raw-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-raw-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-api
   name: api-rules-raw-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-raw-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-raw-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-api
   name: api-rules-raw-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-rules-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-rules-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-sync-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-rules-sync-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-sync-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-production
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-rules-sync-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-receive-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-receive-availability-slo.yaml
@@ -8,8 +8,8 @@ metadata:
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
   creationTimestamp: null
   labels:
+    pyrra.dev/service: telemeter
     route: telemeter-server-receive
-    service: telemeter
   name: rhobs-telemeter-server-metrics-receive-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-receive-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-receive-latency-slo.yaml
@@ -8,8 +8,8 @@ metadata:
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
   creationTimestamp: null
   labels:
+    pyrra.dev/service: telemeter
     route: telemeter-server-receive
-    service: telemeter
   name: rhobs-telemeter-server-metrics-receive-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-upload-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-upload-availability-slo.yaml
@@ -8,8 +8,8 @@ metadata:
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
   creationTimestamp: null
   labels:
+    pyrra.dev/service: telemeter
     route: telemeter-server-upload
-    service: telemeter
   name: rhobs-telemeter-server-metrics-upload-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-upload-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-upload-latency-slo.yaml
@@ -8,8 +8,8 @@ metadata:
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
   creationTimestamp: null
   labels:
+    pyrra.dev/service: telemeter
     route: telemeter-server-upload
-    service: telemeter
   name: rhobs-telemeter-server-metrics-upload-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-alerting-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-alerting-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-alerting-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-alerting-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-query-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-query-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-range-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-query-range-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-range-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-query-range-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-100M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-100M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-100M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-100M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-10M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-10M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-10M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-10M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-1M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-query
   name: api-metrics-read-1M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-read-1M-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    pyrra.dev/service: observatorium-thanos-query
+    pyrra.dev/service: observatorium-api
   name: api-metrics-read-1M-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-receive
   name: api-metrics-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    pyrra.dev/service: observatorium-thanos-receive
+    pyrra.dev/service: observatorium-api
   name: api-metrics-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-write-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-write-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    pyrra.dev/service: observatorium-thanos-receive
+    pyrra.dev/service: observatorium-api
   name: api-metrics-write-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-write-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-write-latency-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-receive
   name: api-metrics-write-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-raw-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-raw-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-api
   name: api-rules-raw-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-raw-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-raw-write-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-api
   name: api-rules-raw-write-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-rules-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-read-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-rules-read-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-sync-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    service: observatorium-api
+    pyrra.dev/service: observatorium-thanos-ruler
   name: api-rules-sync-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-sync-availability-slo.yaml
@@ -9,7 +9,7 @@ metadata:
   creationTimestamp: null
   labels:
     instance: telemeter-staging
-    pyrra.dev/service: observatorium-thanos-ruler
+    pyrra.dev/service: observatorium-api
   name: api-rules-sync-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-receive-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-receive-availability-slo.yaml
@@ -8,8 +8,8 @@ metadata:
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
   creationTimestamp: null
   labels:
+    pyrra.dev/service: telemeter
     route: telemeter-server-receive
-    service: telemeter
   name: rhobs-telemeter-server-metrics-receive-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-receive-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-receive-latency-slo.yaml
@@ -8,8 +8,8 @@ metadata:
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
   creationTimestamp: null
   labels:
+    pyrra.dev/service: telemeter
     route: telemeter-server-receive
-    service: telemeter
   name: rhobs-telemeter-server-metrics-receive-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-upload-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-upload-availability-slo.yaml
@@ -8,8 +8,8 @@ metadata:
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
   creationTimestamp: null
   labels:
+    pyrra.dev/service: telemeter
     route: telemeter-server-upload
-    service: telemeter
   name: rhobs-telemeter-server-metrics-upload-availability-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-upload-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-upload-latency-slo.yaml
@@ -8,8 +8,8 @@ metadata:
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
   creationTimestamp: null
   labels:
+    pyrra.dev/service: telemeter
     route: telemeter-server-upload
-    service: telemeter
   name: rhobs-telemeter-server-metrics-upload-latency-slo
 spec:
   alerting:

--- a/resources/observability/prometheusrules/rhobs-slos-logs-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-logs-mst-production.prometheusrules.yaml
@@ -948,7 +948,6 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        le: "5"
         severity: critical
         slo: api-logs-write-latency-slo
   - interval: 30s

--- a/resources/observability/prometheusrules/rhobs-slos-logs-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-logs-mst-stage.prometheusrules.yaml
@@ -948,7 +948,6 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        le: "5"
         severity: high
         slo: api-logs-write-latency-slo
   - interval: 30s

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -18,6 +18,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -33,6 +34,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-availability-slo
   - interval: 30s
@@ -44,6 +46,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -52,6 +55,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -60,6 +64,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -68,6 +73,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -76,6 +82,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -84,6 +91,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -92,6 +100,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
@@ -109,6 +118,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
@@ -127,6 +137,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
@@ -145,6 +156,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
@@ -163,6 +175,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
@@ -199,6 +212,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -214,6 +228,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-query-availability-slo
   - interval: 30s
@@ -225,6 +240,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[30m]))
@@ -233,6 +249,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1h]))
@@ -241,6 +258,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[2h]))
@@ -249,6 +267,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[6h]))
@@ -257,6 +276,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1d]))
@@ -265,6 +285,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[4d]))
@@ -273,6 +294,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
@@ -290,6 +312,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
@@ -308,6 +331,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
@@ -326,6 +350,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
@@ -344,6 +369,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
@@ -380,6 +406,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -395,6 +422,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
@@ -406,6 +434,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[30m]))
@@ -414,6 +443,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1h]))
@@ -422,6 +452,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[2h]))
@@ -430,6 +461,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[6h]))
@@ -438,6 +470,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1d]))
@@ -446,6 +479,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[4d]))
@@ -454,6 +488,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
@@ -471,6 +506,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
@@ -489,6 +525,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
@@ -507,6 +544,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
@@ -525,6 +563,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
@@ -562,6 +601,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -578,6 +618,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         severity: critical
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
@@ -590,6 +631,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[30m]))
@@ -599,6 +641,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[1h]))
@@ -608,6 +651,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[2h]))
@@ -617,6 +661,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[6h]))
@@ -626,6 +671,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[1d]))
@@ -635,6 +681,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[4d]))
@@ -644,6 +691,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
@@ -662,6 +710,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: PUT
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-raw-write-availability-slo
@@ -681,6 +730,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: PUT
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-raw-write-availability-slo
@@ -700,6 +750,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: PUT
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-raw-write-availability-slo
@@ -719,6 +770,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: PUT
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-raw-write-availability-slo
@@ -756,6 +808,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -772,6 +825,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         severity: critical
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
@@ -784,6 +838,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[30m]))
@@ -793,6 +848,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[1h]))
@@ -802,6 +858,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[2h]))
@@ -811,6 +868,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[6h]))
@@ -820,6 +878,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[1d]))
@@ -829,6 +888,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[4d]))
@@ -838,6 +898,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
@@ -856,6 +917,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: GET
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-raw-read-availability-slo
@@ -875,6 +937,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: GET
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-raw-read-availability-slo
@@ -894,6 +957,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: GET
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-raw-read-availability-slo
@@ -913,6 +977,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: GET
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-raw-read-availability-slo
@@ -950,6 +1015,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -966,6 +1032,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         severity: critical
         slo: api-rules-read-availability-slo
   - interval: 30s
@@ -978,6 +1045,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[30m]))
@@ -987,6 +1055,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1h]))
@@ -996,6 +1065,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[2h]))
@@ -1005,6 +1075,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[6h]))
@@ -1014,6 +1085,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1d]))
@@ -1023,6 +1095,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[4d]))
@@ -1032,6 +1105,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
@@ -1050,6 +1124,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: GET
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
@@ -1069,6 +1144,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: GET
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
@@ -1088,6 +1164,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: GET
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
@@ -1107,6 +1184,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: GET
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
@@ -1143,6 +1221,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1158,6 +1237,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         slo: api-rules-sync-availability-slo
   - interval: 30s
@@ -1169,6 +1249,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate5m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[30m]))
@@ -1177,6 +1258,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate30m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1h]))
@@ -1185,6 +1267,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[2h]))
@@ -1193,6 +1276,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate2h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[6h]))
@@ -1201,6 +1285,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate6h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1d]))
@@ -1209,6 +1294,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1d
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[4d]))
@@ -1217,6 +1303,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate4d
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1234,6 +1321,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
@@ -1252,6 +1340,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
@@ -1270,6 +1359,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
@@ -1288,6 +1378,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
@@ -1323,6 +1414,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:increase4w
     - alert: SLOMetricAbsent
@@ -1337,6 +1429,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         slo: api-alerting-availability-slo
   - interval: 30s
@@ -1347,6 +1440,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate5m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[30m]))
@@ -1354,6 +1448,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate30m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[1h]))
@@ -1361,6 +1456,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[2h]))
@@ -1368,6 +1464,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate2h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[6h]))
@@ -1375,6 +1472,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate6h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[1d]))
@@ -1382,6 +1480,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1d
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[4d]))
@@ -1389,6 +1488,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate4d
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1405,6 +1505,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 5m
         slo: api-alerting-availability-slo
@@ -1422,6 +1523,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 30m
         slo: api-alerting-availability-slo
@@ -1439,6 +1541,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-availability-slo
@@ -1456,6 +1559,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-availability-slo
@@ -1660,6 +1764,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",le="5"}[4w]))
@@ -1668,6 +1773,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         le: "5"
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1683,6 +1789,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
@@ -1699,6 +1806,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         le: "5"
+        service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-latency-slo
   - interval: 30s
@@ -1711,6 +1819,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -1720,6 +1829,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -1729,6 +1839,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -1738,6 +1849,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -1747,6 +1859,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -1756,6 +1869,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -1765,6 +1879,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
@@ -1782,6 +1897,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
@@ -1800,6 +1916,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
@@ -1818,6 +1935,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
@@ -1836,6 +1954,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
@@ -1871,6 +1990,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="10",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4w]))
@@ -1878,6 +1998,7 @@ spec:
         le: "10"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1892,6 +2013,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
@@ -1907,6 +2029,7 @@ spec:
         le: "10"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
@@ -1918,6 +2041,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[30m]))
@@ -1926,6 +2050,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1h]))
@@ -1934,6 +2059,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[2h]))
@@ -1942,6 +2068,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[6h]))
@@ -1950,6 +2077,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1d]))
@@ -1958,6 +2086,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4d]))
@@ -1966,6 +2095,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
@@ -1982,6 +2112,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
@@ -1999,6 +2130,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
@@ -2016,6 +2148,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
@@ -2033,6 +2166,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
@@ -2068,6 +2202,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="30",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[4w]))
@@ -2075,6 +2210,7 @@ spec:
         le: "30"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2089,6 +2225,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
@@ -2104,6 +2241,7 @@ spec:
         le: "30"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
@@ -2115,6 +2253,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[30m]))
@@ -2123,6 +2262,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[1h]))
@@ -2131,6 +2271,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[2h]))
@@ -2139,6 +2280,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[6h]))
@@ -2147,6 +2289,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[1d]))
@@ -2155,6 +2298,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[4d]))
@@ -2163,6 +2307,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
@@ -2179,6 +2324,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
@@ -2196,6 +2342,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
@@ -2213,6 +2360,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
@@ -2230,6 +2378,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
@@ -2265,6 +2414,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="120",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4w]))
@@ -2272,6 +2422,7 @@ spec:
         le: "120"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2286,6 +2437,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
@@ -2301,6 +2453,7 @@ spec:
         le: "120"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
@@ -2312,6 +2465,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[30m]))
@@ -2320,6 +2474,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1h]))
@@ -2328,6 +2483,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[2h]))
@@ -2336,6 +2492,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[6h]))
@@ -2344,6 +2501,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1d]))
@@ -2352,6 +2510,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4d]))
@@ -2360,6 +2519,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
@@ -2376,6 +2536,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
@@ -2393,6 +2554,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
@@ -2410,6 +2572,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
@@ -2427,6 +2590,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -18,7 +18,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -34,7 +34,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         slo: api-metrics-write-availability-slo
   - interval: 30s
@@ -46,7 +46,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -55,7 +55,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -64,7 +64,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -73,7 +73,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -82,7 +82,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -91,7 +91,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -100,7 +100,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
@@ -118,7 +118,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
@@ -137,7 +137,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
@@ -156,7 +156,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
@@ -175,7 +175,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
@@ -212,7 +212,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -228,7 +228,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-query-availability-slo
   - interval: 30s
@@ -240,7 +240,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[30m]))
@@ -249,7 +249,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1h]))
@@ -258,7 +258,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[2h]))
@@ -267,7 +267,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[6h]))
@@ -276,7 +276,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1d]))
@@ -285,7 +285,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[4d]))
@@ -294,7 +294,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
@@ -312,7 +312,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
@@ -331,7 +331,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
@@ -350,7 +350,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
@@ -369,7 +369,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
@@ -406,7 +406,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -422,7 +422,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
@@ -434,7 +434,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[30m]))
@@ -443,7 +443,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1h]))
@@ -452,7 +452,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[2h]))
@@ -461,7 +461,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[6h]))
@@ -470,7 +470,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1d]))
@@ -479,7 +479,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[4d]))
@@ -488,7 +488,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
@@ -506,7 +506,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
@@ -525,7 +525,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
@@ -544,7 +544,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
@@ -563,7 +563,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
@@ -1015,7 +1015,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1032,7 +1032,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         slo: api-rules-read-availability-slo
   - interval: 30s
@@ -1045,7 +1045,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[30m]))
@@ -1055,7 +1055,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1h]))
@@ -1065,7 +1065,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[2h]))
@@ -1075,7 +1075,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[6h]))
@@ -1085,7 +1085,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1d]))
@@ -1095,7 +1095,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[4d]))
@@ -1105,7 +1105,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
@@ -1124,7 +1124,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
@@ -1144,7 +1144,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
@@ -1164,7 +1164,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
@@ -1184,7 +1184,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
@@ -1221,7 +1221,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1235,7 +1235,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         slo: api-rules-sync-availability-slo
   - interval: 30s
@@ -1247,7 +1247,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate5m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[30m]))
@@ -1256,7 +1256,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate30m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1h]))
@@ -1265,7 +1265,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[2h]))
@@ -1274,7 +1274,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate2h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[6h]))
@@ -1283,7 +1283,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate6h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1d]))
@@ -1292,7 +1292,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1d
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[4d]))
@@ -1301,7 +1301,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate4d
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1317,7 +1317,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
@@ -1334,7 +1334,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
@@ -1351,7 +1351,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
@@ -1368,7 +1368,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
@@ -1404,7 +1404,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:increase4w
     - alert: SLOMetricAbsent
@@ -1418,7 +1418,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         slo: api-alerting-availability-slo
   - interval: 30s
@@ -1429,7 +1429,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate5m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[30m]))
@@ -1437,7 +1437,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate30m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[1h]))
@@ -1445,7 +1445,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[2h]))
@@ -1453,7 +1453,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate2h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[6h]))
@@ -1461,7 +1461,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate6h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[1d]))
@@ -1469,7 +1469,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1d
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[4d]))
@@ -1477,7 +1477,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate4d
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1493,7 +1493,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-alerting-availability-slo
@@ -1510,7 +1510,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-alerting-availability-slo
@@ -1527,7 +1527,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-availability-slo
@@ -1544,7 +1544,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-availability-slo
@@ -1593,7 +1593,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-mst-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: critical
         slo: api-alerting-notif-availability-slo
   - interval: 30s
@@ -1661,7 +1661,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-alerting-notif-availability-slo
@@ -1678,7 +1678,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-alerting-notif-availability-slo
@@ -1695,7 +1695,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-notif-availability-slo
@@ -1712,7 +1712,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-notif-availability-slo
@@ -1749,7 +1749,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",le="5"}[4w]))
@@ -1758,7 +1758,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         le: "5"
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1774,7 +1774,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
@@ -1790,7 +1790,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         slo: api-metrics-write-latency-slo
   - interval: 30s
@@ -1803,7 +1803,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -1813,7 +1813,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -1823,7 +1823,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -1833,7 +1833,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -1843,7 +1843,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -1853,7 +1853,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -1863,7 +1863,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
@@ -1881,7 +1881,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
@@ -1900,7 +1900,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
@@ -1919,7 +1919,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
@@ -1938,7 +1938,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
@@ -1974,7 +1974,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="10",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4w]))
@@ -1982,7 +1982,7 @@ spec:
         le: "10"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1997,7 +1997,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
@@ -2012,7 +2012,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
@@ -2024,7 +2024,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[30m]))
@@ -2033,7 +2033,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1h]))
@@ -2042,7 +2042,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[2h]))
@@ -2051,7 +2051,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[6h]))
@@ -2060,7 +2060,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1d]))
@@ -2069,7 +2069,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4d]))
@@ -2078,7 +2078,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
@@ -2095,7 +2095,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
@@ -2113,7 +2113,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
@@ -2131,7 +2131,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
@@ -2149,7 +2149,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
@@ -2185,7 +2185,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="30",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[4w]))
@@ -2193,7 +2193,7 @@ spec:
         le: "30"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2208,7 +2208,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
@@ -2223,7 +2223,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
@@ -2235,7 +2235,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[30m]))
@@ -2244,7 +2244,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[1h]))
@@ -2253,7 +2253,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[2h]))
@@ -2262,7 +2262,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[6h]))
@@ -2271,7 +2271,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[1d]))
@@ -2280,7 +2280,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[4d]))
@@ -2289,7 +2289,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
@@ -2306,7 +2306,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
@@ -2324,7 +2324,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
@@ -2342,7 +2342,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
@@ -2360,7 +2360,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
@@ -2396,7 +2396,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="120",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4w]))
@@ -2404,7 +2404,7 @@ spec:
         le: "120"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2419,7 +2419,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
@@ -2434,7 +2434,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
@@ -2446,7 +2446,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[30m]))
@@ -2455,7 +2455,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1h]))
@@ -2464,7 +2464,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[2h]))
@@ -2473,7 +2473,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[6h]))
@@ -2482,7 +2482,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1d]))
@@ -2491,7 +2491,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4d]))
@@ -2500,7 +2500,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
@@ -2517,7 +2517,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
@@ -2535,7 +2535,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
@@ -2553,7 +2553,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
@@ -2571,7 +2571,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -1234,8 +1234,6 @@ spec:
         == 1
       for: 2m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
         severity: critical
@@ -1317,8 +1315,6 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1336,8 +1332,6 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1355,8 +1349,6 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1374,8 +1366,6 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1427,7 +1417,6 @@ spec:
         == 1
       for: 2m
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
         severity: critical
@@ -1502,7 +1491,6 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        container: thanos-rule
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1520,7 +1508,6 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        container: thanos-rule
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1538,7 +1525,6 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        container: thanos-rule
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1556,7 +1542,6 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        container: thanos-rule
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1805,7 +1790,6 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        le: "5"
         service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-latency-slo
@@ -2026,7 +2010,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "10"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-thanos-query
@@ -2238,7 +2221,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "30"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         service: observatorium-thanos-query
@@ -2450,7 +2432,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "120"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-thanos-query

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -1234,8 +1234,6 @@ spec:
         == 1
       for: 2m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         namespace: observatorium-mst-stage
         service: observatorium-thanos-ruler
         severity: high
@@ -1317,8 +1315,6 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         service: observatorium-thanos-ruler
@@ -1336,8 +1332,6 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         service: observatorium-thanos-ruler
@@ -1355,8 +1349,6 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         service: observatorium-thanos-ruler
@@ -1374,8 +1366,6 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         service: observatorium-thanos-ruler
@@ -1427,7 +1417,6 @@ spec:
         == 1
       for: 2m
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-stage
         service: observatorium-thanos-ruler
         severity: high
@@ -1502,7 +1491,6 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        container: thanos-rule
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         service: observatorium-thanos-ruler
@@ -1520,7 +1508,6 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        container: thanos-rule
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         service: observatorium-thanos-ruler
@@ -1538,7 +1525,6 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        container: thanos-rule
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         service: observatorium-thanos-ruler
@@ -1556,7 +1542,6 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        container: thanos-rule
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         service: observatorium-thanos-ruler
@@ -1805,7 +1790,6 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        le: "5"
         service: observatorium-thanos-receive
         severity: high
         slo: api-metrics-write-latency-slo
@@ -2026,7 +2010,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "10"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         service: observatorium-thanos-query
@@ -2238,7 +2221,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "30"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
         service: observatorium-thanos-query
@@ -2450,7 +2432,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "120"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         service: observatorium-thanos-query

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -18,6 +18,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -33,6 +34,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         severity: high
         slo: api-metrics-write-availability-slo
   - interval: 30s
@@ -44,6 +46,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -52,6 +55,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -60,6 +64,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -68,6 +73,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -76,6 +82,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -84,6 +91,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -92,6 +100,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
@@ -109,6 +118,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-receive
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
@@ -127,6 +137,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-receive
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
@@ -145,6 +156,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
@@ -163,6 +175,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
@@ -199,6 +212,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -214,6 +228,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-query-availability-slo
   - interval: 30s
@@ -225,6 +240,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[30m]))
@@ -233,6 +249,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1h]))
@@ -241,6 +258,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[2h]))
@@ -249,6 +267,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[6h]))
@@ -257,6 +276,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1d]))
@@ -265,6 +285,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[4d]))
@@ -273,6 +294,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
@@ -290,6 +312,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
@@ -308,6 +331,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
@@ -326,6 +350,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
@@ -344,6 +369,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
@@ -380,6 +406,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -395,6 +422,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
@@ -406,6 +434,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[30m]))
@@ -414,6 +443,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1h]))
@@ -422,6 +452,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[2h]))
@@ -430,6 +461,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[6h]))
@@ -438,6 +470,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1d]))
@@ -446,6 +479,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[4d]))
@@ -454,6 +488,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
@@ -471,6 +506,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
@@ -489,6 +525,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
@@ -507,6 +544,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
@@ -525,6 +563,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
@@ -562,6 +601,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -578,6 +618,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         severity: high
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
@@ -590,6 +631,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[30m]))
@@ -599,6 +641,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[1h]))
@@ -608,6 +651,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[2h]))
@@ -617,6 +661,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[6h]))
@@ -626,6 +671,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[1d]))
@@ -635,6 +681,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[4d]))
@@ -644,6 +691,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
@@ -662,6 +710,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: PUT
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-raw-write-availability-slo
@@ -681,6 +730,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: PUT
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-raw-write-availability-slo
@@ -700,6 +750,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: PUT
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-raw-write-availability-slo
@@ -719,6 +770,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: PUT
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-raw-write-availability-slo
@@ -756,6 +808,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -772,6 +825,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         severity: high
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
@@ -784,6 +838,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[30m]))
@@ -793,6 +848,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[1h]))
@@ -802,6 +858,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[2h]))
@@ -811,6 +868,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[6h]))
@@ -820,6 +878,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[1d]))
@@ -829,6 +888,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[4d]))
@@ -838,6 +898,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
@@ -856,6 +917,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: GET
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-raw-read-availability-slo
@@ -875,6 +937,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: GET
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-raw-read-availability-slo
@@ -894,6 +957,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: GET
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-raw-read-availability-slo
@@ -913,6 +977,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: GET
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-raw-read-availability-slo
@@ -950,6 +1015,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -966,6 +1032,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         severity: high
         slo: api-rules-read-availability-slo
   - interval: 30s
@@ -978,6 +1045,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[30m]))
@@ -987,6 +1055,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1h]))
@@ -996,6 +1065,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[2h]))
@@ -1005,6 +1075,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[6h]))
@@ -1014,6 +1085,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1d]))
@@ -1023,6 +1095,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[4d]))
@@ -1032,6 +1105,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
@@ -1050,6 +1124,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: GET
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
@@ -1069,6 +1144,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: GET
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
@@ -1088,6 +1164,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: GET
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
@@ -1107,6 +1184,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: GET
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
@@ -1143,6 +1221,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1158,6 +1237,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         severity: high
         slo: api-rules-sync-availability-slo
   - interval: 30s
@@ -1169,6 +1249,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate5m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[30m]))
@@ -1177,6 +1258,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate30m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[1h]))
@@ -1185,6 +1267,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[2h]))
@@ -1193,6 +1276,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate2h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[6h]))
@@ -1201,6 +1285,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate6h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[1d]))
@@ -1209,6 +1294,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1d
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[4d]))
@@ -1217,6 +1303,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate4d
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1234,6 +1321,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
@@ -1252,6 +1340,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
@@ -1270,6 +1359,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
@@ -1288,6 +1378,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
@@ -1323,6 +1414,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:increase4w
     - alert: SLOMetricAbsent
@@ -1337,6 +1429,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         severity: high
         slo: api-alerting-availability-slo
   - interval: 30s
@@ -1347,6 +1440,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate5m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[30m]))
@@ -1354,6 +1448,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate30m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[1h]))
@@ -1361,6 +1456,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[2h]))
@@ -1368,6 +1464,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate2h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[6h]))
@@ -1375,6 +1472,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate6h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[1d]))
@@ -1382,6 +1480,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1d
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[4d]))
@@ -1389,6 +1488,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate4d
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1405,6 +1505,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 5m
         slo: api-alerting-availability-slo
@@ -1422,6 +1523,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 30m
         slo: api-alerting-availability-slo
@@ -1439,6 +1541,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-availability-slo
@@ -1456,6 +1559,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-availability-slo
@@ -1660,6 +1764,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",le="5"}[4w]))
@@ -1668,6 +1773,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         le: "5"
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1683,6 +1789,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         severity: high
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
@@ -1699,6 +1806,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         le: "5"
+        service: observatorium-thanos-receive
         severity: high
         slo: api-metrics-write-latency-slo
   - interval: 30s
@@ -1711,6 +1819,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -1720,6 +1829,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -1729,6 +1839,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -1738,6 +1849,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -1747,6 +1859,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -1756,6 +1869,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -1765,6 +1879,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
@@ -1782,6 +1897,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-receive
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
@@ -1800,6 +1916,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-receive
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
@@ -1818,6 +1935,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
@@ -1836,6 +1954,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
@@ -1871,6 +1990,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[4w]))
@@ -1878,6 +1998,7 @@ spec:
         le: "10"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1892,6 +2013,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
@@ -1907,6 +2029,7 @@ spec:
         le: "10"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
@@ -1918,6 +2041,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[30m]))
@@ -1926,6 +2050,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[1h]))
@@ -1934,6 +2059,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[2h]))
@@ -1942,6 +2068,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[6h]))
@@ -1950,6 +2077,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[1d]))
@@ -1958,6 +2086,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[4d]))
@@ -1966,6 +2095,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
@@ -1982,6 +2112,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
@@ -1999,6 +2130,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
@@ -2016,6 +2148,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
@@ -2033,6 +2166,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
@@ -2068,6 +2202,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[4w]))
@@ -2075,6 +2210,7 @@ spec:
         le: "30"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2089,6 +2225,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
@@ -2104,6 +2241,7 @@ spec:
         le: "30"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
@@ -2115,6 +2253,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[30m]))
@@ -2123,6 +2262,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[1h]))
@@ -2131,6 +2271,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[2h]))
@@ -2139,6 +2280,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[6h]))
@@ -2147,6 +2289,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[1d]))
@@ -2155,6 +2298,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[4d]))
@@ -2163,6 +2307,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
@@ -2179,6 +2324,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
@@ -2196,6 +2342,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
@@ -2213,6 +2360,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
@@ -2230,6 +2378,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
@@ -2265,6 +2414,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[4w]))
@@ -2272,6 +2422,7 @@ spec:
         le: "120"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2286,6 +2437,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
@@ -2301,6 +2453,7 @@ spec:
         le: "120"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
@@ -2312,6 +2465,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[30m]))
@@ -2320,6 +2474,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[1h]))
@@ -2328,6 +2483,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[2h]))
@@ -2336,6 +2492,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[6h]))
@@ -2344,6 +2501,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[1d]))
@@ -2352,6 +2510,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[4d]))
@@ -2360,6 +2519,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
@@ -2376,6 +2536,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
@@ -2393,6 +2554,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
@@ -2410,6 +2572,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
@@ -2427,6 +2590,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -18,7 +18,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -34,7 +34,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         slo: api-metrics-write-availability-slo
   - interval: 30s
@@ -46,7 +46,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -55,7 +55,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -64,7 +64,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -73,7 +73,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -82,7 +82,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -91,7 +91,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -100,7 +100,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
@@ -118,7 +118,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
@@ -137,7 +137,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
@@ -156,7 +156,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
@@ -175,7 +175,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
@@ -212,7 +212,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -228,7 +228,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-query-availability-slo
   - interval: 30s
@@ -240,7 +240,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[30m]))
@@ -249,7 +249,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1h]))
@@ -258,7 +258,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[2h]))
@@ -267,7 +267,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[6h]))
@@ -276,7 +276,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1d]))
@@ -285,7 +285,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[4d]))
@@ -294,7 +294,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
@@ -312,7 +312,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
@@ -331,7 +331,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
@@ -350,7 +350,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
@@ -369,7 +369,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
@@ -406,7 +406,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -422,7 +422,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
@@ -434,7 +434,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[30m]))
@@ -443,7 +443,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1h]))
@@ -452,7 +452,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[2h]))
@@ -461,7 +461,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[6h]))
@@ -470,7 +470,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1d]))
@@ -479,7 +479,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[4d]))
@@ -488,7 +488,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
@@ -506,7 +506,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
@@ -525,7 +525,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
@@ -544,7 +544,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
@@ -563,7 +563,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
@@ -1015,7 +1015,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1032,7 +1032,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         slo: api-rules-read-availability-slo
   - interval: 30s
@@ -1045,7 +1045,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[30m]))
@@ -1055,7 +1055,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1h]))
@@ -1065,7 +1065,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[2h]))
@@ -1075,7 +1075,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[6h]))
@@ -1085,7 +1085,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1d]))
@@ -1095,7 +1095,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[4d]))
@@ -1105,7 +1105,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
@@ -1124,7 +1124,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
@@ -1144,7 +1144,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
@@ -1164,7 +1164,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
@@ -1184,7 +1184,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
@@ -1221,7 +1221,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1235,7 +1235,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         slo: api-rules-sync-availability-slo
   - interval: 30s
@@ -1247,7 +1247,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate5m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[30m]))
@@ -1256,7 +1256,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate30m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[1h]))
@@ -1265,7 +1265,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[2h]))
@@ -1274,7 +1274,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate2h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[6h]))
@@ -1283,7 +1283,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate6h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[1d]))
@@ -1292,7 +1292,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1d
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage"}[4d]))
@@ -1301,7 +1301,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate4d
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1317,7 +1317,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
@@ -1334,7 +1334,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
@@ -1351,7 +1351,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
@@ -1368,7 +1368,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
@@ -1404,7 +1404,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:increase4w
     - alert: SLOMetricAbsent
@@ -1418,7 +1418,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         slo: api-alerting-availability-slo
   - interval: 30s
@@ -1429,7 +1429,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate5m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[30m]))
@@ -1437,7 +1437,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate30m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[1h]))
@@ -1445,7 +1445,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[2h]))
@@ -1453,7 +1453,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate2h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[6h]))
@@ -1461,7 +1461,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate6h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[1d]))
@@ -1469,7 +1469,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1d
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-stage"}[4d]))
@@ -1477,7 +1477,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate4d
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1493,7 +1493,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-alerting-availability-slo
@@ -1510,7 +1510,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-alerting-availability-slo
@@ -1527,7 +1527,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-availability-slo
@@ -1544,7 +1544,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-availability-slo
@@ -1593,7 +1593,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-mst-stage
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: high
         slo: api-alerting-notif-availability-slo
   - interval: 30s
@@ -1661,7 +1661,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-alerting-notif-availability-slo
@@ -1678,7 +1678,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-alerting-notif-availability-slo
@@ -1695,7 +1695,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-notif-availability-slo
@@ -1712,7 +1712,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-notif-availability-slo
@@ -1749,7 +1749,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",le="5"}[4w]))
@@ -1758,7 +1758,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         le: "5"
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1774,7 +1774,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
@@ -1790,7 +1790,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         slo: api-metrics-write-latency-slo
   - interval: 30s
@@ -1803,7 +1803,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -1813,7 +1813,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -1823,7 +1823,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -1833,7 +1833,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -1843,7 +1843,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -1853,7 +1853,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -1863,7 +1863,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
@@ -1881,7 +1881,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
@@ -1900,7 +1900,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
@@ -1919,7 +1919,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
@@ -1938,7 +1938,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
@@ -1974,7 +1974,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[4w]))
@@ -1982,7 +1982,7 @@ spec:
         le: "10"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1997,7 +1997,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
@@ -2012,7 +2012,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
@@ -2024,7 +2024,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[30m]))
@@ -2033,7 +2033,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[1h]))
@@ -2042,7 +2042,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[2h]))
@@ -2051,7 +2051,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[6h]))
@@ -2060,7 +2060,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[1d]))
@@ -2069,7 +2069,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[4d]))
@@ -2078,7 +2078,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
@@ -2095,7 +2095,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
@@ -2113,7 +2113,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
@@ -2131,7 +2131,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
@@ -2149,7 +2149,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
@@ -2185,7 +2185,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[4w]))
@@ -2193,7 +2193,7 @@ spec:
         le: "30"
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2208,7 +2208,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
@@ -2223,7 +2223,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
@@ -2235,7 +2235,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[30m]))
@@ -2244,7 +2244,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[1h]))
@@ -2253,7 +2253,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[2h]))
@@ -2262,7 +2262,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[6h]))
@@ -2271,7 +2271,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[1d]))
@@ -2280,7 +2280,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-10M-samples"}[4d]))
@@ -2289,7 +2289,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
@@ -2306,7 +2306,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
@@ -2324,7 +2324,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
@@ -2342,7 +2342,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
@@ -2360,7 +2360,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
@@ -2396,7 +2396,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[4w]))
@@ -2404,7 +2404,7 @@ spec:
         le: "120"
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2419,7 +2419,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
@@ -2434,7 +2434,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
@@ -2446,7 +2446,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[30m]))
@@ -2455,7 +2455,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[1h]))
@@ -2464,7 +2464,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[2h]))
@@ -2473,7 +2473,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[6h]))
@@ -2482,7 +2482,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[1d]))
@@ -2491,7 +2491,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-stage",query="query-path-sli-1M-samples"}[4d]))
@@ -2500,7 +2500,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
@@ -2517,7 +2517,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
@@ -2535,7 +2535,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
@@ -2553,7 +2553,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
@@ -2571,7 +2571,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
@@ -18,6 +18,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -33,6 +34,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-availability-slo
   - interval: 30s
@@ -44,6 +46,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -52,6 +55,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -60,6 +64,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -68,6 +73,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -76,6 +82,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -84,6 +91,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -92,6 +100,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
@@ -109,6 +118,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
@@ -127,6 +137,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
@@ -145,6 +156,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
@@ -163,6 +175,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
@@ -199,6 +212,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -214,6 +228,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-query-availability-slo
   - interval: 30s
@@ -225,6 +240,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[30m]))
@@ -233,6 +249,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1h]))
@@ -241,6 +258,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[2h]))
@@ -249,6 +267,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[6h]))
@@ -257,6 +276,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1d]))
@@ -265,6 +285,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[4d]))
@@ -273,6 +294,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
@@ -290,6 +312,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
@@ -308,6 +331,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
@@ -326,6 +350,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
@@ -344,6 +369,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
@@ -380,6 +406,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -395,6 +422,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
@@ -406,6 +434,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[30m]))
@@ -414,6 +443,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1h]))
@@ -422,6 +452,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[2h]))
@@ -430,6 +461,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[6h]))
@@ -438,6 +470,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1d]))
@@ -446,6 +479,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[4d]))
@@ -454,6 +488,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
@@ -471,6 +506,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
@@ -489,6 +525,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
@@ -507,6 +544,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
@@ -525,6 +563,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
@@ -562,6 +601,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -578,6 +618,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         severity: critical
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
@@ -590,6 +631,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[30m]))
@@ -599,6 +641,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[1h]))
@@ -608,6 +651,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[2h]))
@@ -617,6 +661,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[6h]))
@@ -626,6 +671,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[1d]))
@@ -635,6 +681,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT"}[4d]))
@@ -644,6 +691,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
@@ -662,6 +710,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: PUT
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-raw-write-availability-slo
@@ -681,6 +730,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: PUT
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-raw-write-availability-slo
@@ -700,6 +750,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: PUT
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-raw-write-availability-slo
@@ -719,6 +770,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: PUT
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-raw-write-availability-slo
@@ -756,6 +808,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -772,6 +825,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         severity: critical
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
@@ -784,6 +838,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[30m]))
@@ -793,6 +848,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[1h]))
@@ -802,6 +858,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[2h]))
@@ -811,6 +868,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[6h]))
@@ -820,6 +878,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[1d]))
@@ -829,6 +888,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET"}[4d]))
@@ -838,6 +898,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
@@ -856,6 +917,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: GET
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-raw-read-availability-slo
@@ -875,6 +937,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: GET
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-raw-read-availability-slo
@@ -894,6 +957,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: GET
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-raw-read-availability-slo
@@ -913,6 +977,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: GET
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-raw-read-availability-slo
@@ -950,6 +1015,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -966,6 +1032,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         severity: critical
         slo: api-rules-read-availability-slo
   - interval: 30s
@@ -978,6 +1045,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[30m]))
@@ -987,6 +1055,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1h]))
@@ -996,6 +1065,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[2h]))
@@ -1005,6 +1075,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[6h]))
@@ -1014,6 +1085,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1d]))
@@ -1023,6 +1095,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[4d]))
@@ -1032,6 +1105,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
@@ -1050,6 +1124,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: GET
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
@@ -1069,6 +1144,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: GET
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
@@ -1088,6 +1164,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: GET
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
@@ -1107,6 +1184,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: GET
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
@@ -1143,6 +1221,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1158,6 +1237,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         slo: api-rules-sync-availability-slo
   - interval: 30s
@@ -1169,6 +1249,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate5m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[30m]))
@@ -1177,6 +1258,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate30m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1h]))
@@ -1185,6 +1267,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[2h]))
@@ -1193,6 +1276,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate2h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[6h]))
@@ -1201,6 +1285,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate6h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1d]))
@@ -1209,6 +1294,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1d
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[4d]))
@@ -1217,6 +1303,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate4d
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1234,6 +1321,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
@@ -1252,6 +1340,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
@@ -1270,6 +1359,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
@@ -1288,6 +1378,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
@@ -1323,6 +1414,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:increase4w
     - alert: SLOMetricAbsent
@@ -1337,6 +1429,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         slo: api-alerting-availability-slo
   - interval: 30s
@@ -1347,6 +1440,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate5m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[30m]))
@@ -1354,6 +1448,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate30m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[1h]))
@@ -1361,6 +1456,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[2h]))
@@ -1368,6 +1464,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate2h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[6h]))
@@ -1375,6 +1472,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate6h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[1d]))
@@ -1382,6 +1480,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1d
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[4d]))
@@ -1389,6 +1488,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate4d
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1405,6 +1505,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 5m
         slo: api-alerting-availability-slo
@@ -1422,6 +1523,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 30m
         slo: api-alerting-availability-slo
@@ -1439,6 +1541,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-availability-slo
@@ -1456,6 +1559,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-availability-slo
@@ -1660,6 +1764,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",le="5"}[4w]))
@@ -1668,6 +1773,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         le: "5"
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1683,6 +1789,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
@@ -1699,6 +1806,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         le: "5"
+        service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-latency-slo
   - interval: 30s
@@ -1711,6 +1819,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -1720,6 +1829,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -1729,6 +1839,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -1738,6 +1849,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -1747,6 +1859,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -1756,6 +1869,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -1765,6 +1879,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
@@ -1782,6 +1897,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
@@ -1800,6 +1916,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
@@ -1818,6 +1935,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
@@ -1836,6 +1954,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
@@ -1871,6 +1990,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="10",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4w]))
@@ -1878,6 +1998,7 @@ spec:
         le: "10"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1892,6 +2013,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
@@ -1907,6 +2029,7 @@ spec:
         le: "10"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
@@ -1918,6 +2041,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[30m]))
@@ -1926,6 +2050,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1h]))
@@ -1934,6 +2059,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[2h]))
@@ -1942,6 +2068,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[6h]))
@@ -1950,6 +2077,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1d]))
@@ -1958,6 +2086,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4d]))
@@ -1966,6 +2095,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
@@ -1982,6 +2112,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
@@ -1999,6 +2130,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
@@ -2016,6 +2148,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
@@ -2033,6 +2166,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
@@ -2068,6 +2202,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="30",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[4w]))
@@ -2075,6 +2210,7 @@ spec:
         le: "30"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2089,6 +2225,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
@@ -2104,6 +2241,7 @@ spec:
         le: "30"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
@@ -2115,6 +2253,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[30m]))
@@ -2123,6 +2262,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[1h]))
@@ -2131,6 +2271,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[2h]))
@@ -2139,6 +2280,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[6h]))
@@ -2147,6 +2289,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[1d]))
@@ -2155,6 +2298,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[4d]))
@@ -2163,6 +2307,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
@@ -2179,6 +2324,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
@@ -2196,6 +2342,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
@@ -2213,6 +2360,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
@@ -2230,6 +2378,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
@@ -2265,6 +2414,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="120",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4w]))
@@ -2272,6 +2422,7 @@ spec:
         le: "120"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2286,6 +2437,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
@@ -2301,6 +2453,7 @@ spec:
         le: "120"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
@@ -2312,6 +2465,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[30m]))
@@ -2320,6 +2474,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1h]))
@@ -2328,6 +2483,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[2h]))
@@ -2336,6 +2492,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[6h]))
@@ -2344,6 +2501,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1d]))
@@ -2352,6 +2510,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4d]))
@@ -2360,6 +2519,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
@@ -2376,6 +2536,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
@@ -2393,6 +2554,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
@@ -2410,6 +2572,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
@@ -2427,6 +2590,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
@@ -18,7 +18,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -34,7 +34,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         slo: api-metrics-write-availability-slo
   - interval: 30s
@@ -46,7 +46,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -55,7 +55,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -64,7 +64,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -73,7 +73,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -82,7 +82,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -91,7 +91,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -100,7 +100,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
@@ -118,7 +118,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
@@ -137,7 +137,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
@@ -156,7 +156,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
@@ -175,7 +175,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
@@ -212,7 +212,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -228,7 +228,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-query-availability-slo
   - interval: 30s
@@ -240,7 +240,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[30m]))
@@ -249,7 +249,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1h]))
@@ -258,7 +258,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[2h]))
@@ -267,7 +267,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[6h]))
@@ -276,7 +276,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[1d]))
@@ -285,7 +285,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[4d]))
@@ -294,7 +294,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
@@ -312,7 +312,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
@@ -331,7 +331,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
@@ -350,7 +350,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
@@ -369,7 +369,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
@@ -406,7 +406,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -422,7 +422,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
@@ -434,7 +434,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[30m]))
@@ -443,7 +443,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1h]))
@@ -452,7 +452,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[2h]))
@@ -461,7 +461,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[6h]))
@@ -470,7 +470,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[1d]))
@@ -479,7 +479,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api"}[4d]))
@@ -488,7 +488,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
@@ -506,7 +506,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
@@ -525,7 +525,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
@@ -544,7 +544,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
@@ -563,7 +563,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
@@ -1015,7 +1015,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1032,7 +1032,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         slo: api-rules-read-availability-slo
   - interval: 30s
@@ -1045,7 +1045,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[30m]))
@@ -1055,7 +1055,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1h]))
@@ -1065,7 +1065,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[2h]))
@@ -1075,7 +1075,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[6h]))
@@ -1085,7 +1085,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[1d]))
@@ -1095,7 +1095,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET"}[4d]))
@@ -1105,7 +1105,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-mst-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
@@ -1124,7 +1124,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
@@ -1144,7 +1144,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
@@ -1164,7 +1164,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
@@ -1184,7 +1184,7 @@ spec:
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
@@ -1221,7 +1221,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1235,7 +1235,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         slo: api-rules-sync-availability-slo
   - interval: 30s
@@ -1247,7 +1247,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate5m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[30m]))
@@ -1256,7 +1256,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate30m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1h]))
@@ -1265,7 +1265,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[2h]))
@@ -1274,7 +1274,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate2h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[6h]))
@@ -1283,7 +1283,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate6h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[1d]))
@@ -1292,7 +1292,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1d
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-mst-production"}[4d]))
@@ -1301,7 +1301,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate4d
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1317,7 +1317,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
@@ -1334,7 +1334,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
@@ -1351,7 +1351,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
@@ -1368,7 +1368,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
@@ -1404,7 +1404,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:increase4w
     - alert: SLOMetricAbsent
@@ -1418,7 +1418,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         slo: api-alerting-availability-slo
   - interval: 30s
@@ -1429,7 +1429,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate5m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[30m]))
@@ -1437,7 +1437,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate30m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[1h]))
@@ -1445,7 +1445,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[2h]))
@@ -1453,7 +1453,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate2h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[6h]))
@@ -1461,7 +1461,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate6h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[1d]))
@@ -1469,7 +1469,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1d
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-mst-production"}[4d]))
@@ -1477,7 +1477,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate4d
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -1493,7 +1493,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-alerting-availability-slo
@@ -1510,7 +1510,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-alerting-availability-slo
@@ -1527,7 +1527,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-availability-slo
@@ -1544,7 +1544,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-availability-slo
@@ -1593,7 +1593,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-mst-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: critical
         slo: api-alerting-notif-availability-slo
   - interval: 30s
@@ -1661,7 +1661,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-alerting-notif-availability-slo
@@ -1678,7 +1678,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-alerting-notif-availability-slo
@@ -1695,7 +1695,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-notif-availability-slo
@@ -1712,7 +1712,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-notif-availability-slo
@@ -1749,7 +1749,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",le="5"}[4w]))
@@ -1758,7 +1758,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         le: "5"
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1774,7 +1774,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
@@ -1790,7 +1790,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         slo: api-metrics-write-latency-slo
   - interval: 30s
@@ -1803,7 +1803,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[30m]))
@@ -1813,7 +1813,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1h]))
@@ -1823,7 +1823,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[2h]))
@@ -1833,7 +1833,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[6h]))
@@ -1843,7 +1843,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[1d]))
@@ -1853,7 +1853,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api"}[4d]))
@@ -1863,7 +1863,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
@@ -1881,7 +1881,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
@@ -1900,7 +1900,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
@@ -1919,7 +1919,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
@@ -1938,7 +1938,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
@@ -1974,7 +1974,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="10",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4w]))
@@ -1982,7 +1982,7 @@ spec:
         le: "10"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -1997,7 +1997,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
@@ -2012,7 +2012,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
@@ -2024,7 +2024,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[30m]))
@@ -2033,7 +2033,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1h]))
@@ -2042,7 +2042,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[2h]))
@@ -2051,7 +2051,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[6h]))
@@ -2060,7 +2060,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1d]))
@@ -2069,7 +2069,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4d]))
@@ -2078,7 +2078,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
@@ -2095,7 +2095,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
@@ -2113,7 +2113,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
@@ -2131,7 +2131,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
@@ -2149,7 +2149,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
@@ -2185,7 +2185,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="30",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[4w]))
@@ -2193,7 +2193,7 @@ spec:
         le: "30"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2208,7 +2208,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
@@ -2223,7 +2223,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
@@ -2235,7 +2235,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[30m]))
@@ -2244,7 +2244,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[1h]))
@@ -2253,7 +2253,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[2h]))
@@ -2262,7 +2262,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[6h]))
@@ -2271,7 +2271,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[1d]))
@@ -2280,7 +2280,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-10M-samples"}[4d]))
@@ -2289,7 +2289,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
@@ -2306,7 +2306,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
@@ -2324,7 +2324,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
@@ -2342,7 +2342,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
@@ -2360,7 +2360,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
@@ -2396,7 +2396,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="120",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4w]))
@@ -2404,7 +2404,7 @@ spec:
         le: "120"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2419,7 +2419,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
@@ -2434,7 +2434,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
@@ -2446,7 +2446,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[30m]))
@@ -2455,7 +2455,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1h]))
@@ -2464,7 +2464,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[2h]))
@@ -2473,7 +2473,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[6h]))
@@ -2482,7 +2482,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[1d]))
@@ -2491,7 +2491,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-mst-production",query="query-path-sli-1M-samples"}[4d]))
@@ -2500,7 +2500,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
@@ -2517,7 +2517,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
@@ -2535,7 +2535,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
@@ -2553,7 +2553,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
@@ -2571,7 +2571,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
@@ -1234,8 +1234,6 @@ spec:
         == 1
       for: 2m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
         severity: critical
@@ -1317,8 +1315,6 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1336,8 +1332,6 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1355,8 +1349,6 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1374,8 +1366,6 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1427,7 +1417,6 @@ spec:
         == 1
       for: 2m
       labels:
-        container: thanos-rule
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
         severity: critical
@@ -1502,7 +1491,6 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        container: thanos-rule
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1520,7 +1508,6 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        container: thanos-rule
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1538,7 +1525,6 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        container: thanos-rule
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1556,7 +1542,6 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        container: thanos-rule
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-thanos-ruler
@@ -1805,7 +1790,6 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
-        le: "5"
         service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-latency-slo
@@ -2026,7 +2010,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "10"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-thanos-query
@@ -2238,7 +2221,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "30"
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         service: observatorium-thanos-query
@@ -2450,7 +2432,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "120"
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-thanos-query

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -776,7 +776,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -792,7 +792,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         slo: api-metrics-write-availability-slo
   - interval: 30s
@@ -804,7 +804,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[30m]))
@@ -813,7 +813,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1h]))
@@ -822,7 +822,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[2h]))
@@ -831,7 +831,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[6h]))
@@ -840,7 +840,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1d]))
@@ -849,7 +849,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[4d]))
@@ -858,7 +858,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
@@ -876,7 +876,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
@@ -895,7 +895,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
@@ -914,7 +914,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
@@ -933,7 +933,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
@@ -970,7 +970,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -986,7 +986,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-query-availability-slo
   - interval: 30s
@@ -998,7 +998,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[30m]))
@@ -1007,7 +1007,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1h]))
@@ -1016,7 +1016,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[2h]))
@@ -1025,7 +1025,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[6h]))
@@ -1034,7 +1034,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1d]))
@@ -1043,7 +1043,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[4d]))
@@ -1052,7 +1052,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
@@ -1070,7 +1070,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
@@ -1089,7 +1089,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
@@ -1108,7 +1108,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
@@ -1127,7 +1127,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
@@ -1164,7 +1164,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1180,7 +1180,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
@@ -1192,7 +1192,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[30m]))
@@ -1201,7 +1201,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[1h]))
@@ -1210,7 +1210,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[2h]))
@@ -1219,7 +1219,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[6h]))
@@ -1228,7 +1228,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[1d]))
@@ -1237,7 +1237,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[4d]))
@@ -1246,7 +1246,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
@@ -1264,7 +1264,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
@@ -1283,7 +1283,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
@@ -1302,7 +1302,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
@@ -1321,7 +1321,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
@@ -1773,7 +1773,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1790,7 +1790,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         slo: api-rules-read-availability-slo
   - interval: 30s
@@ -1803,7 +1803,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[30m]))
@@ -1813,7 +1813,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[1h]))
@@ -1823,7 +1823,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[2h]))
@@ -1833,7 +1833,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[6h]))
@@ -1843,7 +1843,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[1d]))
@@ -1853,7 +1853,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[4d]))
@@ -1863,7 +1863,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
@@ -1882,7 +1882,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
@@ -1902,7 +1902,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
@@ -1922,7 +1922,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
@@ -1942,7 +1942,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
@@ -1979,7 +1979,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1993,7 +1993,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         slo: api-rules-sync-availability-slo
   - interval: 30s
@@ -2005,7 +2005,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate5m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[30m]))
@@ -2014,7 +2014,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate30m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[1h]))
@@ -2023,7 +2023,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[2h]))
@@ -2032,7 +2032,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate2h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[6h]))
@@ -2041,7 +2041,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate6h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[1d]))
@@ -2050,7 +2050,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1d
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[4d]))
@@ -2059,7 +2059,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate4d
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -2075,7 +2075,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
@@ -2092,7 +2092,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
@@ -2109,7 +2109,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
@@ -2126,7 +2126,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
@@ -2162,7 +2162,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:increase4w
     - alert: SLOMetricAbsent
@@ -2176,7 +2176,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         slo: api-alerting-availability-slo
   - interval: 30s
@@ -2187,7 +2187,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate5m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[30m]))
@@ -2195,7 +2195,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate30m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[1h]))
@@ -2203,7 +2203,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[2h]))
@@ -2211,7 +2211,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate2h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[6h]))
@@ -2219,7 +2219,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate6h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[1d]))
@@ -2227,7 +2227,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1d
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[4d]))
@@ -2235,7 +2235,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate4d
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -2251,7 +2251,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-alerting-availability-slo
@@ -2268,7 +2268,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-alerting-availability-slo
@@ -2285,7 +2285,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-availability-slo
@@ -2302,7 +2302,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-metrics-production
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-availability-slo
@@ -2351,7 +2351,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-metrics-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: critical
         slo: api-alerting-notif-availability-slo
   - interval: 30s
@@ -2419,7 +2419,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-metrics-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-alerting-notif-availability-slo
@@ -2436,7 +2436,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-metrics-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-alerting-notif-availability-slo
@@ -2453,7 +2453,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-metrics-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-notif-availability-slo
@@ -2470,7 +2470,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-metrics-production
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-notif-availability-slo
@@ -2507,7 +2507,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",le="5"}[4w]))
@@ -2516,7 +2516,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         le: "5"
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2532,7 +2532,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
@@ -2548,7 +2548,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         slo: api-metrics-write-latency-slo
   - interval: 30s
@@ -2561,7 +2561,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[30m]))
@@ -2571,7 +2571,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1h]))
@@ -2581,7 +2581,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[2h]))
@@ -2591,7 +2591,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[6h]))
@@ -2601,7 +2601,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1d]))
@@ -2611,7 +2611,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[4d]))
@@ -2621,7 +2621,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
@@ -2639,7 +2639,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
@@ -2658,7 +2658,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
@@ -2677,7 +2677,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
@@ -2696,7 +2696,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
@@ -2732,7 +2732,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="10",namespace="observatorium-production",query="query-path-sli-1M-samples"}[4w]))
@@ -2740,7 +2740,7 @@ spec:
         le: "10"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2755,7 +2755,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
@@ -2770,7 +2770,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
@@ -2782,7 +2782,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[30m]))
@@ -2791,7 +2791,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[1h]))
@@ -2800,7 +2800,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[2h]))
@@ -2809,7 +2809,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[6h]))
@@ -2818,7 +2818,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[1d]))
@@ -2827,7 +2827,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[4d]))
@@ -2836,7 +2836,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
@@ -2853,7 +2853,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
@@ -2871,7 +2871,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
@@ -2889,7 +2889,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
@@ -2907,7 +2907,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
@@ -2943,7 +2943,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="30",namespace="observatorium-production",query="query-path-sli-10M-samples"}[4w]))
@@ -2951,7 +2951,7 @@ spec:
         le: "30"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2966,7 +2966,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
@@ -2981,7 +2981,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
@@ -2993,7 +2993,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[30m]))
@@ -3002,7 +3002,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[1h]))
@@ -3011,7 +3011,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[2h]))
@@ -3020,7 +3020,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[6h]))
@@ -3029,7 +3029,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[1d]))
@@ -3038,7 +3038,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[4d]))
@@ -3047,7 +3047,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
@@ -3064,7 +3064,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
@@ -3082,7 +3082,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
@@ -3100,7 +3100,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
@@ -3118,7 +3118,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
@@ -3154,7 +3154,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="120",namespace="observatorium-production",query="query-path-sli-1M-samples"}[4w]))
@@ -3162,7 +3162,7 @@ spec:
         le: "120"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -3177,7 +3177,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
@@ -3192,7 +3192,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
@@ -3204,7 +3204,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[30m]))
@@ -3213,7 +3213,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[1h]))
@@ -3222,7 +3222,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[2h]))
@@ -3231,7 +3231,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[6h]))
@@ -3240,7 +3240,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[1d]))
@@ -3249,7 +3249,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[4d]))
@@ -3258,7 +3258,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
@@ -3275,7 +3275,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
@@ -3293,7 +3293,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
@@ -3311,7 +3311,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
@@ -3329,7 +3329,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -16,6 +16,7 @@ spec:
     - expr: sum by(code) (increase(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[4w]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:increase4w
     - alert: SLOMetricAbsent
@@ -29,6 +30,7 @@ spec:
       for: 2m
       labels:
         route: telemeter-server-upload
+        service: telemeter
         severity: critical
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
   - interval: 30s
@@ -38,42 +40,49 @@ spec:
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[5m]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate5m
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[30m]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[30m]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate30m
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[1h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[1h]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate1h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[2h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[2h]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate2h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[6h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[6h]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate6h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[1d]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[1d]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate1d
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[4d]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[4d]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate4d
     - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
@@ -89,6 +98,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         route: telemeter-server-upload
+        service: telemeter
         severity: critical
         short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
@@ -105,6 +115,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         route: telemeter-server-upload
+        service: telemeter
         severity: critical
         short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
@@ -121,6 +132,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         route: telemeter-server-upload
+        service: telemeter
         severity: warning
         short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
@@ -137,6 +149,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         route: telemeter-server-upload
+        service: telemeter
         severity: warning
         short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
@@ -171,6 +184,7 @@ spec:
     - expr: sum by(code) (increase(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[4w]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:increase4w
     - alert: SLOMetricAbsent
@@ -184,6 +198,7 @@ spec:
       for: 2m
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         severity: critical
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
   - interval: 30s
@@ -193,42 +208,49 @@ spec:
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[5m]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate5m
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[30m]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[30m]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate30m
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[1h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[1h]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate1h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[2h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[2h]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate2h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[6h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[6h]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate6h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[1d]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[1d]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate1d
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[4d]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[4d]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate4d
     - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
@@ -244,6 +266,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         severity: critical
         short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
@@ -260,6 +283,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         severity: critical
         short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
@@ -276,6 +300,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         severity: warning
         short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
@@ -292,6 +317,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         severity: warning
         short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
@@ -327,6 +353,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",handler="upload",job="telemeter-server",le="5"}[4w]))
@@ -334,6 +361,7 @@ spec:
         handler: upload
         job: telemeter-server
         le: "5"
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -348,6 +376,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         severity: critical
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
     - alert: SLOMetricAbsent
@@ -363,6 +392,7 @@ spec:
         handler: upload
         job: telemeter-server
         le: "5"
+        service: telemeter
         severity: critical
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
   - interval: 30s
@@ -374,6 +404,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[30m]))
@@ -382,6 +413,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[1h]))
@@ -390,6 +422,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[2h]))
@@ -398,6 +431,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[6h]))
@@ -406,6 +440,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[1d]))
@@ -414,6 +449,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[4d]))
@@ -422,6 +458,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
@@ -438,6 +475,7 @@ spec:
         handler: upload
         job: telemeter-server
         long_burnrate_window: 1h
+        service: telemeter
         severity: critical
         short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -455,6 +493,7 @@ spec:
         handler: upload
         job: telemeter-server
         long_burnrate_window: 6h
+        service: telemeter
         severity: critical
         short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -472,6 +511,7 @@ spec:
         handler: upload
         job: telemeter-server
         long_burnrate_window: 1d
+        service: telemeter
         severity: warning
         short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -489,6 +529,7 @@ spec:
         handler: upload
         job: telemeter-server
         long_burnrate_window: 4d
+        service: telemeter
         severity: warning
         short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -524,6 +565,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",handler="receive",job="telemeter-server",le="5"}[4w]))
@@ -531,6 +573,7 @@ spec:
         handler: receive
         job: telemeter-server
         le: "5"
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -545,6 +588,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         severity: critical
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
     - alert: SLOMetricAbsent
@@ -560,6 +604,7 @@ spec:
         handler: receive
         job: telemeter-server
         le: "5"
+        service: telemeter
         severity: critical
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
   - interval: 30s
@@ -571,6 +616,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[30m]))
@@ -579,6 +625,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[1h]))
@@ -587,6 +634,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[2h]))
@@ -595,6 +643,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[6h]))
@@ -603,6 +652,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[1d]))
@@ -611,6 +661,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[4d]))
@@ -619,6 +670,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
@@ -635,6 +687,7 @@ spec:
         handler: receive
         job: telemeter-server
         long_burnrate_window: 1h
+        service: telemeter
         severity: critical
         short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -652,6 +705,7 @@ spec:
         handler: receive
         job: telemeter-server
         long_burnrate_window: 6h
+        service: telemeter
         severity: critical
         short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -669,6 +723,7 @@ spec:
         handler: receive
         job: telemeter-server
         long_burnrate_window: 1d
+        service: telemeter
         severity: warning
         short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -686,6 +741,7 @@ spec:
         handler: receive
         job: telemeter-server
         long_burnrate_window: 4d
+        service: telemeter
         severity: warning
         short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -722,6 +778,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -737,6 +794,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-availability-slo
   - interval: 30s
@@ -748,6 +806,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[30m]))
@@ -756,6 +815,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1h]))
@@ -764,6 +824,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[2h]))
@@ -772,6 +833,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[6h]))
@@ -780,6 +842,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1d]))
@@ -788,6 +851,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[4d]))
@@ -796,6 +860,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
@@ -813,6 +878,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
@@ -831,6 +897,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
@@ -849,6 +916,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
@@ -867,6 +935,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
@@ -903,6 +972,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -918,6 +988,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-query-availability-slo
   - interval: 30s
@@ -929,6 +1000,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[30m]))
@@ -937,6 +1009,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1h]))
@@ -945,6 +1018,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[2h]))
@@ -953,6 +1027,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[6h]))
@@ -961,6 +1036,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1d]))
@@ -969,6 +1045,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[4d]))
@@ -977,6 +1054,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
@@ -994,6 +1072,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
@@ -1012,6 +1091,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
@@ -1030,6 +1110,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
@@ -1048,6 +1129,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
@@ -1084,6 +1166,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1099,6 +1182,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
@@ -1110,6 +1194,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[30m]))
@@ -1118,6 +1203,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[1h]))
@@ -1126,6 +1212,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[2h]))
@@ -1134,6 +1221,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[6h]))
@@ -1142,6 +1230,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[1d]))
@@ -1150,6 +1239,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[4d]))
@@ -1158,6 +1248,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
@@ -1175,6 +1266,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
@@ -1193,6 +1285,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
@@ -1211,6 +1304,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
@@ -1229,6 +1323,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
@@ -1266,6 +1361,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1282,6 +1378,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         severity: critical
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
@@ -1294,6 +1391,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[30m]))
@@ -1303,6 +1401,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[1h]))
@@ -1312,6 +1411,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[2h]))
@@ -1321,6 +1421,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[6h]))
@@ -1330,6 +1431,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[1d]))
@@ -1339,6 +1441,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[4d]))
@@ -1348,6 +1451,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
@@ -1366,6 +1470,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
         method: PUT
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-raw-write-availability-slo
@@ -1385,6 +1490,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
         method: PUT
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-raw-write-availability-slo
@@ -1404,6 +1510,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
         method: PUT
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-raw-write-availability-slo
@@ -1423,6 +1530,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
         method: PUT
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-raw-write-availability-slo
@@ -1460,6 +1568,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1476,6 +1585,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         severity: critical
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
@@ -1488,6 +1598,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[30m]))
@@ -1497,6 +1608,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[1h]))
@@ -1506,6 +1618,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[2h]))
@@ -1515,6 +1628,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[6h]))
@@ -1524,6 +1638,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[1d]))
@@ -1533,6 +1648,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[4d]))
@@ -1542,6 +1658,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
@@ -1560,6 +1677,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
         method: GET
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-raw-read-availability-slo
@@ -1579,6 +1697,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
         method: GET
+        service: observatorium-api
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-raw-read-availability-slo
@@ -1598,6 +1717,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
         method: GET
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-raw-read-availability-slo
@@ -1617,6 +1737,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
         method: GET
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-raw-read-availability-slo
@@ -1654,6 +1775,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1670,6 +1792,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         severity: critical
         slo: api-rules-read-availability-slo
   - interval: 30s
@@ -1682,6 +1805,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[30m]))
@@ -1691,6 +1815,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[1h]))
@@ -1700,6 +1825,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[2h]))
@@ -1709,6 +1835,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[6h]))
@@ -1718,6 +1845,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[1d]))
@@ -1727,6 +1855,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[4d]))
@@ -1736,6 +1865,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
@@ -1754,6 +1884,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
         method: GET
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
@@ -1773,6 +1904,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
         method: GET
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
@@ -1792,6 +1924,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
         method: GET
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
@@ -1811,6 +1944,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
         method: GET
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
@@ -1847,6 +1981,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1862,6 +1997,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         severity: critical
         slo: api-rules-sync-availability-slo
   - interval: 30s
@@ -1873,6 +2009,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate5m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[30m]))
@@ -1881,6 +2018,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate30m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[1h]))
@@ -1889,6 +2027,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[2h]))
@@ -1897,6 +2036,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate2h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[6h]))
@@ -1905,6 +2045,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate6h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[1d]))
@@ -1913,6 +2054,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1d
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production"}[4d]))
@@ -1921,6 +2063,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate4d
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1938,6 +2081,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 1h
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
@@ -1956,6 +2100,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 6h
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
@@ -1974,6 +2119,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 1d
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
@@ -1992,6 +2138,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 4d
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
@@ -2027,6 +2174,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:increase4w
     - alert: SLOMetricAbsent
@@ -2041,6 +2189,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         severity: critical
         slo: api-alerting-availability-slo
   - interval: 30s
@@ -2051,6 +2200,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate5m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[30m]))
@@ -2058,6 +2208,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate30m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[1h]))
@@ -2065,6 +2216,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[2h]))
@@ -2072,6 +2224,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate2h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[6h]))
@@ -2079,6 +2232,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate6h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[1d]))
@@ -2086,6 +2240,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1d
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-production"}[4d]))
@@ -2093,6 +2248,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate4d
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -2109,6 +2265,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 1h
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 5m
         slo: api-alerting-availability-slo
@@ -2126,6 +2283,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 6h
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         severity: critical
         short_burnrate_window: 30m
         slo: api-alerting-availability-slo
@@ -2143,6 +2301,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 1d
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-availability-slo
@@ -2160,6 +2319,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 4d
         namespace: observatorium-metrics-production
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-availability-slo
@@ -2364,6 +2524,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",le="5"}[4w]))
@@ -2372,6 +2533,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         le: "5"
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2387,6 +2549,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
@@ -2403,6 +2566,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         le: "5"
+        service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-latency-slo
   - interval: 30s
@@ -2415,6 +2579,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[30m]))
@@ -2424,6 +2589,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1h]))
@@ -2433,6 +2599,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[2h]))
@@ -2442,6 +2609,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[6h]))
@@ -2451,6 +2619,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1d]))
@@ -2460,6 +2629,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[4d]))
@@ -2469,6 +2639,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
@@ -2486,6 +2657,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
@@ -2504,6 +2676,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-receive
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
@@ -2522,6 +2695,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
@@ -2540,6 +2714,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
@@ -2575,6 +2750,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="10",namespace="observatorium-production",query="query-path-sli-1M-samples"}[4w]))
@@ -2582,6 +2758,7 @@ spec:
         le: "10"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2596,6 +2773,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
@@ -2611,6 +2789,7 @@ spec:
         le: "10"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
@@ -2622,6 +2801,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[30m]))
@@ -2630,6 +2810,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[1h]))
@@ -2638,6 +2819,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[2h]))
@@ -2646,6 +2828,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[6h]))
@@ -2654,6 +2837,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[1d]))
@@ -2662,6 +2846,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[4d]))
@@ -2670,6 +2855,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
@@ -2686,6 +2872,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
@@ -2703,6 +2890,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
@@ -2720,6 +2908,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
@@ -2737,6 +2926,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
@@ -2772,6 +2962,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="30",namespace="observatorium-production",query="query-path-sli-10M-samples"}[4w]))
@@ -2779,6 +2970,7 @@ spec:
         le: "30"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2793,6 +2985,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
@@ -2808,6 +3001,7 @@ spec:
         le: "30"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
@@ -2819,6 +3013,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[30m]))
@@ -2827,6 +3022,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[1h]))
@@ -2835,6 +3031,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[2h]))
@@ -2843,6 +3040,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[6h]))
@@ -2851,6 +3049,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[1d]))
@@ -2859,6 +3058,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-10M-samples"}[4d]))
@@ -2867,6 +3067,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
@@ -2883,6 +3084,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
@@ -2900,6 +3102,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
@@ -2917,6 +3120,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
@@ -2934,6 +3138,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
@@ -2969,6 +3174,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="120",namespace="observatorium-production",query="query-path-sli-1M-samples"}[4w]))
@@ -2976,6 +3182,7 @@ spec:
         le: "120"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2990,6 +3197,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
@@ -3005,6 +3213,7 @@ spec:
         le: "120"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
@@ -3016,6 +3225,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[30m]))
@@ -3024,6 +3234,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[1h]))
@@ -3032,6 +3243,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[2h]))
@@ -3040,6 +3252,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[6h]))
@@ -3048,6 +3261,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[1d]))
@@ -3056,6 +3270,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-production",query="query-path-sli-1M-samples"}[4d]))
@@ -3064,6 +3279,7 @@ spec:
       labels:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
@@ -3080,6 +3296,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
@@ -3097,6 +3314,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: critical
         short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
@@ -3114,6 +3332,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
@@ -3131,6 +3350,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -391,7 +391,6 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
-        le: "5"
         service: telemeter
         severity: critical
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -603,7 +602,6 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
-        le: "5"
         service: telemeter
         severity: critical
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -1994,8 +1992,6 @@ spec:
         == 1
       for: 2m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-production
         service: observatorium-thanos-ruler
         severity: critical
@@ -2077,8 +2073,6 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 1h
         namespace: observatorium-metrics-production
         service: observatorium-thanos-ruler
@@ -2096,8 +2090,6 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 6h
         namespace: observatorium-metrics-production
         service: observatorium-thanos-ruler
@@ -2115,8 +2107,6 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 1d
         namespace: observatorium-metrics-production
         service: observatorium-thanos-ruler
@@ -2134,8 +2124,6 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 4d
         namespace: observatorium-metrics-production
         service: observatorium-thanos-ruler
@@ -2187,7 +2175,6 @@ spec:
         == 1
       for: 2m
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-production
         service: observatorium-thanos-ruler
         severity: critical
@@ -2262,7 +2249,6 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        container: thanos-rule
         long_burnrate_window: 1h
         namespace: observatorium-metrics-production
         service: observatorium-thanos-ruler
@@ -2280,7 +2266,6 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        container: thanos-rule
         long_burnrate_window: 6h
         namespace: observatorium-metrics-production
         service: observatorium-thanos-ruler
@@ -2298,7 +2283,6 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        container: thanos-rule
         long_burnrate_window: 1d
         namespace: observatorium-metrics-production
         service: observatorium-thanos-ruler
@@ -2316,7 +2300,6 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        container: thanos-rule
         long_burnrate_window: 4d
         namespace: observatorium-metrics-production
         service: observatorium-thanos-ruler
@@ -2565,7 +2548,6 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        le: "5"
         service: observatorium-thanos-receive
         severity: critical
         slo: api-metrics-write-latency-slo
@@ -2786,7 +2768,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "10"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         service: observatorium-thanos-query
@@ -2998,7 +2979,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "30"
         namespace: observatorium-production
         query: query-path-sli-10M-samples
         service: observatorium-thanos-query
@@ -3210,7 +3190,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "120"
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         service: observatorium-thanos-query

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -776,7 +776,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -792,7 +792,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         slo: api-metrics-write-availability-slo
   - interval: 30s
@@ -804,7 +804,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[30m]))
@@ -813,7 +813,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1h]))
@@ -822,7 +822,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[2h]))
@@ -831,7 +831,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[6h]))
@@ -840,7 +840,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1d]))
@@ -849,7 +849,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[4d]))
@@ -858,7 +858,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
@@ -876,7 +876,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
@@ -895,7 +895,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
@@ -914,7 +914,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
@@ -933,7 +933,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
@@ -970,7 +970,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -986,7 +986,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-query-availability-slo
   - interval: 30s
@@ -998,7 +998,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[30m]))
@@ -1007,7 +1007,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1h]))
@@ -1016,7 +1016,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[2h]))
@@ -1025,7 +1025,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[6h]))
@@ -1034,7 +1034,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1d]))
@@ -1043,7 +1043,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[4d]))
@@ -1052,7 +1052,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
@@ -1070,7 +1070,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
@@ -1089,7 +1089,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
@@ -1108,7 +1108,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
@@ -1127,7 +1127,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
@@ -1164,7 +1164,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1180,7 +1180,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
@@ -1192,7 +1192,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[30m]))
@@ -1201,7 +1201,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[1h]))
@@ -1210,7 +1210,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[2h]))
@@ -1219,7 +1219,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[6h]))
@@ -1228,7 +1228,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[1d]))
@@ -1237,7 +1237,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[4d]))
@@ -1246,7 +1246,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
@@ -1264,7 +1264,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
@@ -1283,7 +1283,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
@@ -1302,7 +1302,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
@@ -1321,7 +1321,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
@@ -1773,7 +1773,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1790,7 +1790,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         slo: api-rules-read-availability-slo
   - interval: 30s
@@ -1803,7 +1803,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[30m]))
@@ -1813,7 +1813,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[1h]))
@@ -1823,7 +1823,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[2h]))
@@ -1833,7 +1833,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[6h]))
@@ -1843,7 +1843,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[1d]))
@@ -1853,7 +1853,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[4d]))
@@ -1863,7 +1863,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
@@ -1882,7 +1882,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
@@ -1902,7 +1902,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
@@ -1922,7 +1922,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
@@ -1942,7 +1942,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
         method: GET
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
@@ -1979,7 +1979,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1993,7 +1993,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         slo: api-rules-sync-availability-slo
   - interval: 30s
@@ -2005,7 +2005,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate5m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[30m]))
@@ -2014,7 +2014,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate30m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[1h]))
@@ -2023,7 +2023,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[2h]))
@@ -2032,7 +2032,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate2h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[6h]))
@@ -2041,7 +2041,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate6h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[1d]))
@@ -2050,7 +2050,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1d
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[4d]))
@@ -2059,7 +2059,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate4d
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -2075,7 +2075,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
@@ -2092,7 +2092,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
@@ -2109,7 +2109,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
@@ -2126,7 +2126,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
@@ -2162,7 +2162,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:increase4w
     - alert: SLOMetricAbsent
@@ -2176,7 +2176,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         slo: api-alerting-availability-slo
   - interval: 30s
@@ -2187,7 +2187,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate5m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[30m]))
@@ -2195,7 +2195,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate30m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[1h]))
@@ -2203,7 +2203,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[2h]))
@@ -2211,7 +2211,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate2h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[6h]))
@@ -2219,7 +2219,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate6h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[1d]))
@@ -2227,7 +2227,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1d
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[4d]))
@@ -2235,7 +2235,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate4d
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -2251,7 +2251,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-alerting-availability-slo
@@ -2268,7 +2268,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-alerting-availability-slo
@@ -2285,7 +2285,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-availability-slo
@@ -2302,7 +2302,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
-        service: observatorium-thanos-ruler
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-availability-slo
@@ -2351,7 +2351,7 @@ spec:
       for: 2m
       labels:
         namespace: observatorium-metrics-stage
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: high
         slo: api-alerting-notif-availability-slo
   - interval: 30s
@@ -2419,7 +2419,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-alerting-notif-availability-slo
@@ -2436,7 +2436,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-alerting-notif-availability-slo
@@ -2453,7 +2453,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-notif-availability-slo
@@ -2470,7 +2470,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
-        service: observatorium-alertmanager
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-notif-availability-slo
@@ -2507,7 +2507,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",le="5"}[4w]))
@@ -2516,7 +2516,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         le: "5"
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2532,7 +2532,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
@@ -2548,7 +2548,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         slo: api-metrics-write-latency-slo
   - interval: 30s
@@ -2561,7 +2561,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[30m]))
@@ -2571,7 +2571,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1h]))
@@ -2581,7 +2581,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[2h]))
@@ -2591,7 +2591,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[6h]))
@@ -2601,7 +2601,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1d]))
@@ -2611,7 +2611,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[4d]))
@@ -2621,7 +2621,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        service: observatorium-thanos-receive
+        service: observatorium-api
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
@@ -2639,7 +2639,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
@@ -2658,7 +2658,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
@@ -2677,7 +2677,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
@@ -2696,7 +2696,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
-        service: observatorium-thanos-receive
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
@@ -2732,7 +2732,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="10",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[4w]))
@@ -2740,7 +2740,7 @@ spec:
         le: "10"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2755,7 +2755,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
@@ -2770,7 +2770,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
@@ -2782,7 +2782,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[30m]))
@@ -2791,7 +2791,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[1h]))
@@ -2800,7 +2800,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[2h]))
@@ -2809,7 +2809,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[6h]))
@@ -2818,7 +2818,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[1d]))
@@ -2827,7 +2827,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[4d]))
@@ -2836,7 +2836,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
@@ -2853,7 +2853,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
@@ -2871,7 +2871,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
@@ -2889,7 +2889,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
@@ -2907,7 +2907,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
@@ -2943,7 +2943,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="30",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[4w]))
@@ -2951,7 +2951,7 @@ spec:
         le: "30"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2966,7 +2966,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
@@ -2981,7 +2981,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
@@ -2993,7 +2993,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[30m]))
@@ -3002,7 +3002,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[1h]))
@@ -3011,7 +3011,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[2h]))
@@ -3020,7 +3020,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[6h]))
@@ -3029,7 +3029,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[1d]))
@@ -3038,7 +3038,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[4d]))
@@ -3047,7 +3047,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
@@ -3064,7 +3064,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
@@ -3082,7 +3082,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
@@ -3100,7 +3100,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
@@ -3118,7 +3118,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
@@ -3154,7 +3154,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="120",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[4w]))
@@ -3162,7 +3162,7 @@ spec:
         le: "120"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -3177,7 +3177,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
@@ -3192,7 +3192,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
@@ -3204,7 +3204,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[30m]))
@@ -3213,7 +3213,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[1h]))
@@ -3222,7 +3222,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[2h]))
@@ -3231,7 +3231,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[6h]))
@@ -3240,7 +3240,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[1d]))
@@ -3249,7 +3249,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[4d]))
@@ -3258,7 +3258,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
@@ -3275,7 +3275,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
@@ -3293,7 +3293,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
@@ -3311,7 +3311,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
@@ -3329,7 +3329,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
-        service: observatorium-thanos-query
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -391,7 +391,6 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
-        le: "5"
         service: telemeter
         severity: high
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -603,7 +602,6 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
-        le: "5"
         service: telemeter
         severity: high
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -1994,8 +1992,6 @@ spec:
         == 1
       for: 2m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
         service: observatorium-thanos-ruler
         severity: high
@@ -2077,8 +2073,6 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
         service: observatorium-thanos-ruler
@@ -2096,8 +2090,6 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
         service: observatorium-thanos-ruler
@@ -2115,8 +2107,6 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
         service: observatorium-thanos-ruler
@@ -2134,8 +2124,6 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        client: reload
-        container: thanos-rule-syncer
         long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
         service: observatorium-thanos-ruler
@@ -2187,7 +2175,6 @@ spec:
         == 1
       for: 2m
       labels:
-        container: thanos-rule
         namespace: observatorium-metrics-stage
         service: observatorium-thanos-ruler
         severity: high
@@ -2262,7 +2249,6 @@ spec:
         > (14 * (1-0.995))
       for: 2m
       labels:
-        container: thanos-rule
         long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
         service: observatorium-thanos-ruler
@@ -2280,7 +2266,6 @@ spec:
         > (7 * (1-0.995))
       for: 15m
       labels:
-        container: thanos-rule
         long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
         service: observatorium-thanos-ruler
@@ -2298,7 +2283,6 @@ spec:
         > (2 * (1-0.995))
       for: 1h
       labels:
-        container: thanos-rule
         long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
         service: observatorium-thanos-ruler
@@ -2316,7 +2300,6 @@ spec:
         > (1 * (1-0.995))
       for: 3h
       labels:
-        container: thanos-rule
         long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
         service: observatorium-thanos-ruler
@@ -2565,7 +2548,6 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
-        le: "5"
         service: observatorium-thanos-receive
         severity: high
         slo: api-metrics-write-latency-slo
@@ -2786,7 +2768,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "10"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         service: observatorium-thanos-query
@@ -2998,7 +2979,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "30"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
         service: observatorium-thanos-query
@@ -3210,7 +3190,6 @@ spec:
         == 1
       for: 2m
       labels:
-        le: "120"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         service: observatorium-thanos-query

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -16,6 +16,7 @@ spec:
     - expr: sum by(code) (increase(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[4w]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:increase4w
     - alert: SLOMetricAbsent
@@ -29,6 +30,7 @@ spec:
       for: 2m
       labels:
         route: telemeter-server-upload
+        service: telemeter
         severity: high
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
   - interval: 30s
@@ -38,42 +40,49 @@ spec:
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[5m]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate5m
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[30m]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[30m]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate30m
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[1h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[1h]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate1h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[2h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[2h]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate2h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[6h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[6h]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate6h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[1d]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[1d]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate1d
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-upload"}[4d]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-upload"}[4d]))
       labels:
         route: telemeter-server-upload
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: haproxy_server_http_responses:burnrate4d
     - alert: TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
@@ -89,6 +98,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         route: telemeter-server-upload
+        service: telemeter
         severity: high
         short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
@@ -105,6 +115,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         route: telemeter-server-upload
+        service: telemeter
         severity: high
         short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
@@ -121,6 +132,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         route: telemeter-server-upload
+        service: telemeter
         severity: warning
         short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
@@ -137,6 +149,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         route: telemeter-server-upload
+        service: telemeter
         severity: warning
         short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
@@ -171,6 +184,7 @@ spec:
     - expr: sum by(code) (increase(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[4w]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:increase4w
     - alert: SLOMetricAbsent
@@ -184,6 +198,7 @@ spec:
       for: 2m
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         severity: high
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
   - interval: 30s
@@ -193,42 +208,49 @@ spec:
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[5m]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate5m
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[30m]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[30m]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate30m
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[1h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[1h]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate1h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[2h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[2h]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate2h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[6h]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[6h]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate6h
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[1d]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[1d]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate1d
     - expr: sum by(code) (rate(haproxy_server_http_responses_total{code=~"5..",route="telemeter-server-metrics-v1-receive"}[4d]))
         / sum by(code) (rate(haproxy_server_http_responses_total{code!~"^4..$",route="telemeter-server-metrics-v1-receive"}[4d]))
       labels:
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: haproxy_server_http_responses:burnrate4d
     - alert: TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
@@ -244,6 +266,7 @@ spec:
       labels:
         long_burnrate_window: 1h
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         severity: high
         short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
@@ -260,6 +283,7 @@ spec:
       labels:
         long_burnrate_window: 6h
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         severity: high
         short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
@@ -276,6 +300,7 @@ spec:
       labels:
         long_burnrate_window: 1d
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         severity: warning
         short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
@@ -292,6 +317,7 @@ spec:
       labels:
         long_burnrate_window: 4d
         route: telemeter-server-metrics-v1-receive
+        service: telemeter
         severity: warning
         short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
@@ -327,6 +353,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",handler="upload",job="telemeter-server",le="5"}[4w]))
@@ -334,6 +361,7 @@ spec:
         handler: upload
         job: telemeter-server
         le: "5"
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -348,6 +376,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         severity: high
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
     - alert: SLOMetricAbsent
@@ -363,6 +392,7 @@ spec:
         handler: upload
         job: telemeter-server
         le: "5"
+        service: telemeter
         severity: high
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
   - interval: 30s
@@ -374,6 +404,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[30m]))
@@ -382,6 +413,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[1h]))
@@ -390,6 +422,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[2h]))
@@ -398,6 +431,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[6h]))
@@ -406,6 +440,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[1d]))
@@ -414,6 +449,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="upload",job="telemeter-server"}[4d]))
@@ -422,6 +458,7 @@ spec:
       labels:
         handler: upload
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: TelemeterServerMetricsUploadWriteLatencyErrorBudgetBurning
@@ -438,6 +475,7 @@ spec:
         handler: upload
         job: telemeter-server
         long_burnrate_window: 1h
+        service: telemeter
         severity: high
         short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -455,6 +493,7 @@ spec:
         handler: upload
         job: telemeter-server
         long_burnrate_window: 6h
+        service: telemeter
         severity: high
         short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -472,6 +511,7 @@ spec:
         handler: upload
         job: telemeter-server
         long_burnrate_window: 1d
+        service: telemeter
         severity: warning
         short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -489,6 +529,7 @@ spec:
         handler: upload
         job: telemeter-server
         long_burnrate_window: 4d
+        service: telemeter
         severity: warning
         short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -524,6 +565,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",handler="receive",job="telemeter-server",le="5"}[4w]))
@@ -531,6 +573,7 @@ spec:
         handler: receive
         job: telemeter-server
         le: "5"
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -545,6 +588,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         severity: high
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
     - alert: SLOMetricAbsent
@@ -560,6 +604,7 @@ spec:
         handler: receive
         job: telemeter-server
         le: "5"
+        service: telemeter
         severity: high
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
   - interval: 30s
@@ -571,6 +616,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[30m]))
@@ -579,6 +625,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[1h]))
@@ -587,6 +634,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[2h]))
@@ -595,6 +643,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[6h]))
@@ -603,6 +652,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[1d]))
@@ -611,6 +661,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",handler="receive",job="telemeter-server"}[4d]))
@@ -619,6 +670,7 @@ spec:
       labels:
         handler: receive
         job: telemeter-server
+        service: telemeter
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: TelemeterServerMetricsReceiveWriteLatencyErrorBudgetBurning
@@ -635,6 +687,7 @@ spec:
         handler: receive
         job: telemeter-server
         long_burnrate_window: 1h
+        service: telemeter
         severity: high
         short_burnrate_window: 5m
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -652,6 +705,7 @@ spec:
         handler: receive
         job: telemeter-server
         long_burnrate_window: 6h
+        service: telemeter
         severity: high
         short_burnrate_window: 30m
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -669,6 +723,7 @@ spec:
         handler: receive
         job: telemeter-server
         long_burnrate_window: 1d
+        service: telemeter
         severity: warning
         short_burnrate_window: 2h
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -686,6 +741,7 @@ spec:
         handler: receive
         job: telemeter-server
         long_burnrate_window: 4d
+        service: telemeter
         severity: warning
         short_burnrate_window: 6h
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -722,6 +778,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -737,6 +794,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         severity: high
         slo: api-metrics-write-availability-slo
   - interval: 30s
@@ -748,6 +806,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[30m]))
@@ -756,6 +815,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1h]))
@@ -764,6 +824,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[2h]))
@@ -772,6 +833,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[6h]))
@@ -780,6 +842,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1d]))
@@ -788,6 +851,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[4d]))
@@ -796,6 +860,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsWriteAvailabilityErrorBudgetBurning
@@ -813,6 +878,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-receive
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-write-availability-slo
@@ -831,6 +897,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-receive
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-write-availability-slo
@@ -849,6 +916,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-availability-slo
@@ -867,6 +935,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-availability-slo
@@ -903,6 +972,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -918,6 +988,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-query-availability-slo
   - interval: 30s
@@ -929,6 +1000,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[30m]))
@@ -937,6 +1009,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1h]))
@@ -945,6 +1018,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[2h]))
@@ -953,6 +1027,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[6h]))
@@ -961,6 +1036,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[1d]))
@@ -969,6 +1045,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query",job="observatorium-observatorium-api"}[4d]))
@@ -977,6 +1054,7 @@ spec:
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryAvailabilityErrorBudgetBurning
@@ -994,6 +1072,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-query-availability-slo
@@ -1012,6 +1091,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-query-availability-slo
@@ -1030,6 +1110,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-availability-slo
@@ -1048,6 +1129,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-availability-slo
@@ -1084,6 +1166,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1099,6 +1182,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
@@ -1110,6 +1194,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[30m]))
@@ -1118,6 +1203,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[1h]))
@@ -1126,6 +1212,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[2h]))
@@ -1134,6 +1221,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[6h]))
@@ -1142,6 +1230,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[1d]))
@@ -1150,6 +1239,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api"}[4d]))
@@ -1158,6 +1248,7 @@ spec:
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
+        service: observatorium-thanos-query
         slo: api-metrics-query-range-availability-slo
       record: http_requests:burnrate4d
     - alert: APIMetricsQueryRangeAvailabilityErrorBudgetBurning
@@ -1175,6 +1266,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-query-range-availability-slo
@@ -1193,6 +1285,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-query-range-availability-slo
@@ -1211,6 +1304,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-query-range-availability-slo
@@ -1229,6 +1323,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-query-range-availability-slo
@@ -1266,6 +1361,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1282,6 +1378,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         severity: high
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
@@ -1294,6 +1391,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[30m]))
@@ -1303,6 +1401,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[1h]))
@@ -1312,6 +1411,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[2h]))
@@ -1321,6 +1421,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[6h]))
@@ -1330,6 +1431,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[1d]))
@@ -1339,6 +1441,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT"}[4d]))
@@ -1348,6 +1451,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: PUT
+        service: observatorium-api
         slo: api-rules-raw-write-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesRawWriteAvailabilityErrorBudgetBurning
@@ -1366,6 +1470,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
         method: PUT
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-raw-write-availability-slo
@@ -1385,6 +1490,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
         method: PUT
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-raw-write-availability-slo
@@ -1404,6 +1510,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
         method: PUT
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-raw-write-availability-slo
@@ -1423,6 +1530,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
         method: PUT
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-raw-write-availability-slo
@@ -1460,6 +1568,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1476,6 +1585,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         severity: high
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
@@ -1488,6 +1598,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[30m]))
@@ -1497,6 +1608,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[1h]))
@@ -1506,6 +1618,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[2h]))
@@ -1515,6 +1628,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[6h]))
@@ -1524,6 +1638,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[1d]))
@@ -1533,6 +1648,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET"}[4d]))
@@ -1542,6 +1658,7 @@ spec:
         handler: rules-raw
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-api
         slo: api-rules-raw-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesRawReadAvailabilityErrorBudgetBurning
@@ -1560,6 +1677,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
         method: GET
+        service: observatorium-api
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-raw-read-availability-slo
@@ -1579,6 +1697,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
         method: GET
+        service: observatorium-api
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-raw-read-availability-slo
@@ -1598,6 +1717,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
         method: GET
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-raw-read-availability-slo
@@ -1617,6 +1737,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
         method: GET
+        service: observatorium-api
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-raw-read-availability-slo
@@ -1654,6 +1775,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1670,6 +1792,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         severity: high
         slo: api-rules-read-availability-slo
   - interval: 30s
@@ -1682,6 +1805,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate5m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[30m]))
@@ -1691,6 +1815,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate30m
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[1h]))
@@ -1700,6 +1825,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[2h]))
@@ -1709,6 +1835,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate2h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[6h]))
@@ -1718,6 +1845,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate6h
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[1d]))
@@ -1727,6 +1855,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate1d
     - expr: sum by(code) (rate(http_requests_total{code=~"^5..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET"}[4d]))
@@ -1736,6 +1865,7 @@ spec:
         handler: rules
         job: observatorium-observatorium-api
         method: GET
+        service: observatorium-thanos-ruler
         slo: api-rules-read-availability-slo
       record: http_requests:burnrate4d
     - alert: APIRulesReadAvailabilityErrorBudgetBurning
@@ -1754,6 +1884,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
         method: GET
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-read-availability-slo
@@ -1773,6 +1904,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
         method: GET
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-read-availability-slo
@@ -1792,6 +1924,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
         method: GET
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-read-availability-slo
@@ -1811,6 +1944,7 @@ spec:
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
         method: GET
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-read-availability-slo
@@ -1847,6 +1981,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:increase4w
     - alert: SLOMetricAbsent
@@ -1862,6 +1997,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         severity: high
         slo: api-rules-sync-availability-slo
   - interval: 30s
@@ -1873,6 +2009,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate5m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[30m]))
@@ -1881,6 +2018,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate30m
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[1h]))
@@ -1889,6 +2027,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[2h]))
@@ -1897,6 +2036,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate2h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[6h]))
@@ -1905,6 +2045,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate6h
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[1d]))
@@ -1913,6 +2054,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate1d
     - expr: sum by(code) (rate(client_api_requests_total{client="reload",code=~"^5..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage"}[4d]))
@@ -1921,6 +2063,7 @@ spec:
         client: reload
         container: thanos-rule-syncer
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-rules-sync-availability-slo
       record: client_api_requests:burnrate4d
     - alert: APIRulesSyncAvailabilityErrorBudgetBurning
@@ -1938,6 +2081,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 5m
         slo: api-rules-sync-availability-slo
@@ -1956,6 +2100,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 30m
         slo: api-rules-sync-availability-slo
@@ -1974,6 +2119,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-rules-sync-availability-slo
@@ -1992,6 +2138,7 @@ spec:
         container: thanos-rule-syncer
         long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-rules-sync-availability-slo
@@ -2027,6 +2174,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:increase4w
     - alert: SLOMetricAbsent
@@ -2041,6 +2189,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         severity: high
         slo: api-alerting-availability-slo
   - interval: 30s
@@ -2051,6 +2200,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate5m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[30m]))
@@ -2058,6 +2208,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate30m
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[1h]))
@@ -2065,6 +2216,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[2h]))
@@ -2072,6 +2224,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate2h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[6h]))
@@ -2079,6 +2232,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate6h
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[1d]))
@@ -2086,6 +2240,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate1d
     - expr: sum by(code) (rate(thanos_alert_sender_alerts_dropped_total{code=~"^5..$",container="thanos-rule",namespace="observatorium-metrics-stage"}[4d]))
@@ -2093,6 +2248,7 @@ spec:
       labels:
         container: thanos-rule
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         slo: api-alerting-availability-slo
       record: thanos_alert_sender_alerts_dropped:burnrate4d
     - alert: APIAlertmanagerAvailabilityErrorBudgetBurning
@@ -2109,6 +2265,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 5m
         slo: api-alerting-availability-slo
@@ -2126,6 +2283,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         severity: high
         short_burnrate_window: 30m
         slo: api-alerting-availability-slo
@@ -2143,6 +2301,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 2h
         slo: api-alerting-availability-slo
@@ -2160,6 +2319,7 @@ spec:
         container: thanos-rule
         long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
+        service: observatorium-thanos-ruler
         severity: warning
         short_burnrate_window: 6h
         slo: api-alerting-availability-slo
@@ -2364,6 +2524,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - expr: sum by(code) (increase(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",le="5"}[4w]))
@@ -2372,6 +2533,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         le: "5"
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2387,6 +2549,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         severity: high
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
@@ -2403,6 +2566,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         le: "5"
+        service: observatorium-thanos-receive
         severity: high
         slo: api-metrics-write-latency-slo
   - interval: 30s
@@ -2415,6 +2579,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate5m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[30m]))
@@ -2424,6 +2589,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate30m
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1h]))
@@ -2433,6 +2599,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[2h]))
@@ -2442,6 +2609,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate2h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[6h]))
@@ -2451,6 +2619,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate6h
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[1d]))
@@ -2460,6 +2629,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate1d
     - expr: (sum(rate(http_request_duration_seconds_count{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api"}[4d]))
@@ -2469,6 +2639,7 @@ spec:
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
+        service: observatorium-thanos-receive
         slo: api-metrics-write-latency-slo
       record: http_request_duration_seconds:burnrate4d
     - alert: APIMetricsWriteLatencyErrorBudgetBurning
@@ -2486,6 +2657,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1h
+        service: observatorium-thanos-receive
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-write-latency-slo
@@ -2504,6 +2676,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 6h
+        service: observatorium-thanos-receive
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-write-latency-slo
@@ -2522,6 +2695,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 1d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-write-latency-slo
@@ -2540,6 +2714,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         long_burnrate_window: 4d
+        service: observatorium-thanos-receive
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-write-latency-slo
@@ -2575,6 +2750,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="10",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[4w]))
@@ -2582,6 +2758,7 @@ spec:
         le: "10"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2596,6 +2773,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
@@ -2611,6 +2789,7 @@ spec:
         le: "10"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
@@ -2622,6 +2801,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[30m]))
@@ -2630,6 +2810,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[1h]))
@@ -2638,6 +2819,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[2h]))
@@ -2646,6 +2828,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[6h]))
@@ -2654,6 +2837,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[1d]))
@@ -2662,6 +2846,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[4d]))
@@ -2670,6 +2855,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-1M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency1MErrorBudgetBurning
@@ -2686,6 +2872,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-1M-latency-slo
@@ -2703,6 +2890,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-1M-latency-slo
@@ -2720,6 +2908,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-1M-latency-slo
@@ -2737,6 +2926,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-1M-latency-slo
@@ -2772,6 +2962,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="30",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[4w]))
@@ -2779,6 +2970,7 @@ spec:
         le: "30"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2793,6 +2985,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
@@ -2808,6 +3001,7 @@ spec:
         le: "30"
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
@@ -2819,6 +3013,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[30m]))
@@ -2827,6 +3022,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[1h]))
@@ -2835,6 +3031,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[2h]))
@@ -2843,6 +3040,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[6h]))
@@ -2851,6 +3049,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[1d]))
@@ -2859,6 +3058,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-10M-samples"}[4d]))
@@ -2867,6 +3067,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-10M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency10MErrorBudgetBurning
@@ -2883,6 +3084,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-10M-latency-slo
@@ -2900,6 +3102,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-10M-latency-slo
@@ -2917,6 +3120,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-10M-latency-slo
@@ -2934,6 +3138,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-10M-latency-slo
@@ -2969,6 +3174,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - expr: sum by(code) (increase(up_custom_query_duration_seconds_bucket{code=~"^2..$",le="120",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[4w]))
@@ -2976,6 +3182,7 @@ spec:
         le: "120"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:increase4w
     - alert: SLOMetricAbsent
@@ -2990,6 +3197,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
@@ -3005,6 +3213,7 @@ spec:
         le: "120"
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
@@ -3016,6 +3225,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate5m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[30m]))
@@ -3024,6 +3234,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate30m
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[1h]))
@@ -3032,6 +3243,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[2h]))
@@ -3040,6 +3252,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate2h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[6h]))
@@ -3048,6 +3261,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate6h
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[1d]))
@@ -3056,6 +3270,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate1d
     - expr: (sum(rate(up_custom_query_duration_seconds_count{code=~"^2..$",namespace="observatorium-stage",query="query-path-sli-1M-samples"}[4d]))
@@ -3064,6 +3279,7 @@ spec:
       labels:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         slo: api-metrics-read-100M-latency-slo
       record: up_custom_query_duration_seconds:burnrate4d
     - alert: APIMetricsReadLatency100MErrorBudgetBurning
@@ -3080,6 +3296,7 @@ spec:
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 5m
         slo: api-metrics-read-100M-latency-slo
@@ -3097,6 +3314,7 @@ spec:
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: high
         short_burnrate_window: 30m
         slo: api-metrics-read-100M-latency-slo
@@ -3114,6 +3332,7 @@ spec:
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 2h
         slo: api-metrics-read-100M-latency-slo
@@ -3131,6 +3350,7 @@ spec:
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
+        service: observatorium-thanos-query
         severity: warning
         short_burnrate_window: 6h
         slo: api-metrics-read-100M-latency-slo


### PR DESCRIPTION
Add service label, which is required in App-interface spec, to our SLO rules
Also, prune client, le and container labels
