### PR TITLE
receive: fix receive limits configmap generation

### DIFF
--- a/resources/services/observatorium-metrics-limits-template.yaml
+++ b/resources/services/observatorium-metrics-limits-template.yaml
@@ -7,7 +7,7 @@ metadata:
 objects:
 - apiVersion: v1
   data:
-    receive.limits.yaml: ${{RECEIVE_LIMITS}}
+    receive.limits.yaml: ${RECEIVE_LIMITS}
   kind: ConfigMap
   metadata:
     annotations:

--- a/services/observatorium-metrics-limits-template.jsonnet
+++ b/services/observatorium-metrics-limits-template.jsonnet
@@ -18,7 +18,7 @@
         },
       },
       data: {
-        'receive.limits.yaml': '${{RECEIVE_LIMITS}}',
+        'receive.limits.yaml': '${RECEIVE_LIMITS}',
       },
     },
   ],


### PR DESCRIPTION
Using double curly braces fails on app-sre side. It expects a json as parameter and fails otherwise.
Changing to single curly braces. As per my tests, openshift template correctly generates multiline string in resulting configmap for the RECEIVE_LIMITS parameter.