### PR TITLE
Fixing neverFiringAlerts to return false expression

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -485,7 +485,7 @@ objects:
         annotations:
           description: Does not fire!
           message: Alert not fired.
-        expr: vector(0)
+        expr: vector(0) = 1
         for: 1m
         labels:
           severity: page
@@ -496,7 +496,7 @@ objects:
         labels:
           test: slo-record
         record: AlwaysRecord
-      - expr: vector(0)
+      - expr: vector(0) = 1
         labels:
           test: slo-record
         record: NeverRecord

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -257,7 +257,7 @@ local obsctlReloader = (import 'github.com/rhobs/obsctl-reloader/jsonnet/lib/obs
             },
             {
               alert: 'NeverFiringAlert',
-              expr: 'vector(0)',
+              expr: 'vector(0) = 1',
               'for': '1m',
               annotations: {
                 description: 'Does not fire!',
@@ -282,7 +282,7 @@ local obsctlReloader = (import 'github.com/rhobs/obsctl-reloader/jsonnet/lib/obs
             },
             {
               record: 'NeverRecord',
-              expr: 'vector(0)',
+              expr: 'vector(0) = 1',
               labels: {
                 test: 'slo-record',
               },


### PR DESCRIPTION
Currently the `NeverFiring` alerts always fire as `vector(0)` returns a single sample (of value `0`), this fixes that. 