### PR TITLE
Fix layout issue in instance dashboard

### DIFF
--- a/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
+++ b/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
@@ -109,39 +109,39 @@ function() {
       .addRow(
         g.row('Receive Overview')
         .addPanel(
-          g.panel('Rate of requests', 'Shows rate of requests against Receive for the given time') +
-          g.httpQpsPanel('http_requests_total', receiveHandlerSelector, thanos.receive.dashboard.dimensions) +
+          g.panel('Rate of requests', 'Shows rate of requests against Receive for the given time') { span:: 0 } +
+          g.httpQpsPanel('http_requests_total', receiveHandlerSelector, thanos.receive.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.receive.dashboard.title) +
           g.stack
         )
         .addPanel(
-          g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests against Receive.') +
-          g.httpErrPanel('http_requests_total', receiveHandlerSelector, thanos.receive.dashboard.dimensions) +
+          g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests against Receive.') { span:: 0 } +
+          g.httpErrPanel('http_requests_total', receiveHandlerSelector, thanos.receive.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.receive.dashboard.title)
         )
         .addPanel(
           g.panel('Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', receiveHandlerSelector, thanos.receive.dashboard.dimensions) +
+          g.latencyPanel('http_request_duration_seconds', receiveHandlerSelector, thanos.receive.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.receive.dashboard.title)
         )
         .addPanel(
-          g.panel('Replication request count', 'Shows the number of replication requests against Receive.') +
-          g.grpcRequestsPanel('grpc_client_handled_total', 'grpc_type="unary", grpc_method="RemoteWrite"', thanos.receive.dashboard.dimensions) +
+          g.panel('Replication request count', 'Shows the number of replication requests against Receive.') { span:: 0 } +
+          g.grpcRequestsPanel('grpc_client_handled_total', 'grpc_type="unary", grpc_method="RemoteWrite"', thanos.receive.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.receive.dashboard.title) +
           g.stack
         )
         .addPanel(
-          g.panel('Replication request duration', 'Shows how long has it taken to handle replication requests in quantiles.') +
-          g.latencyPanel('grpc_client_handling_seconds', 'grpc_type="unary", grpc_method="RemoteWrite"', thanos.receive.dashboard.dimensions) +
+          g.panel('Replication request duration', 'Shows how long has it taken to handle replication requests in quantiles.') { span:: 0 } +
+          g.latencyPanel('grpc_client_handling_seconds', 'grpc_type="unary", grpc_method="RemoteWrite"', thanos.receive.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.receive.dashboard.title)
         )
         .addPanel(
-          g.panel('Replication request errors', 'Shows the number of replication request errors.') +
-          g.grpcErrorsPanel('grpc_client_handled_total', 'grpc_type="unary", grpc_method="RemoteWrite"', thanos.receive.dashboard.dimensions) +
+          g.panel('Replication request errors', 'Shows the number of replication request errors.') { span:: 0 } +
+          g.grpcErrorsPanel('grpc_client_handled_total', 'grpc_type="unary", grpc_method="RemoteWrite"', thanos.receive.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.receive.dashboard.title)
         )
         .addPanel(
-          g.panel('Concurrency gate utilization') +
+          g.panel('Concurrency gate utilization') { span:: 0 } +
           g.queryPanel(
             [
               'max by (pod) (http_inflight_requests{handler="receive", namespace="$namespace"})',
@@ -151,11 +151,11 @@ function() {
               'concurrency gate used {{pod}}',
               'concurrency gate limit {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.receive.dashboard.title)
         )
         .addPanel(
-          g.panel('Memory Used', 'Memory working set') +
+          g.panel('Memory Used', 'Memory working set') { span:: 0 } +
           g.queryPanel(
             [
               '(container_memory_working_set_bytes{container="thanos-receive", namespace="$namespace"})',
@@ -163,13 +163,13 @@ function() {
             [
               'memory usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.receive.dashboard.title) +
           { yaxes: g.yaxes('bytes') } +
           g.stack
         )
         .addPanel(
-          g.panel('CPU Usage') +
+          g.panel('CPU Usage') { span:: 0 } +
           g.queryPanel(
             [
               'rate(process_cpu_seconds_total{job="observatorium-thanos-receive-default", namespace="$namespace"}[$interval]) * 100',
@@ -177,11 +177,11 @@ function() {
             [
               'cpu usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.receive.dashboard.title)
         )
         .addPanel(
-          g.panel('Pod/Container Restarts') +
+          g.panel('Pod/Container Restarts') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (kube_pod_container_status_restarts_total{namespace="$namespace", container="thanos-receive"})',
@@ -189,11 +189,11 @@ function() {
             [
               'pod restart count {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.receive.dashboard.title)
         )
         .addPanel(
-          g.panel('Network Traffic') +
+          g.panel('Network Traffic') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-thanos-receive-.*"}[$interval]))',
@@ -203,7 +203,7 @@ function() {
               'network traffic in {{pod}}',
               'network traffic out {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.stack +
           g.addDashboardLink(thanos.receive.dashboard.title) +
           { yaxes: g.yaxes('binBps') }
@@ -212,23 +212,23 @@ function() {
       .addRow(
         g.row('Query Frontend Overview')
         .addPanel(
-          g.panel('Rate of requests', 'Shows rate of requests against Query Frontend for the given time.') +
-          g.httpQpsPanel('http_requests_total', queryFrontendHandlerSelector, thanos.queryFrontend.dashboard.dimensions) +
+          g.panel('Rate of requests', 'Shows rate of requests against Query Frontend for the given time.') { span:: 0 } +
+          g.httpQpsPanel('http_requests_total', queryFrontendHandlerSelector, thanos.queryFrontend.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title) +
           g.stack
         )
         .addPanel(
-          g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests against Query Frontend.') +
-          g.httpErrPanel('http_requests_total', queryFrontendHandlerSelector, thanos.queryFrontend.dashboard.dimensions) +
+          g.panel('Errors', 'Shows ratio of errors compared to the total number of handled requests against Query Frontend.') { span:: 0 } +
+          g.httpErrPanel('http_requests_total', queryFrontendHandlerSelector, thanos.queryFrontend.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title)
         )
         .addPanel(
-          g.panel('Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', queryFrontendHandlerSelector, thanos.queryFrontend.dashboard.dimensions) +
+          g.panel('Duration', 'Shows how long has it taken to handle requests in quantiles.') { span:: 0 } +
+          g.latencyPanel('http_request_duration_seconds', queryFrontendHandlerSelector, thanos.queryFrontend.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title)
         )
         .addPanel(
-          g.panel('Memory Used') +
+          g.panel('Memory Used') { span:: 0 } +
           g.queryPanel(
             [
               '(container_memory_working_set_bytes{container="thanos-query-frontend", namespace="$namespace"})',
@@ -236,13 +236,13 @@ function() {
             [
               'memory usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title) +
           { yaxes: g.yaxes('bytes') } +
           g.stack
         )
         .addPanel(
-          g.panel('CPU Usage') +
+          g.panel('CPU Usage') { span:: 0 } +
           g.queryPanel(
             [
               'rate(process_cpu_seconds_total{job="observatorium-thanos-query-frontend", namespace="$namespace"}[$interval]) * 100',
@@ -250,11 +250,11 @@ function() {
             [
               'cpu usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title)
         )
         .addPanel(
-          g.panel('Pod/Container Restarts') +
+          g.panel('Pod/Container Restarts') { span:: 0 } +
           g.queryPanel(
             [
               'increase(kube_pod_container_status_restarts_total{namespace="$namespace", container=\'thanos-query-frontend\'}[$interval])',
@@ -262,11 +262,11 @@ function() {
             [
               'pod {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title)
         )
         .addPanel(
-          g.panel('Network Usage') +
+          g.panel('Network Usage') { span:: 0 } +
           g.queryPanel(
             [
               'rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-thanos-query-frontend-.*"}[$interval])',
@@ -276,7 +276,7 @@ function() {
               'receive bytes pod {{pod}}',
               'transmit bytes pod {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title) +
           { yaxes: g.yaxes('binBps') }
         )
@@ -284,44 +284,44 @@ function() {
       .addRow(
         g.row('Query Overview')
         .addPanel(
-          g.panel('Instant Query Rate', 'Shows rate of requests against /query for the given time.') +
-          g.httpQpsPanel('http_requests_total', queryHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Instant Query Rate', 'Shows rate of requests against /query for the given time.') { span:: 0 } +
+          g.httpQpsPanel('http_requests_total', queryHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Instant Query Errors', 'Shows ratio of errors compared to the total number of handled requests against /query.') +
-          g.httpErrPanel('http_requests_total', queryHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Instant Query Errors', 'Shows ratio of errors compared to the total number of handled requests against /query.') { span:: 0 } +
+          g.httpErrPanel('http_requests_total', queryHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Instant Query Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', queryHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Instant Query Duration', 'Shows how long has it taken to handle requests in quantiles.') { span:: 0 } +
+          g.latencyPanel('http_request_duration_seconds', queryHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Range Query Rate', 'Shows rate of requests against /query_range for the given time range.') +
-          g.httpQpsPanel('http_requests_total', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Range Query Rate', 'Shows rate of requests against /query_range for the given time range.') { span:: 0 } +
+          g.httpQpsPanel('http_requests_total', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Range Query Errors', 'Shows ratio of errors compared to the total number of handled requests against /query_range.') +
-          g.httpErrPanel('http_requests_total', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Range Query Errors', 'Shows ratio of errors compared to the total number of handled requests against /query_range.') { span:: 0 } +
+          g.httpErrPanel('http_requests_total', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Range Query Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Range Query Duration', 'Shows how long has it taken to handle requests in quantiles.') { span:: 0 } +
+          g.latencyPanel('http_request_duration_seconds', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Concurrent Capacity', 'Shows available capacity of processing queries in parallel.') +
+          g.panel('Concurrent Capacity', 'Shows available capacity of processing queries in parallel.') { span:: 0 } +
           g.queryPanel(
             'max_over_time(thanos_query_concurrent_gate_queries_max{%s}[$__rate_interval]) - avg_over_time(thanos_query_concurrent_gate_queries_in_flight{%s}[$__rate_interval])' % [thanos.query.dashboard.selector, thanos.query.dashboard.selector],
             '{{job}} - {{pod}}'
-          )
+          ) { span:: 0 }
         )
         .addPanel(
-          g.panel('Memory Used', 'Memory working set') +
+          g.panel('Memory Used', 'Memory working set') { span:: 0 } +
           g.queryPanel(
             [
               '(container_memory_working_set_bytes{container="thanos-query", namespace="$namespace"})',
@@ -329,13 +329,13 @@ function() {
             [
               'memory usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title) +
           { yaxes: g.yaxes('bytes') } +
           g.stack
         )
         .addPanel(
-          g.panel('CPU Usage') +
+          g.panel('CPU Usage') { span:: 0 } +
           g.queryPanel(
             [
               'rate(process_cpu_seconds_total{job=~"observatorium-thanos-query", namespace="$namespace"}[$interval]) * 100',
@@ -343,11 +343,11 @@ function() {
             [
               'cpu usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Pod/Container Restarts') +
+          g.panel('Pod/Container Restarts') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (kube_pod_container_status_restarts_total{namespace="$namespace", container="thanos-query"})',
@@ -355,11 +355,11 @@ function() {
             [
               'pod restart count {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Network Traffic') +
+          g.panel('Network Traffic') { span:: 0 } +
           g.queryPanel(
             [
               //added container="thanos-query" to the query to avoid pods from query-frontend
@@ -379,44 +379,44 @@ function() {
       .addRow(
         g.row('Ruler - Query Overview')
         .addPanel(
-          g.panel('Instant Query Rate', 'Shows rate of requests against /query for the given time.') +
-          g.httpQpsPanel('http_requests_total', queryHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Instant Query Rate', 'Shows rate of requests against /query for the given time.') { span:: 0 } +
+          g.httpQpsPanel('http_requests_total', queryHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Instant Query Errors', 'Shows ratio of errors compared to the total number of handled requests against /query.') +
-          g.httpErrPanel('http_requests_total', queryHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Instant Query Errors', 'Shows ratio of errors compared to the total number of handled requests against /query.') { span:: 0 } +
+          g.httpErrPanel('http_requests_total', queryHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Instant Query Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', queryHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Instant Query Duration', 'Shows how long has it taken to handle requests in quantiles.') { span:: 0 } +
+          g.latencyPanel('http_request_duration_seconds', queryHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Range Query Rate', 'Shows rate of requests against /query_range for the given time range.') +
-          g.httpQpsPanel('http_requests_total', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Range Query Rate', 'Shows rate of requests against /query_range for the given time range.') { span:: 0 } +
+          g.httpQpsPanel('http_requests_total', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Range Query Errors', 'Shows ratio of errors compared to the total number of handled requests against /query_range.') +
-          g.httpErrPanel('http_requests_total', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Range Query Errors', 'Shows ratio of errors compared to the total number of handled requests against /query_range.') { span:: 0 } +
+          g.httpErrPanel('http_requests_total', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Range Query Duration', 'Shows how long has it taken to handle requests in quantiles.') +
-          g.latencyPanel('http_request_duration_seconds', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) +
+          g.panel('Range Query Duration', 'Shows how long has it taken to handle requests in quantiles.') { span:: 0 } +
+          g.latencyPanel('http_request_duration_seconds', queryRangeHandlerSelector, thanos.query.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Concurrent Capacity', 'Shows available capacity of processing queries in parallel.') +
+          g.panel('Concurrent Capacity', 'Shows available capacity of processing queries in parallel.') { span:: 0 } +
           g.queryPanel(
             'max_over_time(thanos_query_concurrent_gate_queries_max{%s}[$__rate_interval]) - avg_over_time(thanos_query_concurrent_gate_queries_in_flight{%s}[$__rate_interval])' % [thanos.query.dashboard.selector, thanos.query.dashboard.selector],
             '{{job}} - {{pod}}'
-          )
+          ) { span:: 0 }
         )
         .addPanel(
-          g.panel('Memory Used', 'Memory working set') +
+          g.panel('Memory Used', 'Memory working set') { span:: 0 } +
           g.queryPanel(
             [
               '(container_memory_working_set_bytes{container="thanos-query", namespace="$namespace"})',
@@ -424,13 +424,13 @@ function() {
             [
               'memory usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title) +
           { yaxes: g.yaxes('bytes') } +
           g.stack
         )
         .addPanel(
-          g.panel('CPU Usage') +
+          g.panel('CPU Usage') { span:: 0 } +
           g.queryPanel(
             [
               'rate(process_cpu_seconds_total{job=~"observatorium-thanos-query", namespace="$namespace"}[$interval]) * 100',
@@ -438,11 +438,11 @@ function() {
             [
               'cpu usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Pod/Container Restarts') +
+          g.panel('Pod/Container Restarts') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (kube_pod_container_status_restarts_total{namespace="$namespace", container="thanos-query"})',
@@ -450,11 +450,11 @@ function() {
             [
               'pod restart count {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.query.dashboard.title)
         )
         .addPanel(
-          g.panel('Network Traffic') +
+          g.panel('Network Traffic') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-ruler-query-.*"}[$interval]))',
@@ -464,7 +464,7 @@ function() {
               'network traffic in {{pod}}',
               'network traffic out {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.stack +
           g.addDashboardLink(thanos.query.dashboard.title) +
           { yaxes: g.yaxes('binBps') }
@@ -474,59 +474,53 @@ function() {
         g.row('Thanos Rule Overview')
         // First line (y=1): evaluations metrics
         .addPanel(
-          g.panel('Total evaluations', 'Displays the rate of total rule evaluations,') +
+          g.panel('Total evaluations', 'Displays the rate of total rule evaluations,') { span:: 0 } +
           g.queryPanel(
             'sum by (job, rule_group) (rate(prometheus_rule_evaluations_total{%(selector)s}[$interval]))' % thanos.rule.dashboard,
             '{{rule_group}}'
-          ) +
-          g.addDashboardLink(thanos.rule.dashboard.title) +
-          { gridPos: { x: 0, y: thanos.rule.yStart + 1, w: 6, h: 6 } },
+          ) { span:: 0 } +
+          g.addDashboardLink(thanos.rule.dashboard.title)
         )
         .addPanel(
-          g.panel('Failed evaluations', 'Displays the rate of rule evaluation failures, grouped by rule group.') +
+          g.panel('Failed evaluations', 'Displays the rate of rule evaluation failures, grouped by rule group.') { span:: 0 } +
           g.queryPanel(
             'sum by (job, rule_group) (rate(prometheus_rule_evaluation_failures_total{%(selector)s}[$interval]))' % thanos.rule.dashboard,
             '{{rule_group}}'
-          ) +
-          g.addDashboardLink(thanos.rule.dashboard.title) +
-          { gridPos: { x: 6, y: thanos.rule.yStart + 1, w: 6, h: 6 } },
+          ) { span:: 0 } +
+          g.addDashboardLink(thanos.rule.dashboard.title)
         )
         .addPanel(
-          g.panel('Evaluations with warnings') +
+          g.panel('Evaluations with warnings') { span:: 0 } +
           g.queryPanel(
             'sum by (job, strategy) (rate(thanos_rule_evaluation_with_warnings_total{%(selector)s}[$interval]))' % thanos.rule.dashboard,
             '{{rule_group}}'
-          ) +
-          g.addDashboardLink(thanos.rule.dashboard.title) +
-          { gridPos: { x: 12, y: thanos.rule.yStart + 1, w: 6, h: 6 } },
+          ) { span:: 0 } +
+          g.addDashboardLink(thanos.rule.dashboard.title)
         )
         .addPanel(
-          g.panel('Too slow evaluations', 'Displays the total time of rule group evaluations that took longer than their scheduled interval.') +
+          g.panel('Too slow evaluations', 'Displays the total time of rule group evaluations that took longer than their scheduled interval.') { span:: 0 } +
           g.addDashboardLink(thanos.rule.dashboard.title) +
           g.queryPanel(
             'sum by(job, rule_group) (prometheus_rule_group_last_duration_seconds{%(selector)s}) / sum by(job, rule_group) (prometheus_rule_group_interval_seconds{%(selector)s})' % thanos.rule.dashboard,
             '{{rule_group}}'
-          ) +
-          { gridPos: { x: 18, y: thanos.rule.yStart + 1, w: 6, h: 6 } },
+          ) { span:: 0 }
         )
         // Second line (y=7): alerts push to aler manager metrics
         .addPanel(
-          g.panel('Rate of sent alerts', 'Shows the rate of total alerts sent by Thanos.') +
-          g.queryPanel('sum by (job) (rate(thanos_alert_sender_alerts_sent_total{%(selector)s}[$interval]))' % thanos.rule.dashboard, '{{job}}') +
-          g.addDashboardLink(thanos.rule.dashboard.title) +
-          { gridPos: { x: 0, y: thanos.rule.yStart + 7, w: 6, h: 6 } },
+          g.panel('Rate of sent alerts', 'Shows the rate of total alerts sent by Thanos.') { span:: 0 } +
+          g.queryPanel('sum by (job) (rate(thanos_alert_sender_alerts_sent_total{%(selector)s}[$interval]))' % thanos.rule.dashboard, '{{job}}') { span:: 0 } +
+          g.addDashboardLink(thanos.rule.dashboard.title)
         )
         .addPanel(
-          g.panel('Rate of send alerts errors', 'Displays the ratio of error rate to total alerts sent rate by Thanos.') +
+          g.panel('Rate of send alerts errors', 'Displays the ratio of error rate to total alerts sent rate by Thanos.') { span:: 0 } +
           g.queryPanel(
             'sum by (job) (rate(thanos_alert_sender_errors_total{%(selector)s}[$interval])) / sum by (job) (rate(thanos_alert_sender_alerts_sent_total{%(selector)s}[$interval]))' % thanos.rule.dashboard,
             '{{job}}'
-          ) +
-          g.addDashboardLink(thanos.rule.dashboard.title) +
-          { gridPos: { x: 6, y: thanos.rule.yStart + 7, w: 6, h: 6 } },
+          ) { span:: 0 } +
+          g.addDashboardLink(thanos.rule.dashboard.title)
         )
         .addPanel(
-          g.panel('Duration od send alerts', 'Displays the 50th, 90th, and 99th percentile latency of alert requests sent by Thanos.') +
+          g.panel('Duration od send alerts', 'Displays the 50th, 90th, and 99th percentile latency of alert requests sent by Thanos.') { span:: 0 } +
           g.queryPanel(
             [
               'histogram_quantile(0.50, sum by (job, le) (rate(thanos_alert_sender_latency_seconds_bucket{%(selector)s}[$interval])))' % thanos.rule.dashboard,
@@ -538,13 +532,12 @@ function() {
               'p90',
               'p99',
             ]
-          ) +
-          g.addDashboardLink(thanos.queryFrontend.dashboard.title) +
-          { gridPos: { x: 12, y: thanos.rule.yStart + 7, w: 6, h: 6 } },
+          ) { span:: 0 } +
+          g.addDashboardLink(thanos.queryFrontend.dashboard.title)
         )
         // Third line (y=13): CPU, memory, network resource usage and restarts
         .addPanel(
-          g.panel('Memory Used') +
+          g.panel('Memory Used') { span:: 0 } +
           g.queryPanel(
             [
               '(container_memory_working_set_bytes{container="thanos-rule", namespace="$namespace"}) / (1024 * 1024)',
@@ -552,12 +545,12 @@ function() {
             [
               'memory usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title) +
-          { yaxes: g.yaxes('MB'), gridPos: { x: 0, y: thanos.rule.yStart + 13, w: 6, h: 6 } },
+          { yaxes: g.yaxes('MB') },
         )
         .addPanel(
-          g.panel('CPU Usage') +
+          g.panel('CPU Usage') { span:: 0 } +
           g.queryPanel(
             [
               'rate(process_cpu_seconds_total{%(selector)s}[$interval]) * 100' % thanos.rule.dashboard,
@@ -565,12 +558,12 @@ function() {
             [
               'cpu usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title) +
-          { yaxes: g.yaxes('percent'), gridPos: { x: 6, y: thanos.rule.yStart + 13, w: 6, h: 6 } },
+          { yaxes: g.yaxes('percent') },
         )
         .addPanel(
-          g.panel('Network Usage') +
+          g.panel('Network Usage') { span:: 0 } +
           g.queryPanel(
             [
               'rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"%(pod)s"}[$interval]) / (1024 * 1024)' % thanos.rule.dashboard,
@@ -580,12 +573,12 @@ function() {
               'receive bytes pod {{pod}}',
               'transmit bytes pod {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title) +
-          { yaxes: g.yaxes('MB'), gridPos: { x: 12, y: thanos.rule.yStart + 13, w: 6, h: 6 } }
+          { yaxes: g.yaxes('MB') }
         )
         .addPanel(
-          g.panel('Pod/Container Restarts') +
+          g.panel('Pod/Container Restarts') { span:: 0 } +
           g.queryPanel(
             [
               'increase(kube_pod_container_status_restarts_total{namespace="$namespace", container="%(container)s"}[$interval])' % thanos.rule.dashboard,
@@ -593,45 +586,45 @@ function() {
             [
               'pod {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.queryFrontend.dashboard.title) +
-          { yaxes: g.yaxes('count'), gridPos: { x: 18, y: thanos.rule.yStart + 13, w: 6, h: 6 } }
+          { yaxes: g.yaxes('count') }
         )
       )
       .addRow(
         g.row('Store Gateway Overview')
         .addPanel(
-          g.panel('Unary gRPC Rate', 'Shows rate of handled Unary gRPC requests from queriers.') +
-          g.grpcRequestsPanel('grpc_server_handled_total', grpcUnarySelector, thanos.store.dashboard.dimensions) +
+          g.panel('Unary gRPC Rate', 'Shows rate of handled Unary gRPC requests from queriers.') { span:: 0 } +
+          g.grpcRequestsPanel('grpc_server_handled_total', grpcUnarySelector, thanos.store.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title)
         )
         .addPanel(
-          g.panel('Unary gRPC Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('grpc_server_handled_total', grpcUnarySelector, thanos.store.dashboard.dimensions) +
+          g.panel('Unary gRPC Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') { span:: 0 } +
+          g.grpcErrorsPanel('grpc_server_handled_total', grpcUnarySelector, thanos.store.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title)
         )
         .addPanel(
-          g.panel('Unary gRPC Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.latencyPanel('grpc_server_handling_seconds', grpcUnarySelector, thanos.store.dashboard.dimensions) +
+          g.panel('Unary gRPC Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') { span:: 0 } +
+          g.latencyPanel('grpc_server_handling_seconds', grpcUnarySelector, thanos.store.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title)
         )
         .addPanel(
-          g.panel('Sreamed gRPC Rate', 'Shows rate of handled Streamed gRPC requests from queriers.') +
-          g.grpcRequestsPanel('grpc_server_handled_total', grpcServerStreamSelector, thanos.store.dashboard.dimensions) +
+          g.panel('Sreamed gRPC Rate', 'Shows rate of handled Streamed gRPC requests from queriers.') { span:: 0 } +
+          g.grpcRequestsPanel('grpc_server_handled_total', grpcServerStreamSelector, thanos.store.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title)
         )
         .addPanel(
-          g.panel('Sreamed gRPC Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') +
-          g.grpcErrorsPanel('grpc_server_handled_total', grpcServerStreamSelector, thanos.store.dashboard.dimensions) +
+          g.panel('Sreamed gRPC Errors', 'Shows ratio of errors compared to the total number of handled requests from queriers.') { span:: 0 } +
+          g.grpcErrorsPanel('grpc_server_handled_total', grpcServerStreamSelector, thanos.store.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title)
         )
         .addPanel(
-          g.panel('Sreamed gRPC Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') +
-          g.latencyPanel('grpc_server_handling_seconds', grpcServerStreamSelector, thanos.store.dashboard.dimensions) +
+          g.panel('Sreamed gRPC Duration', 'Shows how long has it taken to handle requests from queriers, in quantiles.') { span:: 0 } +
+          g.latencyPanel('grpc_server_handling_seconds', grpcServerStreamSelector, thanos.store.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title)
         )
         .addPanel(
-          g.panel('Data Touched', 'Show the size of data touched') +
+          g.panel('Data Touched', 'Show the size of data touched') { span:: 0 } +
           g.queryPanel(
             [
               'histogram_quantile(0.99, sum by (le) (rate(thanos_bucket_store_series_data_touched{%s}[$__rate_interval])))' % thanos.store.dashboard.selector,
@@ -642,21 +635,21 @@ function() {
               'mean: {{data_type}} / {{job}}',
               'P50: {{data_type}} / {{job}}',
             ],
-          ) +
+          ) { span:: 0 } +
           { yaxes: g.yaxes('bytes') }
         )
         .addPanel(
-          g.panel('Get All', 'Shows how long has it taken to get all series.') +
-          g.latencyPanel('thanos_bucket_store_series_get_all_duration_seconds', thanos.store.dashboard.selector, thanos.store.dashboard.dimensions) +
+          g.panel('Get All', 'Shows how long has it taken to get all series.') { span:: 0 } +
+          g.latencyPanel('thanos_bucket_store_series_get_all_duration_seconds', thanos.store.dashboard.selector, thanos.store.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title)
         )
         .addPanel(
-          g.panel('Merge', 'Shows how long has it taken to merge series.') +
-          g.latencyPanel('thanos_bucket_store_series_merge_duration_seconds', thanos.store.dashboard.selector, thanos.store.dashboard.dimensions) +
+          g.panel('Merge', 'Shows how long has it taken to merge series.') { span:: 0 } +
+          g.latencyPanel('thanos_bucket_store_series_merge_duration_seconds', thanos.store.dashboard.selector, thanos.store.dashboard.dimensions) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title)
         )
         .addPanel(
-          g.panel('Memory Used', 'Memory working set') +
+          g.panel('Memory Used', 'Memory working set') { span:: 0 } +
           g.queryPanel(
             [
               '(container_memory_working_set_bytes{container="thanos-store", namespace="$namespace"})',
@@ -664,13 +657,13 @@ function() {
             [
               'memory usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title) +
           { yaxes: g.yaxes('bytes') } +
           g.stack
         )
         .addPanel(
-          g.panel('CPU Usage') +
+          g.panel('CPU Usage') { span:: 0 } +
           g.queryPanel(
             [
               'rate(process_cpu_seconds_total{job=~"observatorium-thanos-store-.*", namespace="$namespace"}[$interval]) * 100',
@@ -678,11 +671,11 @@ function() {
             [
               'cpu usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title)
         )
         .addPanel(
-          g.panel('Pod/Container Restarts') +
+          g.panel('Pod/Container Restarts') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (kube_pod_container_status_restarts_total{namespace="$namespace", container="thanos-store"})',
@@ -690,11 +683,11 @@ function() {
             [
               'pod restart count {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(thanos.store.dashboard.title)
         )
         .addPanel(
-          g.panel('Network Traffic') +
+          g.panel('Network Traffic') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-thanos-store-.*"}[$interval]))',
@@ -704,7 +697,7 @@ function() {
               'network traffic in {{pod}}',
               'network traffic out {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.stack +
           g.addDashboardLink(thanos.store.dashboard.title) +
           { yaxes: g.yaxes('binBps') }
@@ -713,7 +706,7 @@ function() {
       .addRow(
         g.row('Alertmanager Overview')
         .addPanel(
-          g.panel('Alerts receive rate', 'rate of successful and invalid alerts received by the Alertmanager') +
+          g.panel('Alerts receive rate', 'rate of successful and invalid alerts received by the Alertmanager') { span:: 0 } +
           g.queryPanel(
             [
               'sum(rate(alertmanager_alerts_received_total{namespace=~"$namespace",job=~"$job"}[$__rate_interval])) by (namespace,job,pod)',
@@ -723,11 +716,11 @@ function() {
               'alerts received {{pod}}',
               'alerts invalid {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(am.title)
         )
         .addPanel(
-          g.panel('Memory Used', 'Memory working set') +
+          g.panel('Memory Used', 'Memory working set') { span:: 0 } +
           g.queryPanel(
             [
               '(container_memory_working_set_bytes{container="observatorium-alertmanager", namespace="$namespace"})',
@@ -735,13 +728,13 @@ function() {
             [
               'memory usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(am.title) +
           { yaxes: g.yaxes('bytes') } +
           g.stack
         )
         .addPanel(
-          g.panel('CPU Usage') +
+          g.panel('CPU Usage') { span:: 0 } +
           g.queryPanel(
             [
               'rate(process_cpu_seconds_total{job=~"observatorium-alertmanager.*", namespace="$namespace"}[$interval]) * 100',
@@ -749,11 +742,11 @@ function() {
             [
               'cpu usage system {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(am.title)
         )
         .addPanel(
-          g.panel('Pod/Container Restarts') +
+          g.panel('Pod/Container Restarts') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (kube_pod_container_status_restarts_total{namespace="$namespace", container="observatorium-alertmanager"})',
@@ -761,11 +754,11 @@ function() {
             [
               'pod restart count {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.addDashboardLink(am.title)
         )
         .addPanel(
-          g.panel('Network Traffic') +
+          g.panel('Network Traffic') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-alertmanager.*"}[$interval]))',
@@ -775,7 +768,7 @@ function() {
               'network traffic in {{pod}}',
               'network traffic out {{pod}}',
             ]
-          ) +
+          ) { span:: 0 } +
           g.stack +
           g.addDashboardLink(am.title) +
           { yaxes: g.yaxes('binBps') }

--- a/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
@@ -79,7 +79,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -171,7 +170,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -279,7 +277,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -465,7 +462,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -574,7 +570,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -689,7 +684,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -779,7 +773,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -880,7 +873,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -972,7 +964,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -1064,7 +1055,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -1156,7 +1146,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -1288,7 +1277,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -1380,7 +1368,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -1488,7 +1475,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -1602,7 +1588,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -1694,7 +1679,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -1786,7 +1770,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -1878,7 +1861,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -2010,7 +1992,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -2102,7 +2083,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -2210,7 +2190,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -2344,7 +2323,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -2436,7 +2414,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -2544,7 +2521,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -2653,7 +2629,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -2746,7 +2721,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -2838,7 +2812,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -2930,7 +2903,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -3022,7 +2994,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -3154,7 +3125,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -3246,7 +3216,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -3354,7 +3323,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -3488,7 +3456,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -3580,7 +3547,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -3688,7 +3654,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -3797,7 +3762,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -3890,7 +3854,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -3982,7 +3945,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -4074,7 +4036,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -4166,7 +4127,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -4249,12 +4209,6 @@ data:
          "datasource": "$datasource",
          "description": "Displays the rate of total rule evaluations,",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 0,
-          "y": 9
-         },
          "id": 41,
          "legend": {
           "avg": false,
@@ -4285,7 +4239,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -4348,12 +4301,6 @@ data:
          "datasource": "$datasource",
          "description": "Displays the rate of rule evaluation failures, grouped by rule group.",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 6,
-          "y": 9
-         },
          "id": 42,
          "legend": {
           "avg": false,
@@ -4384,7 +4331,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -4446,12 +4392,6 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 12,
-          "y": 9
-         },
          "id": 43,
          "legend": {
           "avg": false,
@@ -4482,7 +4422,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -4545,12 +4484,6 @@ data:
          "datasource": "$datasource",
          "description": "Displays the total time of rule group evaluations that took longer than their scheduled interval.",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 18,
-          "y": 9
-         },
          "id": 44,
          "legend": {
           "avg": false,
@@ -4581,7 +4514,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -4644,12 +4576,6 @@ data:
          "datasource": "$datasource",
          "description": "Shows the rate of total alerts sent by Thanos.",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 0,
-          "y": 15
-         },
          "id": 45,
          "legend": {
           "avg": false,
@@ -4680,7 +4606,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -4743,12 +4668,6 @@ data:
          "datasource": "$datasource",
          "description": "Displays the ratio of error rate to total alerts sent rate by Thanos.",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 6,
-          "y": 15
-         },
          "id": 46,
          "legend": {
           "avg": false,
@@ -4779,7 +4698,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -4842,12 +4760,6 @@ data:
          "datasource": "$datasource",
          "description": "Displays the 50th, 90th, and 99th percentile latency of alert requests sent by Thanos.",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 12,
-          "y": 15
-         },
          "id": 47,
          "legend": {
           "avg": false,
@@ -4878,7 +4790,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -4956,12 +4867,6 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 0,
-          "y": 21
-         },
          "id": 48,
          "legend": {
           "avg": false,
@@ -4992,7 +4897,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -5054,12 +4958,6 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 6,
-          "y": 21
-         },
          "id": 49,
          "legend": {
           "avg": false,
@@ -5090,7 +4988,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -5152,12 +5049,6 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 12,
-          "y": 21
-         },
          "id": 50,
          "legend": {
           "avg": false,
@@ -5188,7 +5079,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -5258,12 +5148,6 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 1,
-         "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 18,
-          "y": 21
-         },
          "id": 51,
          "legend": {
           "avg": false,
@@ -5294,7 +5178,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -5470,7 +5353,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -5562,7 +5444,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -5670,7 +5551,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -5856,7 +5736,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -5948,7 +5827,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -6056,7 +5934,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -6165,7 +6042,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -6291,7 +6167,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -6423,7 +6298,6 @@ data:
           }
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -6538,7 +6412,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -6630,7 +6503,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -6722,7 +6594,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -6814,7 +6685,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 0,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -6927,7 +6797,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 2,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -7028,7 +6897,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 2,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -7120,7 +6988,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 2,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -7212,7 +7079,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 2,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -7304,7 +7170,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 2,
          "stack": true,
          "steppedLine": false,
          "targets": [


### PR DESCRIPTION
In thanos mixin [builder.libsonnet](https://github.com/thanos-io/thanos/blob/main/mixin/lib/thanos-grafana-builder/builder.libsonnet) we import [grpc.libsonnet](https://github.com/thanos-io/thanos/blob/main/mixin/lib/thanos-grafana-builder/grpc.libsonnet), [http.libsonnet](https://github.com/thanos-io/thanos/blob/main/mixin/lib/thanos-grafana-builder/http.libsonnet), slo.libsonnet and uses their functions like `httpQpsPanel`, `httpErrPanel`, `latencyPanel` etc for creating respective panels in our libsonnet. Since these function's don't have the property to change the span size and without that, they pick up the default values from [this](https://github.com/grafana/jsonnet-libs/blob/f33dff93db677a32303630c3e0910cf6d46a92cc/grafana-builder/grafana.libsonnet#L182). It's best to remove the span property completely as it interferes with the default layout sizing which grafana provides as removing the span property allows grafana to dynamically size the panels inside a row.

[Link](https://grafana.stage.devshift.net/d/ltvkT_r4z/vprashar-test?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace=observatorium-mst-production&var-job=All&var-interval=5m&from=1688715625166&to=1688719225166) to dashboard using generated JSON