### PR TITLE
Add row in instance utilization dashboard for Thanos Receive

### DIFF
--- a/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
+++ b/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
@@ -144,7 +144,7 @@ function() {
           g.panel('Network Traffic') +
           g.queryPanel(
             [
-              'sum by (pod) (rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-thanos-receive-.*"}[$interval])) * -1',
+              'sum by (pod) (rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-thanos-receive-.*"}[$interval]))',
               'sum by (pod) (rate(container_network_transmit_bytes_total{namespace="$namespace", pod=~"observatorium-thanos-receive-.*"}[$interval]))',
             ],
             [
@@ -179,7 +179,7 @@ function() {
           g.panel('Memory Used') +
           g.queryPanel(
             [
-              '(container_memory_working_set_bytes{container="thanos-query-frontend", namespace="$namespace"}) / (1024 * 1024)',
+              '(container_memory_working_set_bytes{container="thanos-query-frontend", namespace="$namespace"})',
             ],
             [
               'memory usage system {{pod}}',
@@ -217,8 +217,8 @@ function() {
           g.panel('Network Usage') +
           g.queryPanel(
             [
-              'rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-thanos-query-frontend-.*"}[$interval]) / (1024 * 1024)',
-              'rate(container_network_transmit_bytes_total{namespace="$namespace", pod=~"observatorium-thanos-query-frontend-.*"}[$interval]) / (1024 * 1024)',
+              'rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-thanos-query-frontend-.*"}[$interval])',
+              'rate(container_network_transmit_bytes_total{namespace="$namespace", pod=~"observatorium-thanos-query-frontend-.*"}[$interval])',
             ],
             [
               'receive bytes pod {{pod}}',

--- a/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
+++ b/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
@@ -92,8 +92,8 @@ function() {
           g.panel('Concurrency gate utilization') +
           g.queryPanel(
             [
-              'max by (pod) http_inflight_requests{handler="receive", namespace="$namespace"}',
-              'max by (pod) thanos_receive_write_request_concurrency_write_request_limit{namespace="$namespace"}',
+              'max by (pod) (http_inflight_requests{handler="receive", namespace="$namespace"})',
+              'max by (pod) (thanos_receive_write_request_concurrency_write_request_limit{namespace="$namespace"})',
             ],
             [
               'concurrency gate used {{pod}}',

--- a/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
@@ -1161,7 +1161,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by (pod) (rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-thanos-receive-.*\"}[$interval])) * -1",
+           "expr": "sum by (pod) (rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-thanos-receive-.*\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "network traffic in {{pod}}",
@@ -1607,7 +1607,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "(container_memory_working_set_bytes{container=\"thanos-query-frontend\", namespace=\"$namespace\"}) / (1024 * 1024)",
+           "expr": "(container_memory_working_set_bytes{container=\"thanos-query-frontend\", namespace=\"$namespace\"})",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "memory usage system {{pod}}",
@@ -1883,7 +1883,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-thanos-query-frontend-.*\"}[$interval]) / (1024 * 1024)",
+           "expr": "rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-thanos-query-frontend-.*\"}[$interval])",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "receive bytes pod {{pod}}",
@@ -1891,7 +1891,7 @@ data:
            "step": 10
           },
           {
-           "expr": "rate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-thanos-query-frontend-.*\"}[$interval]) / (1024 * 1024)",
+           "expr": "rate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-thanos-query-frontend-.*\"}[$interval])",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "transmit bytes pod {{pod}}",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
@@ -18,12 +18,1215 @@ data:
      "rows": [
       {
        "collapse": false,
-       "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-       },
+       "height": "250px",
+       "panels": [
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Shows rate of requests against Receive for the given time",
+         "fill": 10,
+         "id": 1,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+          {
+           "alias": "/1../",
+           "color": "#EAB839"
+          },
+          {
+           "alias": "/2../",
+           "color": "#37872D"
+          },
+          {
+           "alias": "/3../",
+           "color": "#E0B400"
+          },
+          {
+           "alias": "/4../",
+           "color": "#1F60C4"
+          },
+          {
+           "alias": "/5../",
+           "color": "#C4162A"
+          }
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (namespace,  job, handler, code) (rate(http_requests_total{namespace=\"$namespace\", job=~\"observatorium-thanos-receive.*\", handler=\"receive\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{namespace}} {{job}} {{handler}} {{code}}",
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Rate of requests",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+          "error": "#E24D42"
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Shows ratio of errors compared to the total number of handled requests against Receive.",
+         "fill": 10,
+         "id": 2,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (namespace, job, code) (rate(http_requests_total{namespace=\"$namespace\", job=~\"observatorium-thanos-receive.*\", handler=\"receive\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (namespace, job) (rate(http_requests_total{namespace=\"$namespace\", job=~\"observatorium-thanos-receive.*\", handler=\"receive\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Errors",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "percentunit",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Shows how long has it taken to handle requests in quantiles.",
+         "fill": 1,
+         "id": 3,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+          {
+           "alias": "p99",
+           "color": "#FA6400",
+           "fill": 1,
+           "fillGradient": 1
+          },
+          {
+           "alias": "p90",
+           "color": "#E0B400",
+           "fill": 1,
+           "fillGradient": 1
+          },
+          {
+           "alias": "p50",
+           "color": "#37872D",
+           "fill": 10,
+           "fillGradient": 0
+          }
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"observatorium-thanos-receive.*\", handler=\"receive\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{namespace}} {{job}}",
+           "logBase": 10,
+           "max": null,
+           "min": null,
+           "step": 10
+          },
+          {
+           "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"observatorium-thanos-receive.*\", handler=\"receive\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{namespace}} {{job}}",
+           "logBase": 10,
+           "max": null,
+           "min": null,
+           "step": 10
+          },
+          {
+           "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace=\"$namespace\", job=~\"observatorium-thanos-receive.*\", handler=\"receive\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{namespace}} {{job}}",
+           "logBase": 10,
+           "max": null,
+           "min": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Duration",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "s",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Shows the number of replication requests against Receive.",
+         "fill": 10,
+         "id": 4,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+          {
+           "alias": "/Aborted/",
+           "color": "#EAB839"
+          },
+          {
+           "alias": "/AlreadyExists/",
+           "color": "#37872D"
+          },
+          {
+           "alias": "/FailedPrecondition/",
+           "color": "#E0B400"
+          },
+          {
+           "alias": "/Unimplemented/",
+           "color": "#E0B400"
+          },
+          {
+           "alias": "/InvalidArgument/",
+           "color": "#1F60C4"
+          },
+          {
+           "alias": "/NotFound/",
+           "color": "#1F60C4"
+          },
+          {
+           "alias": "/PermissionDenied/",
+           "color": "#1F60C4"
+          },
+          {
+           "alias": "/Unauthenticated/",
+           "color": "#1F60C4"
+          },
+          {
+           "alias": "/Canceled/",
+           "color": "#C4162A"
+          },
+          {
+           "alias": "/DataLoss/",
+           "color": "#C4162A"
+          },
+          {
+           "alias": "/DeadlineExceeded/",
+           "color": "#C4162A"
+          },
+          {
+           "alias": "/Internal/",
+           "color": "#C4162A"
+          },
+          {
+           "alias": "/OutOfRange/",
+           "color": "#C4162A"
+          },
+          {
+           "alias": "/ResourceExhausted/",
+           "color": "#C4162A"
+          },
+          {
+           "alias": "/Unavailable/",
+           "color": "#C4162A"
+          },
+          {
+           "alias": "/Unknown/",
+           "color": "#C4162A"
+          },
+          {
+           "alias": "/OK/",
+           "color": "#37872D"
+          },
+          {
+           "alias": "error",
+           "color": "#C4162A"
+          }
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (namespace,  job, grpc_method, grpc_code) (rate(grpc_client_handled_total{grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}",
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Replication request count",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Shows how long has it taken to handle replication requests in quantiles.",
+         "fill": 1,
+         "id": 5,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+          {
+           "alias": "p99",
+           "color": "#FA6400",
+           "fill": 1,
+           "fillGradient": 1
+          },
+          {
+           "alias": "p90",
+           "color": "#E0B400",
+           "fill": 1,
+           "fillGradient": 1
+          },
+          {
+           "alias": "p50",
+           "color": "#37872D",
+           "fill": 10,
+           "fillGradient": 0
+          }
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_client_handling_seconds_bucket{grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{namespace}} {{job}}",
+           "logBase": 10,
+           "max": null,
+           "min": null,
+           "step": 10
+          },
+          {
+           "expr": "histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_client_handling_seconds_bucket{grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{namespace}} {{job}}",
+           "logBase": 10,
+           "max": null,
+           "min": null,
+           "step": 10
+          },
+          {
+           "expr": "histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_client_handling_seconds_bucket{grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{namespace}} {{job}}",
+           "logBase": 10,
+           "max": null,
+           "min": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Replication request duration",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "s",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+          "error": "#E24D42"
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Shows the number of replication request errors.",
+         "fill": 10,
+         "id": 6,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (namespace, job, grpc_code) (rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval])) / ignoring (grpc_code) group_left() sum by (namespace, job) (rate(grpc_client_handled_total{grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Replication request errors",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "percentunit",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "id": 7,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "max by (pod) http_inflight_requests{handler=\"receive\", namespace=\"$namespace\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "concurrency gate used {{pod}}",
+           "legendLink": null,
+           "step": 10
+          },
+          {
+           "expr": "max by (pod) thanos_receive_write_request_concurrency_write_request_limit{namespace=\"$namespace\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "concurrency gate limit {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Concurrency gate utilization",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Memory working set",
+         "fill": 10,
+         "id": 8,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "(container_memory_working_set_bytes{container=\"thanos-receive\", namespace=\"$namespace\"})",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "memory usage system {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Memory Used",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "bytes",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "id": 9,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "rate(process_cpu_seconds_total{job=\"observatorium-thanos-receive-default\", namespace=\"$namespace\"}[$interval]) * 100",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "cpu usage system {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "CPU Usage",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "id": 10,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (pod) (kube_pod_container_status_restarts_total{namespace=\"$namespace\", container=\"thanos-receive\"})",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "pod restart count {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Pod/Container Restarts",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 10,
+         "id": 11,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+          {
+           "dashboard": "Thanos / Receive",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Thanos / Receive",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (pod) (rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-thanos-receive-.*\"}[$interval])) * -1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "network traffic in {{pod}}",
+           "legendLink": null,
+           "step": 10
+          },
+          {
+           "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-thanos-receive-.*\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "network traffic out {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Network Traffic",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "binBps",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        }
+       ],
+       "repeat": null,
+       "repeatIteration": null,
+       "repeatRowId": null,
+       "showTitle": true,
+       "title": "Receive Overview",
+       "titleSize": "h6"
+      },
+      {
+       "collapse": false,
        "height": "250px",
        "panels": [
         {
@@ -36,13 +1239,7 @@ data:
          "datasource": "$datasource",
          "description": "Shows rate of requests against Query Frontend for the given time.",
          "fill": 10,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 0,
-          "y": 1
-         },
-         "id": 1,
+         "id": 12,
          "legend": {
           "avg": false,
           "current": false,
@@ -153,13 +1350,7 @@ data:
          "datasource": "$datasource",
          "description": "Shows ratio of errors compared to the total number of handled requests against Query Frontend.",
          "fill": 10,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 6,
-          "y": 1
-         },
-         "id": 2,
+         "id": 13,
          "legend": {
           "avg": false,
           "current": false,
@@ -250,13 +1441,7 @@ data:
          "datasource": "$datasource",
          "description": "Shows how long has it taken to handle requests in quantiles.",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 12,
-          "y": 1
-         },
-         "id": 3,
+         "id": 14,
          "legend": {
           "avg": false,
           "current": false,
@@ -386,14 +1571,8 @@ data:
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 18,
-          "y": 1
-         },
-         "id": 4,
+         "fill": 10,
+         "id": 15,
          "legend": {
           "avg": false,
           "current": false,
@@ -404,7 +1583,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 1,
+         "linewidth": 0,
          "links": [
           {
            "dashboard": "Thanos / Query Frontend",
@@ -424,7 +1603,7 @@ data:
          ],
          "spaceLength": 10,
          "span": 1,
-         "stack": false,
+         "stack": true,
          "steppedLine": false,
          "targets": [
           {
@@ -459,7 +1638,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "MB",
+           "format": "bytes",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -485,13 +1664,7 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 0,
-          "y": 7
-         },
-         "id": 5,
+         "id": 16,
          "legend": {
           "avg": false,
           "current": false,
@@ -557,7 +1730,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "percent",
+           "format": "short",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -583,13 +1756,7 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 6,
-          "y": 7
-         },
-         "id": 6,
+         "id": 17,
          "legend": {
           "avg": false,
           "current": false,
@@ -655,7 +1822,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "count",
+           "format": "short",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -681,13 +1848,7 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 12,
-          "y": 7
-         },
-         "id": 7,
+         "id": 18,
          "legend": {
           "avg": false,
           "current": false,
@@ -761,7 +1922,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "MB",
+           "format": "binBps",
            "label": null,
            "logBase": 1,
            "max": null,

--- a/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
@@ -784,7 +784,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "max by (pod) http_inflight_requests{handler=\"receive\", namespace=\"$namespace\"}",
+           "expr": "max by (pod) (http_inflight_requests{handler=\"receive\", namespace=\"$namespace\"})",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "concurrency gate used {{pod}}",
@@ -792,7 +792,7 @@ data:
            "step": 10
           },
           {
-           "expr": "max by (pod) thanos_receive_write_request_concurrency_write_request_limit{namespace=\"$namespace\"}",
+           "expr": "max by (pod) (thanos_receive_write_request_concurrency_write_request_limit{namespace=\"$namespace\"})",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "concurrency gate limit {{pod}}",


### PR DESCRIPTION
I'm planning to follow up with a PR allowing the `job` to be a dashboard variable and used in all the charts. This should help with filtering information.