### PR TITLE
Add Gubernator row to the instance utilization dashboard

### DIFF
--- a/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
+++ b/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
@@ -105,12 +105,10 @@ function() {
 
   gubernator+:: {
     selector: error 'must provide selector for Gubernator dashboard',
-    title: error 'must provide title for Gubernator dashboard',
     dashboard:: {
       title: 'Observatorium - Gubernator',
       selector: std.join(', ', config.dashboard.selector + ['job=~"$job"']),
       dimensions: std.join(', ', config.dashboard.dimensions + ['job']),
-      pod: 'observatorium-gubernator',
     },
   },
 

--- a/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
+++ b/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
@@ -730,7 +730,8 @@ function() {
             [
               'gRPC requests {{pod}}',
             ]
-          )
+          ) +
+          g.stack
         )
         .addPanel(
           g.panel('Rate of errors in gRPC requests', 'Shows count of errors in gRPC requests to gubernator') +
@@ -741,7 +742,8 @@ function() {
             [
               'gRPC request errors {{pod}}',
             ]
-          )
+          ) +
+          g.stack
         )
         .addPanel(
           g.panel('Duration of gRPC requests', 'Shows duration of gRPC requests to gubernator') +
@@ -783,7 +785,7 @@ function() {
           g.panel('Memory Used', 'Memory working set') +
           g.queryPanel(
             [
-              '(container_memory_working_set_bytes{container="observatorium-alertmanager", namespace="$namespace"})',
+              '(container_memory_working_set_bytes{container="gubernator", namespace="$namespace"})',
             ],
             [
               'memory usage system {{pod}}',
@@ -797,7 +799,7 @@ function() {
           g.panel('CPU Usage') +
           g.queryPanel(
             [
-              'rate(process_cpu_seconds_total{job=~"observatorium-alertmanager.*", namespace="$namespace"}[$interval]) * 100',
+              'rate(container_cpu_usage_seconds_total{pod=~"observatorium-gubernator.*", namespace="$namespace"}[$interval]) * 100',
             ],
             [
               'cpu usage system {{pod}}',
@@ -809,7 +811,7 @@ function() {
           g.panel('Pod/Container Restarts') +
           g.queryPanel(
             [
-              'sum by (pod) (kube_pod_container_status_restarts_total{namespace="$namespace", container="observatorium-alertmanager"})',
+              'sum by (pod) (kube_pod_container_status_restarts_total{namespace="$namespace", container="gubernator"})',
             ],
             [
               'pod restart count {{pod}}',
@@ -821,8 +823,8 @@ function() {
           g.panel('Network Traffic') +
           g.queryPanel(
             [
-              'sum by (pod) (rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-alertmanager.*"}[$interval]))',
-              'sum by (pod) (rate(container_network_transmit_bytes_total{namespace="$namespace", pod=~"observatorium-alertmanager.*"}[$interval]))',
+              'sum by (pod) (rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-gubernator.*"}[$interval]))',
+              'sum by (pod) (rate(container_network_transmit_bytes_total{namespace="$namespace", pod=~"observatorium-gubernator.*"}[$interval]))',
             ],
             [
               'network traffic in {{pod}}',

--- a/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
+++ b/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
@@ -715,7 +715,7 @@ function() {
       .addRow(
         g.row('Gubernator Overview')
         .addPanel(
-          g.panel('Rate of gRPC requests', 'Shows count of gRPC requests to gubernator') +
+          g.panel('Rate of gRPC requests', 'Shows count of gRPC requests to gubernator') { span:: 0 } +
           g.queryPanel(
             [
               'sum(rate(gubernator_grpc_request_counts{namespace="$namespace",job=~"$job"}[$__rate_interval])) by (namespace,job,pod)',
@@ -727,7 +727,7 @@ function() {
           g.stack
         )
         .addPanel(
-          g.panel('Rate of errors in gRPC requests', 'Shows count of errors in gRPC requests to gubernator') +
+          g.panel('Rate of errors in gRPC requests', 'Shows count of errors in gRPC requests to gubernator') { span:: 0 } +
           g.queryPanel(
             [
               'sum(rate(gubernator_grpc_request_counts{status="failed",namespace="$namespace",job=~"$job"}[$__rate_interval])) by (namespace,job,pod)',
@@ -739,7 +739,7 @@ function() {
           g.stack
         )
         .addPanel(
-          g.panel('Duration of gRPC requests', 'Shows duration of gRPC requests to gubernator') +
+          g.panel('Duration of gRPC requests', 'Shows duration of gRPC requests to gubernator') { span:: 0 } +
           g.queryPanel(
             [
               'gubernator_grpc_request_duration{quantile="0.99", namespace="$namespace",job=~"$job"}',
@@ -753,7 +753,7 @@ function() {
           { yaxes: g.yaxes('s') },
         )
         .addPanel(
-          g.panel('Local queue of rate checks', 'Shows the number of rate checks in the local queue') +
+          g.panel('Local queue of rate checks', 'Shows the number of rate checks in the local queue') { span:: 0 } +
           g.queryPanel(
             [
               'gubernator_pool_queue_length{namespace="$namespace",job=~"$job"}',
@@ -764,7 +764,7 @@ function() {
           )
         )
         .addPanel(
-          g.panel('Peer queue of rate checks', 'Shows the number of rate checks in the peer queue') +
+          g.panel('Peer queue of rate checks', 'Shows the number of rate checks in the peer queue') { span:: 0 } +
           g.queryPanel(
             [
               'gubernator_queue_length{namespace="$namespace",job=~"$job"}',
@@ -775,7 +775,7 @@ function() {
           )
         )
         .addPanel(
-          g.panel('Memory Used', 'Memory working set') +
+          g.panel('Memory Used', 'Memory working set') { span:: 0 } +
           g.queryPanel(
             [
               '(container_memory_working_set_bytes{container="gubernator", namespace="$namespace"})',
@@ -784,12 +784,11 @@ function() {
               'memory usage system {{pod}}',
             ]
           ) +
-          g.addDashboardLink(am.title) +
           { yaxes: g.yaxes('bytes') } +
           g.stack
         )
         .addPanel(
-          g.panel('CPU Usage') +
+          g.panel('CPU Usage') { span:: 0 } +
           g.queryPanel(
             [
               'rate(container_cpu_usage_seconds_total{pod=~"observatorium-gubernator.*", namespace="$namespace"}[$interval]) * 100',
@@ -797,11 +796,10 @@ function() {
             [
               'cpu usage system {{pod}}',
             ]
-          ) +
-          g.addDashboardLink(am.title)
+          )
         )
         .addPanel(
-          g.panel('Pod/Container Restarts') +
+          g.panel('Pod/Container Restarts') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (kube_pod_container_status_restarts_total{namespace="$namespace", container="gubernator"})',
@@ -809,11 +807,10 @@ function() {
             [
               'pod restart count {{pod}}',
             ]
-          ) +
-          g.addDashboardLink(am.title)
+          )
         )
         .addPanel(
-          g.panel('Network Traffic') +
+          g.panel('Network Traffic') { span:: 0 } +
           g.queryPanel(
             [
               'sum by (pod) (rate(container_network_receive_bytes_total{namespace="$namespace", pod=~"observatorium-gubernator.*"}[$interval]))',
@@ -825,7 +822,6 @@ function() {
             ]
           ) +
           g.stack +
-          g.addDashboardLink(am.title) +
           { yaxes: g.yaxes('binBps') }
         )
       )

--- a/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
@@ -6896,7 +6896,7 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Shows count of gRPC requests to gubernator",
-         "fill": 1,
+         "fill": 10,
          "id": 65,
          "legend": {
           "avg": false,
@@ -6908,7 +6908,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 1,
+         "linewidth": 0,
          "links": [
 
          ],
@@ -6922,7 +6922,7 @@ data:
          ],
          "spaceLength": 10,
          "span": 1,
-         "stack": false,
+         "stack": true,
          "steppedLine": false,
          "targets": [
           {
@@ -6983,7 +6983,7 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Shows count of errors in gRPC requests to gubernator",
-         "fill": 1,
+         "fill": 10,
          "id": 66,
          "legend": {
           "avg": false,
@@ -6995,7 +6995,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 1,
+         "linewidth": 0,
          "links": [
 
          ],
@@ -7009,7 +7009,7 @@ data:
          ],
          "spaceLength": 10,
          "span": 1,
-         "stack": false,
+         "stack": true,
          "steppedLine": false,
          "targets": [
           {
@@ -7375,7 +7375,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "(container_memory_working_set_bytes{container=\"observatorium-alertmanager\", namespace=\"$namespace\"})",
+           "expr": "(container_memory_working_set_bytes{container=\"gubernator\", namespace=\"$namespace\"})",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "memory usage system {{pod}}",
@@ -7467,7 +7467,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "rate(process_cpu_seconds_total{job=~\"observatorium-alertmanager.*\", namespace=\"$namespace\"}[$interval]) * 100",
+           "expr": "rate(container_cpu_usage_seconds_total{pod=~\"observatorium-gubernator.*\", namespace=\"$namespace\"}[$interval]) * 100",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "cpu usage system {{pod}}",
@@ -7559,7 +7559,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by (pod) (kube_pod_container_status_restarts_total{namespace=\"$namespace\", container=\"observatorium-alertmanager\"})",
+           "expr": "sum by (pod) (kube_pod_container_status_restarts_total{namespace=\"$namespace\", container=\"gubernator\"})",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "pod restart count {{pod}}",
@@ -7651,7 +7651,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by (pod) (rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-alertmanager.*\"}[$interval]))",
+           "expr": "sum by (pod) (rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-gubernator.*\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "network traffic in {{pod}}",
@@ -7659,7 +7659,7 @@ data:
            "step": 10
           },
           {
-           "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-alertmanager.*\"}[$interval]))",
+           "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-gubernator.*\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "network traffic out {{pod}}",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
@@ -6791,7 +6791,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -6878,7 +6877,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -6965,7 +6963,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -7060,7 +7057,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -7147,7 +7143,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -7223,13 +7218,7 @@ data:
          "lines": true,
          "linewidth": 0,
          "links": [
-          {
-           "dashboard": "Alertmanager / Overview",
-           "includeVars": true,
-           "keepTime": true,
-           "title": "Alertmanager / Overview",
-           "type": "dashboard"
-          }
+
          ],
          "nullPointMode": "null as zero",
          "percentage": false,
@@ -7240,7 +7229,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [
@@ -7315,13 +7303,7 @@ data:
          "lines": true,
          "linewidth": 1,
          "links": [
-          {
-           "dashboard": "Alertmanager / Overview",
-           "includeVars": true,
-           "keepTime": true,
-           "title": "Alertmanager / Overview",
-           "type": "dashboard"
-          }
+
          ],
          "nullPointMode": "null as zero",
          "percentage": false,
@@ -7332,7 +7314,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -7407,13 +7388,7 @@ data:
          "lines": true,
          "linewidth": 1,
          "links": [
-          {
-           "dashboard": "Alertmanager / Overview",
-           "includeVars": true,
-           "keepTime": true,
-           "title": "Alertmanager / Overview",
-           "type": "dashboard"
-          }
+
          ],
          "nullPointMode": "null as zero",
          "percentage": false,
@@ -7424,7 +7399,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": false,
          "steppedLine": false,
          "targets": [
@@ -7499,13 +7473,7 @@ data:
          "lines": true,
          "linewidth": 0,
          "links": [
-          {
-           "dashboard": "Alertmanager / Overview",
-           "includeVars": true,
-           "keepTime": true,
-           "title": "Alertmanager / Overview",
-           "type": "dashboard"
-          }
+
          ],
          "nullPointMode": "null as zero",
          "percentage": false,
@@ -7516,7 +7484,6 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 1,
          "stack": true,
          "steppedLine": false,
          "targets": [

--- a/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
@@ -6895,9 +6895,841 @@ data:
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "rate of successful and invalid alerts received by the Alertmanager",
+         "description": "Shows count of gRPC requests to gubernator",
          "fill": 1,
          "id": 65,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum(rate(gubernator_grpc_request_counts{namespace=\"$namespace\",job=~\"$job\"}[$__rate_interval])) by (namespace,job,pod)",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "gRPC requests {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Rate of gRPC requests",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Shows count of errors in gRPC requests to gubernator",
+         "fill": 1,
+         "id": 66,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum(rate(gubernator_grpc_request_counts{status=\"failed\",namespace=\"$namespace\",job=~\"$job\"}[$__rate_interval])) by (namespace,job,pod)",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "gRPC request errors {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Rate of errors in gRPC requests",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Shows duration of gRPC requests to gubernator",
+         "fill": 1,
+         "id": 67,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "gubernator_grpc_request_duration{quantile=\"0.99\", namespace=\"$namespace\",job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P99: {{pod}}",
+           "legendLink": null,
+           "step": 10
+          },
+          {
+           "expr": "gubernator_grpc_request_duration{quantile=\"0.5\", namespace=\"$namespace\",job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P50: {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Duration of gRPC requests",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "s",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Shows the number of rate checks in the local queue",
+         "fill": 1,
+         "id": 68,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "gubernator_pool_queue_length{namespace=\"$namespace\",job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "local queue size {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Local queue of rate checks",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Shows the number of rate checks in the peer queue",
+         "fill": 1,
+         "id": 69,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "gubernator_queue_length{namespace=\"$namespace\",job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "peer queue size {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Peer queue of rate checks",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Memory working set",
+         "fill": 10,
+         "id": 70,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+          {
+           "dashboard": "Alertmanager / Overview",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Alertmanager / Overview",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "(container_memory_working_set_bytes{container=\"observatorium-alertmanager\", namespace=\"$namespace\"})",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "memory usage system {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Memory Used",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "bytes",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "id": 71,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+          {
+           "dashboard": "Alertmanager / Overview",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Alertmanager / Overview",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "rate(process_cpu_seconds_total{job=~\"observatorium-alertmanager.*\", namespace=\"$namespace\"}[$interval]) * 100",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "cpu usage system {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "CPU Usage",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 1,
+         "id": 72,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [
+          {
+           "dashboard": "Alertmanager / Overview",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Alertmanager / Overview",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (pod) (kube_pod_container_status_restarts_total{namespace=\"$namespace\", container=\"observatorium-alertmanager\"})",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "pod restart count {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Pod/Container Restarts",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 10,
+         "id": 73,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+          {
+           "dashboard": "Alertmanager / Overview",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Alertmanager / Overview",
+           "type": "dashboard"
+          }
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 1,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (pod) (rate(container_network_receive_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-alertmanager.*\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "network traffic in {{pod}}",
+           "legendLink": null,
+           "step": 10
+          },
+          {
+           "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{namespace=\"$namespace\", pod=~\"observatorium-alertmanager.*\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "network traffic out {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Network Traffic",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "binBps",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        }
+       ],
+       "repeat": null,
+       "repeatIteration": null,
+       "repeatRowId": null,
+       "showTitle": true,
+       "title": "Gubernator Overview",
+       "titleSize": "h6"
+      },
+      {
+       "collapse": false,
+       "height": "250px",
+       "panels": [
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "rate of successful and invalid alerts received by the Alertmanager",
+         "fill": 1,
+         "id": 74,
          "legend": {
           "avg": false,
           "current": false,
@@ -6998,7 +7830,7 @@ data:
          "datasource": "$datasource",
          "description": "Memory working set",
          "fill": 10,
-         "id": 66,
+         "id": 75,
          "legend": {
           "avg": false,
           "current": false,
@@ -7090,7 +7922,7 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 1,
-         "id": 67,
+         "id": 76,
          "legend": {
           "avg": false,
           "current": false,
@@ -7182,7 +8014,7 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 1,
-         "id": 68,
+         "id": 77,
          "legend": {
           "avg": false,
           "current": false,
@@ -7274,7 +8106,7 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "fill": 10,
-         "id": 69,
+         "id": 78,
          "legend": {
           "avg": false,
           "current": false,


### PR DESCRIPTION
Dashboard preview: https://grafana.stage.devshift.net/goto/cWMxVur4z?orgId=1

As we don't have yet a detailed dashboard for Gubernator, it doesn't offer a dashboard link and is adapted to this.