### PR TITLE
Add support to deploy meta monitoring via launch script

### DIFF
--- a/services/minio-template.jsonnet
+++ b/services/minio-template.jsonnet
@@ -15,6 +15,7 @@ local minio = (import 'github.com/observatorium/observatorium/configuration/comp
         spec+: {
           containers: [
             super.containers[0] {
+              image: '${IMAGE}:${IMAGE_TAG}',
               resources: {
                 requests: {
                   cpu: '${MINIO_CPU_REQUEST}',
@@ -59,7 +60,7 @@ local minio = (import 'github.com/observatorium/observatorium/configuration/comp
   parameters: [
     { name: 'NAMESPACE', value: 'minio' },
     { name: 'IMAGE', value: 'minio/minio' },
-    { name: 'IMAGE_TAG', value: 'RELEASE.2021-09-09T21-37-07Z' },
+    { name: 'IMAGE_TAG', value: 'RELEASE.2023-05-27T05-56-19Z' },
     { name: 'REPLICAS', value: '1' },
     { name: 'MINIO_CPU_REQUEST', value: '100m' },
     { name: 'MINIO_MEMORY_REQUEST', value: '200Mi' },

--- a/tests/clusterlogforwader.yaml
+++ b/tests/clusterlogforwader.yaml
@@ -1,0 +1,24 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  inputs:
+  - application:
+      namespaces:
+      - observatorium-metrics
+      - telemeter
+      - observatorium-logs
+      - observatorium
+    name: send-observatorium-app-logs
+  outputs:
+  - name: loki-app
+    type: loki
+    url: https://observatorium-lokistack-gateway-http.observatorium-tools.svc.cluster.local:8080/api/logs/v1/application
+  pipelines:
+  - inputRefs:
+    - send-observatorium-app-logs
+    name: observatorium-app-logs
+    outputRefs:
+    - loki-app

--- a/tests/clusterlogging.yaml
+++ b/tests/clusterlogging.yaml
@@ -1,0 +1,11 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  collection:
+    logs:
+      fluentd: {}
+      type: vector
+  managementState: Managed

--- a/tests/logging-operator.yaml
+++ b/tests/logging-operator.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  targetNamespaces:
+  - openshift-logging
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: "stable-5.6"
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+

--- a/tests/logging.test.env
+++ b/tests/logging.test.env
@@ -1,0 +1,8 @@
+NAMESPACE=observatorium-tools
+ACCESS_KEY_ID=minio
+SECRET_ACCESS_KEY=minio123
+S3_BUCKET_NAME=loki
+S3_BUCKET_ENDPOINT=http://minio.minio.svc.cluster.local:9000
+S3_BUCKET_REGION=""
+LOKI_SIZE=1x.extra-small
+LOKI_STORAGE_CLASS=gp2-csi

--- a/tests/loki-operator.yaml
+++ b/tests/loki-operator.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: operator-group
+  namespace: openshift-operators-redhat
+spec:
+  targetNamespaces:
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: loki-operator
+  namespace: openshift-operators-redhat
+spec:
+  channel: stable-5.6
+  installPlanApproval: Automatic
+  name: loki-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/tests/minio-template.yaml
+++ b/tests/minio-template.yaml
@@ -31,7 +31,7 @@ objects:
             value: ${MINIO_ACCESS_KEY}
           - name: MINIO_ROOT_PASSWORD
             value: ${MINIO_SECRET_KEY}
-          image: minio/minio:RELEASE.2021-09-09T21-37-07Z
+          image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           name: minio
           ports:
@@ -80,7 +80,7 @@ parameters:
 - name: IMAGE
   value: minio/minio
 - name: IMAGE_TAG
-  value: RELEASE.2021-09-09T21-37-07Z
+  value: RELEASE.2023-05-27T05-56-19Z
 - name: REPLICAS
   value: "1"
 - name: MINIO_CPU_REQUEST

--- a/tests/observatorium-tools-network-policy.yaml
+++ b/tests/observatorium-tools-network-policy.yaml
@@ -1,0 +1,43 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-ingress-namespace
+  namespace: observatorium-tools
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+  policyTypes:
+  - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-openshift-logging-namespace
+  namespace: observatorium-tools
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-logging
+  policyTypes:
+  - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-same-namespace
+  namespace: observatorium-tools
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  policyTypes:
+  - Ingress
+


### PR DESCRIPTION
This PR:
* Add support to deploy Loki stack via launch script on any OCP cluster.
* Add support to deploy prerequisites like OpenShift logging and Loki operator required for meta-monitoring template.
* Add support to deploy `clusterlogging` and `clusterlogforwarder` as part of meta monitoring stack.