### PR TITLE
rbac: Add hypershift QE SA to hypershift readonly roles

### DIFF
--- a/configuration/observatorium/rbac.go
+++ b/configuration/observatorium/rbac.go
@@ -234,6 +234,17 @@ func GenerateRBAC(gen *mimic.Generator) {
 		envs:    []env{productionEnv},
 	})
 
+	// hypershift
+	// Special request of extra read account
+	// Ref: https://issues.redhat.com/browse/OHSS-22439
+	attachBinding(&obsRBAC, bindingOpts{
+		name:    "observatorium-hypershift-platform-qe-read",
+		tenant:  hypershiftTenant,
+		signals: []signal{metricsSignal},
+		perms:   []rbac.Permission{rbac.Read}, // Read only.
+		envs:    []env{productionEnv},
+	})
+
 	// hypershift staging
 	// observatorium-hypershift-platform-staging is the only tenant that does not
 	// follow conventions, due to them being present in an unique environment alongside
@@ -252,6 +263,17 @@ func GenerateRBAC(gen *mimic.Generator) {
 	// Ref: https://issues.redhat.com/browse/OHSS-22439
 	attachBinding(&obsRBAC, bindingOpts{
 		name:                "observatorium-hypershift-platform-staging-read",
+		tenant:              hypershiftStagingTenant,
+		signals:             []signal{metricsSignal},
+		perms:               []rbac.Permission{rbac.Read}, // Read only.
+		envs:                []env{productionEnv},
+		skipConventionCheck: true,
+	})
+
+	// hypershift staging
+	// Ref: https://issues.redhat.com/browse/OHSS-22439
+	attachBinding(&obsRBAC, bindingOpts{
+		name:                "observatorium-hypershift-platform-staging-qe-read",
 		tenant:              hypershiftStagingTenant,
 		signals:             []signal{metricsSignal},
 		perms:               []rbac.Permission{rbac.Read}, // Read only.

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -809,6 +809,12 @@ objects:
         "subjects":
         - "kind": "user"
           "name": "service-account-observatorium-hypershift-platform-read"
+      - "name": "observatorium-hypershift-platform-qe-read"
+        "roles":
+        - "hypershift-platform-metrics-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-hypershift-platform-qe-read"
       - "name": "observatorium-hypershift-platform-staging"
         "roles":
         - "hypershift-platform-staging-metrics-write"
@@ -822,6 +828,12 @@ objects:
         "subjects":
         - "kind": "user"
           "name": "service-account-observatorium-hypershift-platform-staging-read"
+      - "name": "observatorium-hypershift-platform-staging-qe-read"
+        "roles":
+        - "hypershift-platform-staging-metrics-read"
+        "subjects":
+        - "kind": "user"
+          "name": "service-account-observatorium-hypershift-platform-staging-qe-read"
       - "name": "observatorium-dptp-reader"
         "roles":
         - "dptp-logs-read"


### PR DESCRIPTION
This adds rbac configuration for a readonly hypershift service account for the hypershift qe team https://issues.redhat.com/browse/OHSS-22439 