### PR TITLE
add thanos receive limits configmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ migrate-vendor:
 manifests: migrate-vendor format $(JSONNET_VENDOR_DIR)
 manifests: resources/services/telemeter-template.yaml resources/services/jaeger-template.yaml resources/services/parca-template.yaml tests/minio-template.yaml tests/dex-template.yaml
 manifests: resources/services/observatorium-template.yaml resources/services/observatorium-metrics-template.yaml resources/services/observatorium-logs-template.yaml resources/services/observatorium-traces-subscriptions-template.yaml resources/services/observatorium-traces-template.yaml resources/crds/observatorium-logs-crds-template.yaml
-manifests: resources/services/metric-federation-rule-template.yaml
+manifests: resources/services/metric-federation-rule-template.yaml resources/services/observatorium-metrics-limits-template.yaml
 	$(MAKE) clean
 
 resources/services/parca-template.yaml: $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
@@ -154,6 +154,10 @@ resources/services/telemeter-template.yaml: $(wildcard services/telemeter-*) $(J
 resources/services/observatorium-tenants-template.yaml: services/observatorium-tenants-template.jsonnet $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
 	@echo ">>>>> Running observatorium mst tenants templates"
 	$(JSONNET) -J vendor services/observatorium-tenants-template.jsonnet | $(GOJSONTOYAML) > $@
+
+resources/services/observatorium-metrics-limits-template.yaml: services/observatorium-metrics-limits-template.jsonnet $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
+	@echo ">>>>> Running observatorium mst receive limits templates"
+	$(JSONNET) -J vendor services/observatorium-metrics-limits-template.jsonnet | $(GOJSONTOYAML) > $@
 
 resources/services/observatorium-template.yaml: resources/.tmp/tenants/rbac.json services/observatorium.libsonnet services/observatorium-template.jsonnet $(JSONNET) $(GOJSONTOYAML) $(JSONNETFMT)
 	@echo ">>>>> Running observatorium templates"

--- a/resources/services/observatorium-metrics-limits-template.yaml
+++ b/resources/services/observatorium-metrics-limits-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   annotations:

--- a/resources/services/observatorium-metrics-limits-template.yaml
+++ b/resources/services/observatorium-metrics-limits-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Template
+metadata:
+  annotations:
+    qontract.recycle: "true"
+  name: ${CONFIGMAP_NAME}
+objects:
+- apiVersion: v1
+  data:
+    receive.limits.yaml: ${{RECEIVE_LIMITS}}
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    name: ${CONFIGMAP_NAME}
+parameters:
+- name: CONFIGMAP_NAME
+- description: The Thanos-Receive limits configuration
+  name: RECEIVE_LIMITS

--- a/services/observatorium-metrics-limits-template.jsonnet
+++ b/services/observatorium-metrics-limits-template.jsonnet
@@ -1,0 +1,29 @@
+{
+  apiVersion: 'v1',
+  kind: 'Template',
+  metadata: {
+    name: '${CONFIGMAP_NAME}',
+    annotations: {
+      'qontract.recycle': 'true',
+    },
+  },
+  objects: [
+    {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata+: {
+        name: '${CONFIGMAP_NAME}',
+        annotations: {
+          'qontract.recycle': 'true',
+        },
+      },
+      data: {
+        'receive.limits.yaml': '${{RECEIVE_LIMITS}}',
+      },
+    },
+  ],
+  parameters: [
+    { name: 'CONFIGMAP_NAME' },
+    { name: 'RECEIVE_LIMITS', description: 'The Thanos-Receive limits configuration' },
+  ],
+}

--- a/services/observatorium-metrics-limits-template.jsonnet
+++ b/services/observatorium-metrics-limits-template.jsonnet
@@ -1,5 +1,5 @@
 {
-  apiVersion: 'v1',
+  apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
   metadata: {
     name: '${CONFIGMAP_NAME}',


### PR DESCRIPTION
Adds an openshift template for generating thanos receive limits configmap.

Couldn't do something fancier than that. Was unable to embed yaml in yaml. The whole configuration must be embedded into the RECEIVE_LIMITS parameter. 
But does the job.