### PR TITLE
Add meta-monitoring template validation to CI

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -39,6 +39,8 @@ Currently, below RHOBS OpenShift templates are being processed and deployed:
 - `observatorium`
 - `parca`
 - `telemeter`
+- `observatorium-tools` 
+> :bulb: The launch script will take care of deploying necessary dependencies for `observatorium-tools` namespace like Logging Operator, Loki Operator, etc.
 
 For optimal use it is recommended to use a OpenShift cluster with more resources.
 

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -16,7 +16,7 @@ This document provides an overview of the CI implementation that has been set up
   - CPU requests/limit, Memory request/limits and PVC storage are decreased so that RHOBS can be deployed on smaller clusters.
   - Number of replicas for components is decreased as well in order for the deployment to not be too resource heavy.
   - Objects names like service accounts, storage classes, secrets are replaced to work with local environment.
-  > :bulb: **Tip:** These parameters can be edited accordingly and as per the requirement in `<namespace>.test.ci.env` files.
+  > :bulb: **Note:** These parameters can be edited accordingly and as per the requirement in `<namespace>.test.ci.env` files.
 
 ### Build Process
 - Whenever new code is pushed or new PR is created to rhobs/configuration CircleCI is triggered to build and test the manifests.
@@ -24,3 +24,4 @@ This document provides an overview of the CI implementation that has been set up
 - [ci_test.sh](https://github.com/rhobs/configuration/blob/main/tests/ci/ci_test.sh) takes care of deploying the manifests and running tests
 ### Limitations
 - Since some template parameters are overriden in order to make deployment smooth on CI, so sanity of those paramters are not done. For e.g defining 4Gi in cpu request and "4" memory request.
+- CI doesn't deploy the Loki operator for meta-monitoring templates. It deploys the necessary CRDs like Lokistack and then apply the template to verify syntactic errors.

--- a/tests/ci/ci_test.sh
+++ b/tests/ci/ci_test.sh
@@ -13,6 +13,7 @@ check_status() {
 prereq() {
     oc apply -f pre-requisites.yaml
     oc create -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/bundle.yaml
+    oc create -f https://raw.githubusercontent.com/grafana/loki/main/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
 }
 
 ns() {
@@ -51,6 +52,12 @@ observatorium_metrics() {
     oc process --param-file=observatorium-metric-federation-rule.test.ci.env \
         -f ../../resources/services/metric-federation-rule-template.yaml| \
         oc apply --namespace observatorium-metrics -f -
+}
+
+observatorium_tools(){
+    oc create ns observatorium-tools || true
+    oc apply --namespace observatorium-tools -f ../observatorium-tools-network-policy.yaml
+    oc process --param-file=logging.test.ci.env -f ../../resources/services/meta-monitoring/logging-template.yaml | oc apply --namespace observatorium-tools -f -
 }
 
 observatorium() {
@@ -152,6 +159,7 @@ ci.deploy() {
     observatorium_metrics
     telemeter
     observatorium_logs
+    observatorium_tools
 }
 
 ci.tests() {

--- a/tests/ci/logging.test.ci.env
+++ b/tests/ci/logging.test.ci.env
@@ -1,0 +1,8 @@
+NAMESPACE=observatorium-tools
+ACCESS_KEY_ID=minio
+SECRET_ACCESS_KEY=minio123
+S3_BUCKET_NAME=loki
+S3_BUCKET_ENDPOINT=http://minio.minio.svc.cluster.local:9000
+S3_BUCKET_REGION=""
+LOKI_SIZE=1x.extra-small
+LOKI_STORAGE_CLASS=kubevirt-hostpath-provisioner


### PR DESCRIPTION
This PR adds the meta-monitoring template validation on CI. Since it is not optimal to deploy the Loki operator and Logging operator on CI this deploys the necessary CRDs and processes the template against it for any syntactical errors.