### PR TITLE
RHOBS-781: Reducing error budget SLO alerts to 95% from 99.5%

### DIFF
--- a/configuration/observatorium/slo.go
+++ b/configuration/observatorium/slo.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	globalSLOWindowDuration                   = "28d"  // Window over which all RHOBS SLOs are calculated.
-	globalMetricsSLOAvailabilityTargetPercent = "99.5" // The Availability Target percentage for RHOBS metrics availability SLOs.
-	globalLogsSLOAvailabilityTargetPercent    = "95"   // The Availability Target percentage for RHOBS logs availability SLOs.
-	globalSLOLatencyTargetPercent             = "90"   // The Latency Target percentage for RHOBS latency SLOs.
-	genericSLOLatencySeconds                  = "5"    // Latency request duration to measure percentile target (this is diff for query SLOs).
+	globalSLOWindowDuration                   = "28d" // Window over which all RHOBS SLOs are calculated.
+	globalMetricsSLOAvailabilityTargetPercent = "95"  // The Availability Target percentage for RHOBS metrics availability SLOs.
+	globalLogsSLOAvailabilityTargetPercent    = "95"  // The Availability Target percentage for RHOBS logs availability SLOs.
+	globalSLOLatencyTargetPercent             = "90"  // The Latency Target percentage for RHOBS latency SLOs.
+	genericSLOLatencySeconds                  = "5"   // Latency request duration to measure percentile target (this is diff for query SLOs).
 )
 
 // rhobsInstanceEnv represents a particular RHOBS Instance environment.

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-alerting-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: thanos_alert_sender_alerts_dropped_total{container="thanos-rule",
           namespace="observatorium-mst-production", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-alerting-notif-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-alerting-notif-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: alertmanager_notifications_failed_total{service="observatorium-alertmanager",
           namespace="observatorium-mst-production", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="query",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-query-range-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="query_range",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-write-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="receive",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-rules-raw-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-rules-raw-read-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="rules-raw",
           method="GET", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-rules-raw-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-rules-raw-write-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="rules-raw",
           method="PUT", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-rules-read-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="rules",
           method="GET", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-rules-sync-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: client_api_requests_total{client="reload", container="thanos-rule-syncer",
           namespace="observatorium-mst-production", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-alerting-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: thanos_alert_sender_alerts_dropped_total{container="thanos-rule",
           namespace="observatorium-mst-stage", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-alerting-notif-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-alerting-notif-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: alertmanager_notifications_failed_total{service="observatorium-alertmanager",
           namespace="observatorium-mst-stage", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="query",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-query-range-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="query_range",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-write-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="receive",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-raw-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-raw-read-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="rules-raw",
           method="GET", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-raw-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-raw-write-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="rules-raw",
           method="PUT", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-read-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="rules",
           method="GET", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-rules-sync-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: client_api_requests_total{client="reload", container="thanos-rule-syncer",
           namespace="observatorium-mst-stage", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-alerting-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: thanos_alert_sender_alerts_dropped_total{container="thanos-rule",
           namespace="observatorium-mst-production", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-alerting-notif-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-alerting-notif-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: alertmanager_notifications_failed_total{service="observatorium-alertmanager",
           namespace="observatorium-mst-production", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="query",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-query-range-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="query_range",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-write-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="receive",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-raw-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-raw-read-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="rules-raw",
           method="GET", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-raw-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-raw-write-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="rules-raw",
           method="PUT", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-read-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-mst-api", handler="rules",
           method="GET", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-rules-sync-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: client_api_requests_total{client="reload", container="thanos-rule-syncer",
           namespace="observatorium-mst-production", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-alerting-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: thanos_alert_sender_alerts_dropped_total{container="thanos-rule",
           namespace="observatorium-metrics-production", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-alerting-notif-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-alerting-notif-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: alertmanager_notifications_failed_total{service="observatorium-alertmanager",
           namespace="observatorium-metrics-production", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="query",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-query-range-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="query_range",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-write-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="receive",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-raw-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-raw-read-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="rules-raw",
           method="GET", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-raw-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-raw-write-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="rules-raw",
           method="PUT", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-read-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="rules",
           method="GET", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-rules-sync-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: client_api_requests_total{client="reload", container="thanos-rule-syncer",
           namespace="observatorium-metrics-production", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-receive-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-receive-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",
           code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-upload-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-rhobs-telemeter-server-metrics-upload-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: haproxy_server_http_responses_total{route="telemeter-server-upload",
           code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-alerting-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-alerting-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: thanos_alert_sender_alerts_dropped_total{container="thanos-rule",
           namespace="observatorium-metrics-stage", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-alerting-notif-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-alerting-notif-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: alertmanager_notifications_failed_total{service="observatorium-alertmanager",
           namespace="observatorium-metrics-stage", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="query",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-range-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-query-range-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="query_range",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-write-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="receive",
           group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-raw-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-raw-read-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="rules-raw",
           method="GET", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-raw-write-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-raw-write-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="rules-raw",
           method="PUT", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-read-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-read-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: http_requests_total{job="observatorium-observatorium-api", handler="rules",
           method="GET", group="metricsv1", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-sync-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-rules-sync-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: client_api_requests_total{client="reload", container="thanos-rule-syncer",
           namespace="observatorium-metrics-stage", code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-receive-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-receive-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: haproxy_server_http_responses_total{route="telemeter-server-metrics-v1-receive",
           code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-upload-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-rhobs-telemeter-server-metrics-upload-availability-slo.yaml
@@ -25,6 +25,6 @@ spec:
       total:
         metric: haproxy_server_http_responses_total{route="telemeter-server-upload",
           code!~"^4..$"}
-  target: "99.5"
+  target: "95"
   window: 28d
 status: {}

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -110,8 +110,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -129,8 +129,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -148,8 +148,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -167,8 +167,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -182,7 +182,7 @@ spec:
   - interval: 30s
     name: api-metrics-write-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-write-availability-slo
       record: pyrra_objective
@@ -304,8 +304,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -323,8 +323,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -342,8 +342,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -361,8 +361,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -376,7 +376,7 @@ spec:
   - interval: 30s
     name: api-metrics-query-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-query-availability-slo
       record: pyrra_objective
@@ -498,8 +498,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -517,8 +517,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -536,8 +536,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -555,8 +555,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -570,7 +570,7 @@ spec:
   - interval: 30s
     name: api-metrics-query-range-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-query-range-availability-slo
       record: pyrra_objective
@@ -701,8 +701,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -721,8 +721,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -741,8 +741,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -761,8 +761,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -777,7 +777,7 @@ spec:
   - interval: 30s
     name: api-rules-raw-write-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-raw-write-availability-slo
       record: pyrra_objective
@@ -908,8 +908,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -928,8 +928,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -948,8 +948,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -968,8 +968,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -984,7 +984,7 @@ spec:
   - interval: 30s
     name: api-rules-raw-read-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-raw-read-availability-slo
       record: pyrra_objective
@@ -1115,8 +1115,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1135,8 +1135,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1155,8 +1155,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1175,8 +1175,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1191,7 +1191,7 @@ spec:
   - interval: 30s
     name: api-rules-read-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-read-availability-slo
       record: pyrra_objective
@@ -1311,8 +1311,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate5m{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (14 * (1-0.995)) and client_api_requests:burnrate1h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and client_api_requests:burnrate1h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -1328,8 +1328,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate30m{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (7 * (1-0.995)) and client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -1345,8 +1345,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate2h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (2 * (1-0.995)) and client_api_requests:burnrate1d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and client_api_requests:burnrate1d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -1362,8 +1362,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (1 * (1-0.995)) and client_api_requests:burnrate4d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and client_api_requests:burnrate4d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -1375,7 +1375,7 @@ spec:
   - interval: 30s
     name: api-rules-sync-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-sync-availability-slo
       record: pyrra_objective
@@ -1487,8 +1487,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate5m{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (14 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate1h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate1h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -1504,8 +1504,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate30m{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (7 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -1521,8 +1521,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate2h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (2 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate1d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate1d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -1538,8 +1538,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (1 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate4d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate4d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -1551,7 +1551,7 @@ spec:
   - interval: 30s
     name: api-alerting-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-alerting-availability-slo
       record: pyrra_objective
@@ -1655,8 +1655,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate5m{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (14 * (1-0.995)) and alertmanager_notifications_failed:burnrate1h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and alertmanager_notifications_failed:burnrate1h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -1672,8 +1672,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate30m{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (7 * (1-0.995)) and alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -1689,8 +1689,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate2h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (2 * (1-0.995)) and alertmanager_notifications_failed:burnrate1d{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and alertmanager_notifications_failed:burnrate1d{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -1706,8 +1706,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (1 * (1-0.995)) and alertmanager_notifications_failed:burnrate4d{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and alertmanager_notifications_failed:burnrate4d{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -1719,7 +1719,7 @@ spec:
   - interval: 30s
     name: api-alerting-notif-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-alerting-notif-availability-slo
       record: pyrra_objective

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -110,8 +110,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -129,8 +129,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -148,8 +148,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -167,8 +167,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -182,7 +182,7 @@ spec:
   - interval: 30s
     name: api-metrics-write-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-write-availability-slo
       record: pyrra_objective
@@ -304,8 +304,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -323,8 +323,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -342,8 +342,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -361,8 +361,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -376,7 +376,7 @@ spec:
   - interval: 30s
     name: api-metrics-query-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-query-availability-slo
       record: pyrra_objective
@@ -498,8 +498,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -517,8 +517,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -536,8 +536,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -555,8 +555,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -570,7 +570,7 @@ spec:
   - interval: 30s
     name: api-metrics-query-range-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-query-range-availability-slo
       record: pyrra_objective
@@ -701,8 +701,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -721,8 +721,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -741,8 +741,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -761,8 +761,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -777,7 +777,7 @@ spec:
   - interval: 30s
     name: api-rules-raw-write-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-raw-write-availability-slo
       record: pyrra_objective
@@ -908,8 +908,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -928,8 +928,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -948,8 +948,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -968,8 +968,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -984,7 +984,7 @@ spec:
   - interval: 30s
     name: api-rules-raw-read-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-raw-read-availability-slo
       record: pyrra_objective
@@ -1115,8 +1115,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1135,8 +1135,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1155,8 +1155,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1175,8 +1175,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1191,7 +1191,7 @@ spec:
   - interval: 30s
     name: api-rules-read-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-read-availability-slo
       record: pyrra_objective
@@ -1311,8 +1311,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate5m{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
-        > (14 * (1-0.995)) and client_api_requests:burnrate1h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and client_api_requests:burnrate1h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -1328,8 +1328,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate30m{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
-        > (7 * (1-0.995)) and client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -1345,8 +1345,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate2h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
-        > (2 * (1-0.995)) and client_api_requests:burnrate1d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and client_api_requests:burnrate1d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -1362,8 +1362,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
-        > (1 * (1-0.995)) and client_api_requests:burnrate4d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and client_api_requests:burnrate4d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-stage",slo="api-rules-sync-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -1375,7 +1375,7 @@ spec:
   - interval: 30s
     name: api-rules-sync-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-sync-availability-slo
       record: pyrra_objective
@@ -1487,8 +1487,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate5m{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
-        > (14 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate1h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate1h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -1504,8 +1504,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate30m{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
-        > (7 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -1521,8 +1521,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate2h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
-        > (2 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate1d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate1d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -1538,8 +1538,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
-        > (1 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate4d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate4d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-stage",slo="api-alerting-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -1551,7 +1551,7 @@ spec:
   - interval: 30s
     name: api-alerting-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-alerting-availability-slo
       record: pyrra_objective
@@ -1655,8 +1655,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate5m{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (14 * (1-0.995)) and alertmanager_notifications_failed:burnrate1h{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and alertmanager_notifications_failed:burnrate1h{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -1672,8 +1672,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate30m{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (7 * (1-0.995)) and alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -1689,8 +1689,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate2h{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (2 * (1-0.995)) and alertmanager_notifications_failed:burnrate1d{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and alertmanager_notifications_failed:burnrate1d{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -1706,8 +1706,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (1 * (1-0.995)) and alertmanager_notifications_failed:burnrate4d{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and alertmanager_notifications_failed:burnrate4d{code!~"^4..$",namespace="observatorium-mst-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -1719,7 +1719,7 @@ spec:
   - interval: 30s
     name: api-alerting-notif-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-alerting-notif-availability-slo
       record: pyrra_objective

--- a/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
@@ -110,8 +110,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -129,8 +129,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -148,8 +148,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -167,8 +167,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",slo="api-metrics-write-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -182,7 +182,7 @@ spec:
   - interval: 30s
     name: api-metrics-write-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-write-availability-slo
       record: pyrra_objective
@@ -304,8 +304,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -323,8 +323,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -342,8 +342,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -361,8 +361,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-mst-api",slo="api-metrics-query-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -376,7 +376,7 @@ spec:
   - interval: 30s
     name: api-metrics-query-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-query-availability-slo
       record: pyrra_objective
@@ -498,8 +498,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -517,8 +517,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -536,8 +536,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -555,8 +555,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-mst-api",slo="api-metrics-query-range-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -570,7 +570,7 @@ spec:
   - interval: 30s
     name: api-metrics-query-range-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-query-range-availability-slo
       record: pyrra_objective
@@ -701,8 +701,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -721,8 +721,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -741,8 +741,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -761,8 +761,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -777,7 +777,7 @@ spec:
   - interval: 30s
     name: api-rules-raw-write-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-raw-write-availability-slo
       record: pyrra_objective
@@ -908,8 +908,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -928,8 +928,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -948,8 +948,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -968,8 +968,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -984,7 +984,7 @@ spec:
   - interval: 30s
     name: api-rules-raw-read-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-raw-read-availability-slo
       record: pyrra_objective
@@ -1115,8 +1115,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1135,8 +1135,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1155,8 +1155,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1175,8 +1175,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-mst-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1191,7 +1191,7 @@ spec:
   - interval: 30s
     name: api-rules-read-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-read-availability-slo
       record: pyrra_objective
@@ -1311,8 +1311,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate5m{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (14 * (1-0.995)) and client_api_requests:burnrate1h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and client_api_requests:burnrate1h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -1328,8 +1328,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate30m{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (7 * (1-0.995)) and client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -1345,8 +1345,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate2h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (2 * (1-0.995)) and client_api_requests:burnrate1d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and client_api_requests:burnrate1d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -1362,8 +1362,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (1 * (1-0.995)) and client_api_requests:burnrate4d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and client_api_requests:burnrate4d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-mst-production",slo="api-rules-sync-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -1375,7 +1375,7 @@ spec:
   - interval: 30s
     name: api-rules-sync-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-sync-availability-slo
       record: pyrra_objective
@@ -1487,8 +1487,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate5m{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (14 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate1h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate1h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -1504,8 +1504,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate30m{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (7 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -1521,8 +1521,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate2h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (2 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate1d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate1d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -1538,8 +1538,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (1 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate4d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate4d{code!~"^4..$",container="thanos-rule",namespace="observatorium-mst-production",slo="api-alerting-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -1551,7 +1551,7 @@ spec:
   - interval: 30s
     name: api-alerting-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-alerting-availability-slo
       record: pyrra_objective
@@ -1655,8 +1655,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate5m{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (14 * (1-0.995)) and alertmanager_notifications_failed:burnrate1h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and alertmanager_notifications_failed:burnrate1h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -1672,8 +1672,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate30m{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (7 * (1-0.995)) and alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -1689,8 +1689,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate2h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (2 * (1-0.995)) and alertmanager_notifications_failed:burnrate1d{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and alertmanager_notifications_failed:burnrate1d{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -1706,8 +1706,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (1 * (1-0.995)) and alertmanager_notifications_failed:burnrate4d{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and alertmanager_notifications_failed:burnrate4d{code!~"^4..$",namespace="observatorium-mst-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -1719,7 +1719,7 @@ spec:
   - interval: 30s
     name: api-alerting-notif-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-alerting-notif-availability-slo
       record: pyrra_objective

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -92,8 +92,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate5m{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (14 * (1-0.995)) and haproxy_server_http_responses:burnrate1h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and haproxy_server_http_responses:burnrate1h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -109,8 +109,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate30m{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (7 * (1-0.995)) and haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -126,8 +126,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate2h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (2 * (1-0.995)) and haproxy_server_http_responses:burnrate1d{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and haproxy_server_http_responses:burnrate1d{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -143,8 +143,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (1 * (1-0.995)) and haproxy_server_http_responses:burnrate4d{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and haproxy_server_http_responses:burnrate4d{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -156,7 +156,7 @@ spec:
   - interval: 30s
     name: rhobs-telemeter-server-metrics-upload-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: pyrra_objective
@@ -260,8 +260,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate5m{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (14 * (1-0.995)) and haproxy_server_http_responses:burnrate1h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and haproxy_server_http_responses:burnrate1h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -277,8 +277,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate30m{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (7 * (1-0.995)) and haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -294,8 +294,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate2h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (2 * (1-0.995)) and haproxy_server_http_responses:burnrate1d{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and haproxy_server_http_responses:burnrate1d{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -311,8 +311,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (1 * (1-0.995)) and haproxy_server_http_responses:burnrate4d{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and haproxy_server_http_responses:burnrate4d{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -324,7 +324,7 @@ spec:
   - interval: 30s
     name: rhobs-telemeter-server-metrics-receive-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: pyrra_objective
@@ -868,8 +868,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -887,8 +887,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -906,8 +906,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -925,8 +925,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -940,7 +940,7 @@ spec:
   - interval: 30s
     name: api-metrics-write-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-write-availability-slo
       record: pyrra_objective
@@ -1062,8 +1062,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1081,8 +1081,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1100,8 +1100,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1119,8 +1119,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1134,7 +1134,7 @@ spec:
   - interval: 30s
     name: api-metrics-query-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-query-availability-slo
       record: pyrra_objective
@@ -1256,8 +1256,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1275,8 +1275,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1294,8 +1294,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1313,8 +1313,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1328,7 +1328,7 @@ spec:
   - interval: 30s
     name: api-metrics-query-range-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-query-range-availability-slo
       record: pyrra_objective
@@ -1459,8 +1459,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1479,8 +1479,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1499,8 +1499,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1519,8 +1519,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1535,7 +1535,7 @@ spec:
   - interval: 30s
     name: api-rules-raw-write-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-raw-write-availability-slo
       record: pyrra_objective
@@ -1666,8 +1666,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1686,8 +1686,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1706,8 +1706,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1726,8 +1726,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1742,7 +1742,7 @@ spec:
   - interval: 30s
     name: api-rules-raw-read-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-raw-read-availability-slo
       record: pyrra_objective
@@ -1873,8 +1873,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1893,8 +1893,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1913,8 +1913,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1933,8 +1933,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1949,7 +1949,7 @@ spec:
   - interval: 30s
     name: api-rules-read-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-read-availability-slo
       record: pyrra_objective
@@ -2069,8 +2069,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate5m{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
-        > (14 * (1-0.995)) and client_api_requests:burnrate1h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and client_api_requests:burnrate1h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -2086,8 +2086,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate30m{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
-        > (7 * (1-0.995)) and client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -2103,8 +2103,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate2h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
-        > (2 * (1-0.995)) and client_api_requests:burnrate1d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and client_api_requests:burnrate1d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -2120,8 +2120,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
-        > (1 * (1-0.995)) and client_api_requests:burnrate4d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and client_api_requests:burnrate4d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-production",slo="api-rules-sync-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -2133,7 +2133,7 @@ spec:
   - interval: 30s
     name: api-rules-sync-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-sync-availability-slo
       record: pyrra_objective
@@ -2245,8 +2245,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate5m{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
-        > (14 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate1h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate1h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -2262,8 +2262,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate30m{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
-        > (7 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -2279,8 +2279,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate2h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
-        > (2 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate1d{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate1d{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -2296,8 +2296,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
-        > (1 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate4d{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate4d{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-production",slo="api-alerting-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -2309,7 +2309,7 @@ spec:
   - interval: 30s
     name: api-alerting-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-alerting-availability-slo
       record: pyrra_objective
@@ -2413,8 +2413,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate5m{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (14 * (1-0.995)) and alertmanager_notifications_failed:burnrate1h{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and alertmanager_notifications_failed:burnrate1h{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -2430,8 +2430,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate30m{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (7 * (1-0.995)) and alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -2447,8 +2447,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate2h{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (2 * (1-0.995)) and alertmanager_notifications_failed:burnrate1d{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and alertmanager_notifications_failed:burnrate1d{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -2464,8 +2464,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (1 * (1-0.995)) and alertmanager_notifications_failed:burnrate4d{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and alertmanager_notifications_failed:burnrate4d{code!~"^4..$",namespace="observatorium-metrics-production",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -2477,7 +2477,7 @@ spec:
   - interval: 30s
     name: api-alerting-notif-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-alerting-notif-availability-slo
       record: pyrra_objective

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -92,8 +92,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate5m{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (14 * (1-0.995)) and haproxy_server_http_responses:burnrate1h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and haproxy_server_http_responses:burnrate1h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -109,8 +109,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate30m{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (7 * (1-0.995)) and haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -126,8 +126,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate2h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (2 * (1-0.995)) and haproxy_server_http_responses:burnrate1d{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and haproxy_server_http_responses:burnrate1d{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -143,8 +143,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsUploadWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (1 * (1-0.995)) and haproxy_server_http_responses:burnrate4d{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and haproxy_server_http_responses:burnrate4d{code!~"^4..$",route="telemeter-server-upload",slo="rhobs-telemeter-server-metrics-upload-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -156,7 +156,7 @@ spec:
   - interval: 30s
     name: rhobs-telemeter-server-metrics-upload-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
       record: pyrra_objective
@@ -260,8 +260,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate5m{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (14 * (1-0.995)) and haproxy_server_http_responses:burnrate1h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and haproxy_server_http_responses:burnrate1h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -277,8 +277,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate30m{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (7 * (1-0.995)) and haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -294,8 +294,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate2h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (2 * (1-0.995)) and haproxy_server_http_responses:burnrate1d{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and haproxy_server_http_responses:burnrate1d{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -311,8 +311,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#TelemeterServerMetricsReceiveWriteAvailabilityErrorBudgetBurning
       expr: haproxy_server_http_responses:burnrate6h{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (1 * (1-0.995)) and haproxy_server_http_responses:burnrate4d{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and haproxy_server_http_responses:burnrate4d{code!~"^4..$",route="telemeter-server-metrics-v1-receive",slo="rhobs-telemeter-server-metrics-receive-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -324,7 +324,7 @@ spec:
   - interval: 30s
     name: rhobs-telemeter-server-metrics-receive-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
       record: pyrra_objective
@@ -868,8 +868,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -887,8 +887,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -906,8 +906,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -925,8 +925,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",slo="api-metrics-write-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -940,7 +940,7 @@ spec:
   - interval: 30s
     name: api-metrics-write-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-write-availability-slo
       record: pyrra_objective
@@ -1062,8 +1062,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1081,8 +1081,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1100,8 +1100,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1119,8 +1119,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query",job="observatorium-observatorium-api",slo="api-metrics-query-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1134,7 +1134,7 @@ spec:
   - interval: 30s
     name: api-metrics-query-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-query-availability-slo
       record: pyrra_objective
@@ -1256,8 +1256,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1275,8 +1275,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1294,8 +1294,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1313,8 +1313,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsQueryRangeAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="query_range",job="observatorium-observatorium-api",slo="api-metrics-query-range-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1328,7 +1328,7 @@ spec:
   - interval: 30s
     name: api-metrics-query-range-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-metrics-query-range-availability-slo
       record: pyrra_objective
@@ -1459,8 +1459,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1479,8 +1479,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1499,8 +1499,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1519,8 +1519,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawWriteAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="PUT",slo="api-rules-raw-write-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1535,7 +1535,7 @@ spec:
   - interval: 30s
     name: api-rules-raw-write-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-raw-write-availability-slo
       record: pyrra_objective
@@ -1666,8 +1666,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1686,8 +1686,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1706,8 +1706,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1726,8 +1726,8 @@ spec:
           to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesRawReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules-raw",job="observatorium-observatorium-api",method="GET",slo="api-rules-raw-read-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1742,7 +1742,7 @@ spec:
   - interval: 30s
     name: api-rules-raw-read-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-raw-read-availability-slo
       record: pyrra_objective
@@ -1873,8 +1873,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (14 * (1-0.995)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and http_requests:burnrate1h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         group: metricsv1
@@ -1893,8 +1893,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (7 * (1-0.995)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         group: metricsv1
@@ -1913,8 +1913,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (2 * (1-0.995)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and http_requests:burnrate1d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         group: metricsv1
@@ -1933,8 +1933,8 @@ spec:
           availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesReadAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (1 * (1-0.995)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and http_requests:burnrate4d{code!~"^4..$",group="metricsv1",handler="rules",job="observatorium-observatorium-api",method="GET",slo="api-rules-read-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         group: metricsv1
@@ -1949,7 +1949,7 @@ spec:
   - interval: 30s
     name: api-rules-read-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-read-availability-slo
       record: pyrra_objective
@@ -2069,8 +2069,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate5m{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
-        > (14 * (1-0.995)) and client_api_requests:burnrate1h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and client_api_requests:burnrate1h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -2086,8 +2086,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate30m{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
-        > (7 * (1-0.995)) and client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -2103,8 +2103,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate2h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
-        > (2 * (1-0.995)) and client_api_requests:burnrate1d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and client_api_requests:burnrate1d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -2120,8 +2120,8 @@ spec:
           guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIRulesSyncAvailabilityErrorBudgetBurning
       expr: client_api_requests:burnrate6h{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
-        > (1 * (1-0.995)) and client_api_requests:burnrate4d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and client_api_requests:burnrate4d{client="reload",code!~"^4..$",container="thanos-rule-syncer",namespace="observatorium-metrics-stage",slo="api-rules-sync-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -2133,7 +2133,7 @@ spec:
   - interval: 30s
     name: api-rules-sync-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-rules-sync-availability-slo
       record: pyrra_objective
@@ -2245,8 +2245,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate5m{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
-        > (14 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate1h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate1h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -2262,8 +2262,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate30m{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
-        > (7 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -2279,8 +2279,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate2h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
-        > (2 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate1d{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate1d{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -2296,8 +2296,8 @@ spec:
           too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerAvailabilityErrorBudgetBurning
       expr: thanos_alert_sender_alerts_dropped:burnrate6h{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
-        > (1 * (1-0.995)) and thanos_alert_sender_alerts_dropped:burnrate4d{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and thanos_alert_sender_alerts_dropped:burnrate4d{code!~"^4..$",container="thanos-rule",namespace="observatorium-metrics-stage",slo="api-alerting-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -2309,7 +2309,7 @@ spec:
   - interval: 30s
     name: api-alerting-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-alerting-availability-slo
       record: pyrra_objective
@@ -2413,8 +2413,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate5m{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (14 * (1-0.995)) and alertmanager_notifications_failed:burnrate1h{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (14 * (1-0.995))
+        > (14 * (1-0.95)) and alertmanager_notifications_failed:burnrate1h{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (14 * (1-0.95))
       for: 2m
       labels:
         long_burnrate_window: 1h
@@ -2430,8 +2430,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate30m{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (7 * (1-0.995)) and alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (7 * (1-0.995))
+        > (7 * (1-0.95)) and alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (7 * (1-0.95))
       for: 15m
       labels:
         long_burnrate_window: 6h
@@ -2447,8 +2447,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate2h{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (2 * (1-0.995)) and alertmanager_notifications_failed:burnrate1d{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (2 * (1-0.995))
+        > (2 * (1-0.95)) and alertmanager_notifications_failed:burnrate1d{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (2 * (1-0.95))
       for: 1h
       labels:
         long_burnrate_window: 1d
@@ -2464,8 +2464,8 @@ spec:
           is burning too much error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIAlertmanagerNotificationsAvailabilityErrorBudgetBurning
       expr: alertmanager_notifications_failed:burnrate6h{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (1 * (1-0.995)) and alertmanager_notifications_failed:burnrate4d{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
-        > (1 * (1-0.995))
+        > (1 * (1-0.95)) and alertmanager_notifications_failed:burnrate4d{code!~"^4..$",namespace="observatorium-metrics-stage",service="observatorium-alertmanager",slo="api-alerting-notif-availability-slo"}
+        > (1 * (1-0.95))
       for: 3h
       labels:
         long_burnrate_window: 4d
@@ -2477,7 +2477,7 @@ spec:
   - interval: 30s
     name: api-alerting-notif-availability-slo-generic
     rules:
-    - expr: "0.995"
+    - expr: "0.95"
       labels:
         slo: api-alerting-notif-availability-slo
       record: pyrra_objective


### PR DESCRIPTION
The change to introduce these burn alerts at 99.5% sent a lot of alerts to app-sre and thus was reverted. As per https://docs.google.com/document/d/1fogL6R1eN4dwf_0Bz0K4S4okwJzJIX1uqyTi9ZCsvWw/edit we're going to investigate the likelihood of it firing at a lower threshold and work our way up. 