### PR TITLE
rbac: Roll out config for readonly SA for hypershift-platform

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -223,6 +223,17 @@ func GenerateRBAC(gen *mimic.Generator) {
 		envs:    []env{productionEnv},
 	})
 
+	// hypershift
+	// Special request of extra read account.
+	// Ref: https://issues.redhat.com/browse/OHSS-22439
+	attachBinding(&obsRBAC, bindingOpts{
+		name:    "observatorium-hypershift-platform-read",
+		tenant:  hypershiftTenant,
+		signals: []signal{metricsSignal},
+		perms:   []rbac.Permission{rbac.Read}, // Read only.
+		envs:    []env{productionEnv},
+	})
+
 	// hypershift staging
 	// observatorium-hypershift-platform-staging is the only tenant that does not
 	// follow conventions, due to them being present in an unique environment alongside
@@ -232,6 +243,18 @@ func GenerateRBAC(gen *mimic.Generator) {
 		tenant:              hypershiftStagingTenant,
 		signals:             []signal{metricsSignal},
 		perms:               []rbac.Permission{rbac.Write, rbac.Read},
+		envs:                []env{productionEnv},
+		skipConventionCheck: true,
+	})
+
+	// hypershift staging
+	// Special request of extra read account.
+	// Ref: https://issues.redhat.com/browse/OHSS-22439
+	attachBinding(&obsRBAC, bindingOpts{
+		name:                "observatorium-hypershift-platform-staging-read",
+		tenant:              hypershiftStagingTenant,
+		signals:             []signal{metricsSignal},
+		perms:               []rbac.Permission{rbac.Read}, // Read only.
 		envs:                []env{productionEnv},
 		skipConventionCheck: true,
 	})

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -803,6 +803,12 @@ objects:
         "subjects":
         - "kind": "user"
           "name": "service-account-observatorium-hypershift-platform"
+      - "name": "observatorium-hypershift-platform-read"
+        "roles":
+        - "hypershift-platform-metrics-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-hypershift-platform-read"
       - "name": "observatorium-hypershift-platform-staging"
         "roles":
         - "hypershift-platform-staging-metrics-write"
@@ -810,6 +816,12 @@ objects:
         "subjects":
         - "kind": "user"
           "name": "service-account-observatorium-hypershift-platform-staging"
+      - "name": "observatorium-hypershift-platform-staging-read"
+        "roles":
+        - "hypershift-platform-staging-metrics-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-hypershift-platform-staging-read"
       - "name": "observatorium-dptp-reader"
         "roles":
         - "dptp-logs-read"


### PR DESCRIPTION
This adds rbac configuration for a readonly hypershift service account for https://issues.redhat.com/browse/OHSS-22439  