### PR TITLE
Update SLOs for split querier

### DIFF
--- a/configuration/observatorium/queries-ruler.libsonnet
+++ b/configuration/observatorium/queries-ruler.libsonnet
@@ -1,0 +1,16 @@
+{
+  queries: [
+    {
+      name: 'rule-query-path-sli-1M-samples',
+      query: 'avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"}[1h])',
+    },
+    {
+      name: 'rule-query-path-sli-10M-samples',
+      query: 'avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"}[10h])',
+    },
+    {
+      name: 'rule-query-path-sli-100M-samples',
+      query: 'avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id="0fc2b00e-201b-4c17-b9f2-19d91adc4fd2"}[100h])',
+    },
+  ],
+}

--- a/configuration/observatorium/slo.go
+++ b/configuration/observatorium/slo.go
@@ -305,7 +305,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 					slo.PropagationLabelsPrefix + "service": "observatorium-api",
 					"instance":                              string(envName),
 				},
-				description:         "API /query handler is burning too much error budget to guarantee availability SLOs.",
+				description:         "API /query handler endpoint for rules evaluation is burning too much error budget to guarantee availability SLOs.",
 				successOrErrorsExpr: "http_requests_total{job=\"observatorium-ruler-query\", handler=\"query\", code=~\"^5..$\"}",
 				totalExpr:           "http_requests_total{job=\"observatorium-ruler-query\", handler=\"query\"}",
 				alertName:           "APIMetricsRulerQueryAvailabilityErrorBudgetBurning",
@@ -445,6 +445,18 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 				successOrErrorsExpr: "up_custom_query_duration_seconds_bucket{query=\"rule-query-path-sli-10M-samples\", namespace=\"" + upNS[envName] + "\", http_code=~\"^2..$\", le=\"30\"}",
 				totalExpr:           "up_custom_query_duration_seconds_count{query=\"rule-query-path-sli-10M-samples\", namespace=\"" + upNS[envName] + "\", http_code=~\"^2..$\"}",
 				alertName:           "APIMetricsRuleReadLatency10MErrorBudgetBurning",
+				sloType:             sloTypeLatency,
+			},
+			{
+				name: "api-metrics-rule-read-100M-latency-slo",
+				labels: map[string]string{
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
+					"instance":                              string(envName),
+				},
+				description:         "API /query endpoint for rules evaluation is burning too much error budget for 100M samples, to guarantee latency SLOs.",
+				successOrErrorsExpr: "up_custom_query_duration_seconds_bucket{query=\"rule-query-path-sli-1M-samples\", namespace=\"" + upNS[envName] + "\", http_code=~\"^2..$\", le=\"120\"}",
+				totalExpr:           "up_custom_query_duration_seconds_count{query=\"rule-query-path-sli-1M-samples\", namespace=\"" + upNS[envName] + "\", http_code=~\"^2..$\"}",
+				alertName:           "APIMetricsRuleReadLatency100MErrorBudgetBurning",
 				sloType:             sloTypeLatency,
 			},
 			{

--- a/configuration/observatorium/slo.go
+++ b/configuration/observatorium/slo.go
@@ -297,6 +297,20 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 				alertName:           "APIMetricsWriteAvailabilityErrorBudgetBurning",
 				sloType:             sloTypeAvailability,
 			},
+			// Queriers are deployed as separate instances for adhoc and rule queries.
+			// The read availability SLO is split to reflect this deployment topology.
+			{
+				name: "api-metrics-rule-query-availability-slo",
+				labels: map[string]string{
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
+					"instance":                              string(envName),
+				},
+				description:         "API /query handler is burning too much error budget to guarantee availability SLOs.",
+				successOrErrorsExpr: "http_requests_total{job=\"observatorium-ruler-query\", handler=\"query\", code=~\"^5..$\"}",
+				totalExpr:           "http_requests_total{job=\"observatorium-ruler-query\", handler=\"query\"}",
+				alertName:           "APIMetricsRulerQueryAvailabilityErrorBudgetBurning",
+				sloType:             sloTypeAvailability,
+			},
 			{
 				name: "api-metrics-query-availability-slo",
 				labels: map[string]string{
@@ -405,6 +419,32 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 				successOrErrorsExpr: "http_request_duration_seconds_bucket{job=\"" + apiJobSelector[envName] + "\", handler=\"receive\", group=\"metricsv1\", code=~\"^2..$\", le=\"" + genericSLOLatencySeconds + "\"}",
 				totalExpr:           "http_request_duration_seconds_count{job=\"" + apiJobSelector[envName] + "\", handler=\"receive\", group=\"metricsv1\", code=~\"^2..$\"}",
 				alertName:           "APIMetricsWriteLatencyErrorBudgetBurning",
+				sloType:             sloTypeLatency,
+			},
+			// Queriers are deployed as separate instances for adhoc and rule queries.
+			// The read latencies SLO are split to reflect this deployment topology.
+			{
+				name: "api-metrics-rule-read-1M-latency-slo",
+				labels: map[string]string{
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
+					"instance":                              string(envName),
+				},
+				description:         "API /query endpoint for rules evaluation is burning too much error budget for 1M samples, to guarantee latency SLOs.",
+				successOrErrorsExpr: "up_custom_query_duration_seconds_bucket{query=\"rule-query-path-sli-1M-samples\", namespace=\"" + upNS[envName] + "\", http_code=~\"^2..$\", le=\"10\"}",
+				totalExpr:           "up_custom_query_duration_seconds_count{query=\"rule-query-path-sli-1M-samples\", namespace=\"" + upNS[envName] + "\", http_code=~\"^2..$\"}",
+				alertName:           "APIMetricsRuleReadLatency1MErrorBudgetBurning",
+				sloType:             sloTypeLatency,
+			},
+			{
+				name: "api-metrics-rule-read-10M-latency-slo",
+				labels: map[string]string{
+					slo.PropagationLabelsPrefix + "service": "observatorium-api",
+					"instance":                              string(envName),
+				},
+				description:         "API /query endpoint for rules evaluation is burning too much error budget for 100M samples, to guarantee latency SLOs.",
+				successOrErrorsExpr: "up_custom_query_duration_seconds_bucket{query=\"rule-query-path-sli-10M-samples\", namespace=\"" + upNS[envName] + "\", http_code=~\"^2..$\", le=\"30\"}",
+				totalExpr:           "up_custom_query_duration_seconds_count{query=\"rule-query-path-sli-10M-samples\", namespace=\"" + upNS[envName] + "\", http_code=~\"^2..$\"}",
+				alertName:           "APIMetricsRuleReadLatency10MErrorBudgetBurning",
 				sloType:             sloTypeLatency,
 			},
 			{

--- a/configuration/observatorium/slo.go
+++ b/configuration/observatorium/slo.go
@@ -456,7 +456,7 @@ func ObservatoriumSLOs(envName rhobsInstanceEnv, signal signal) []pyrrav1alpha1.
 				description:         "API /query endpoint for rules evaluation is burning too much error budget for 100M samples, to guarantee latency SLOs.",
 				successOrErrorsExpr: "up_custom_query_duration_seconds_bucket{query=\"rule-query-path-sli-1M-samples\", namespace=\"" + upNS[envName] + "\", http_code=~\"^2..$\", le=\"120\"}",
 				totalExpr:           "up_custom_query_duration_seconds_count{query=\"rule-query-path-sli-1M-samples\", namespace=\"" + upNS[envName] + "\", http_code=~\"^2..$\"}",
-				alertName:           "APIMetricsRuleReadLatency100MErrorBudgetBurning",
+				alertName:           "APIMetricsRulenReadLatency100MErrorBudgetBurning",
 				sloType:             sloTypeLatency,
 			},
 			{

--- a/observability/dashboards/slo.libsonnet
+++ b/observability/dashboards/slo.libsonnet
@@ -440,7 +440,7 @@ function(instanceName, environment, dashboardName) {
       'sum(rate(http_request_duration_seconds_count{job="%s",code!~"4..",group="metricsv1",handler=~"receive"}[28d]))' % instance.apiJob,
       3
     ) +
-    titleRow('API > Metrics Read > Availability') +
+    titleRow('API > Metrics Read > Ad Hoc > Availability') +
     availabilityRow(
       '99.5% of valid /query requests return successfully',
       0.995,
@@ -455,7 +455,7 @@ function(instanceName, environment, dashboardName) {
       'sum(rate(http_requests_total{job="%s",group="metricsv1",handler=~"query_range",code!~"4.+"}[28d]))' % instance.apiJob,
       5
     ) +
-    titleRow('API > Metrics Read > Latency') +
+    titleRow('API > Metrics Read > Ad Hoc > Latency') +
     latencyRow(
       '90% of valid requests that process 1M samples return < 10s',
       0.9,
@@ -481,6 +481,42 @@ function(instanceName, environment, dashboardName) {
       'sum(rate(up_custom_query_duration_seconds_bucket{namespace="%s",query="query-path-sli-100M-samples",le="120"}[28d]))' % instance.upNamespace,
       'rate(up_custom_query_duration_seconds_bucket{namespace="%s",query="query-path-sli-100M-samples"}[1d])' % instance.upNamespace,
       'sum(rate(up_custom_query_duration_seconds_count{namespace="%s",query="query-path-sli-100M-samples"}[28d]))' % instance.upNamespace,
+      8
+    ) +
+    titleRow('API > Metrics Read > Rule > Availability') +
+    availabilityRow(
+      '99.5% of valid /query requests return successfully',
+      0.995,
+      'sum(rate(http_requests_total{job="observatorium-ruler-query",handler="query",code=~"5.+"}[28d]))',
+      'sum(rate(http_requests_total{job="observatorium-ruler-query",handler="query",code!~"4.+"}[28d]))',
+      4
+    ) +
+    titleRow('API > Metrics Read > Rule > Latency') +
+    latencyRow(
+      '90% of valid requests that process 1M samples return < 10s',
+      0.9,
+      10,
+      'sum(rate(up_custom_query_duration_seconds_bucket{namespace="%s",query="rule-query-path-sli-1M-samples",le="10"}[28d]))' % instance.upNamespace,
+      'rate(up_custom_query_duration_seconds_bucket{namespace="%s",query="rule-query-path-sli-1M-samples"}[1d])' % instance.upNamespace,
+      'sum(rate(up_custom_query_duration_seconds_count{namespace="%s",query="rule-query-path-sli-1M-samples"}[28d]))' % instance.upNamespace,
+      6
+    ) +
+    latencyRow(
+      '90% of valid requests that process 10M samples return < 30s',
+      0.9,
+      30,
+      'sum(rate(up_custom_query_duration_seconds_bucket{namespace="%s",query="rule-query-path-sli-10M-samples",le="30"}[28d]))' % instance.upNamespace,
+      'rate(up_custom_query_duration_seconds_bucket{namespace="%s",query="rule-query-path-sli-10M-samples"}[1d])' % instance.upNamespace,
+      'sum(rate(up_custom_query_duration_seconds_count{namespace="%s",query="rule-query-path-sli-10M-samples"}[28d]))' % instance.upNamespace,
+      7
+    ) +
+    latencyRow(
+      '90% of valid requests that process 100M samples return < 120s',
+      0.9,
+      120,
+      'sum(rate(up_custom_query_duration_seconds_bucket{namespace="%s",query="rule-query-path-sli-100M-samples",le="120"}[28d]))' % instance.upNamespace,
+      'rate(up_custom_query_duration_seconds_bucket{namespace="%s",query="rule-query-path-sli-100M-samples"}[1d])' % instance.upNamespace,
+      'sum(rate(up_custom_query_duration_seconds_count{namespace="%s",query="rule-query-path-sli-100M-samples"}[28d]))' % instance.upNamespace,
       8
     ) +
     titleRow('API > Rules Write (/rules/raw) > Availability') +

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-production.configmap.yaml
@@ -360,7 +360,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Metrics Read > Availability",
+                "title": "API > Metrics Read > Ad Hoc > Availability",
                 "type": "row"
             },
             {
@@ -690,7 +690,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Metrics Read > Latency",
+                "title": "API > Metrics Read > Ad Hoc > Latency",
                 "type": "row"
             },
             {
@@ -1167,6 +1167,666 @@ data:
                     {
                         "exemplar": true,
                         "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Rule > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">99.5% of valid /query requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 8,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 9,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.995\n)\n/\n(1 - 0.995), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Rule > Latency",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 1M samples return < 10s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 10,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 12,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-1M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 13,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-1M-samples\",le=\"10\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-1M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 10M samples return < 30s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 30,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 14,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-10M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 15,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-10M-samples\",le=\"30\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-10M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 100M samples return < 120s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 120,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 16,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-100M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 17,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-mst-stage.configmap.yaml
@@ -360,7 +360,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Metrics Read > Availability",
+                "title": "API > Metrics Read > Ad Hoc > Availability",
                 "type": "row"
             },
             {
@@ -690,7 +690,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Metrics Read > Latency",
+                "title": "API > Metrics Read > Ad Hoc > Latency",
                 "type": "row"
             },
             {
@@ -1167,6 +1167,666 @@ data:
                     {
                         "exemplar": true,
                         "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-stage\",query=\"query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-stage\",query=\"query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Rule > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">99.5% of valid /query requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 8,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 9,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.995\n)\n/\n(1 - 0.995), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Rule > Latency",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 1M samples return < 10s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 10,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 12,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-stage\",query=\"rule-query-path-sli-1M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 13,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-stage\",query=\"rule-query-path-sli-1M-samples\",le=\"10\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-stage\",query=\"rule-query-path-sli-1M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 10M samples return < 30s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 30,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 14,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-stage\",query=\"rule-query-path-sli-10M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 15,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-stage\",query=\"rule-query-path-sli-10M-samples\",le=\"30\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-stage\",query=\"rule-query-path-sli-10M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 100M samples return < 120s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 120,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 16,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-stage\",query=\"rule-query-path-sli-100M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 17,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-stage\",query=\"rule-query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-stage\",query=\"rule-query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-rhobsp02ue1-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-rhobsp02ue1-production.configmap.yaml
@@ -360,7 +360,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Metrics Read > Availability",
+                "title": "API > Metrics Read > Ad Hoc > Availability",
                 "type": "row"
             },
             {
@@ -690,7 +690,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Metrics Read > Latency",
+                "title": "API > Metrics Read > Ad Hoc > Latency",
                 "type": "row"
             },
             {
@@ -1167,6 +1167,666 @@ data:
                     {
                         "exemplar": true,
                         "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Rule > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">99.5% of valid /query requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 8,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 9,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.995\n)\n/\n(1 - 0.995), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Rule > Latency",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 1M samples return < 10s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 10,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 12,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-1M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 13,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-1M-samples\",le=\"10\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-1M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 10M samples return < 30s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 30,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 14,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-10M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 15,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-10M-samples\",le=\"30\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-10M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 100M samples return < 120s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 120,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 16,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-100M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "rhobsp02ue1-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 17,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-mst-production\",query=\"rule-query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-production.configmap.yaml
@@ -698,7 +698,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Metrics Read > Availability",
+                "title": "API > Metrics Read > Ad Hoc > Availability",
                 "type": "row"
             },
             {
@@ -1028,7 +1028,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Metrics Read > Latency",
+                "title": "API > Metrics Read > Ad Hoc > Latency",
                 "type": "row"
             },
             {
@@ -1505,6 +1505,666 @@ data:
                     {
                         "exemplar": true,
                         "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-production\",query=\"query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-production\",query=\"query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Rule > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">99.5% of valid /query requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 8,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 9,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.995\n)\n/\n(1 - 0.995), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Rule > Latency",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 1M samples return < 10s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 10,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 12,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-production\",query=\"rule-query-path-sli-1M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 13,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-production\",query=\"rule-query-path-sli-1M-samples\",le=\"10\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-production\",query=\"rule-query-path-sli-1M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 10M samples return < 30s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 30,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 14,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-production\",query=\"rule-query-path-sli-10M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 15,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-production\",query=\"rule-query-path-sli-10M-samples\",le=\"30\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-production\",query=\"rule-query-path-sli-10M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 100M samples return < 120s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 120,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 16,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-production\",query=\"rule-query-path-sli-100M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "telemeter-prod-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 17,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-production\",query=\"rule-query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-production\",query=\"rule-query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-slo-telemeter-stage.configmap.yaml
@@ -698,7 +698,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Metrics Read > Availability",
+                "title": "API > Metrics Read > Ad Hoc > Availability",
                 "type": "row"
             },
             {
@@ -1028,7 +1028,7 @@ data:
                 "panels": [
 
                 ],
-                "title": "API > Metrics Read > Latency",
+                "title": "API > Metrics Read > Ad Hoc > Latency",
                 "type": "row"
             },
             {
@@ -1505,6 +1505,666 @@ data:
                     {
                         "exemplar": true,
                         "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-stage\",query=\"query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-stage\",query=\"query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Rule > Availability",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">99.5% of valid /query requests return successfully</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 95
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 97.5
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 8,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "1-\n(sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n/\nsum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code!~\"4.+\"}[28d]))\n",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "Availability (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 9,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n( 1 -\n    (\n        (sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code=~\"5.+\"}[28d])) or vector(0))\n        /\n        sum(rate(http_requests_total{job=\"observatorium-ruler-query\",handler=\"query\",code!~\"4.+\"}[28d]))\n    ) - 0.995\n)\n/\n(1 - 0.995), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "collapsed": false,
+                "panels": [
+
+                ],
+                "title": "API > Metrics Read > Rule > Latency",
+                "type": "row"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 1M samples return < 10s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 10,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 12,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-stage\",query=\"rule-query-path-sli-1M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 13,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-stage\",query=\"rule-query-path-sli-1M-samples\",le=\"10\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-stage\",query=\"rule-query-path-sli-1M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 10M samples return < 30s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 30,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 14,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-stage\",query=\"rule-query-path-sli-10M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 15,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-stage\",query=\"rule-query-path-sli-10M-samples\",le=\"30\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-stage\",query=\"rule-query-path-sli-10M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
+                        "hide": false,
+                        "interval": "",
+                        "legendFormat": "",
+                        "refId": "B"
+                    }
+                ],
+                "title": "Error Budget (28d)",
+                "type": "stat"
+            },
+            {
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 0
+                },
+                "options": {
+                    "content": "<center style=\"font-size: 25px;\">90% of valid requests that process 100M samples return < 120s</center>",
+                    "mode": "markdown"
+                },
+                "pluginVersion": "8.2.1",
+                "title": "SLO",
+                "type": "text"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "mappings": [
+
+                        ],
+                        "max": 120,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "green",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 80
+                                },
+                                {
+                                    "color": "red",
+                                    "value": 100
+                                }
+                            ]
+                        },
+                        "unit": "s"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 5
+                },
+                "id": 16,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "histogram_quantile( 0.90000000000000002, sum by (le) ( rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-stage\",query=\"rule-query-path-sli-100M-samples\"}[1d]) ))\n",
+                        "hide": false,
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "refId": "A"
+                    }
+                ],
+                "title": "90th Percentile Request Latency (28d)",
+                "type": "stat"
+            },
+            {
+                "datasource": "app-sre-stage-01-prometheus",
+                "fieldConfig": {
+                    "defaults": {
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "decimals": 2,
+                        "mappings": [
+
+                        ],
+                        "max": 1,
+                        "min": 0,
+                        "thresholds": {
+                            "mode": "percentage",
+                            "steps": [
+                                {
+                                    "color": "red",
+                                    "value": null
+                                },
+                                {
+                                    "color": "orange",
+                                    "value": 33
+                                },
+                                {
+                                    "color": "green",
+                                    "value": 66
+                                }
+                            ]
+                        },
+                        "unit": "percentunit"
+                    },
+                    "overrides": [
+
+                    ]
+                },
+                "gridPos": {
+                    "h": 5,
+                    "w": 5,
+                    "x": 10
+                },
+                "id": 17,
+                "options": {
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "orientation": "auto",
+                    "reduceOptions": {
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": "",
+                        "values": false
+                    },
+                    "text": {
+
+                    },
+                    "textMode": "auto"
+                },
+                "pluginVersion": "8.2.1",
+                "targets": [
+                    {
+                        "exemplar": true,
+                        "expr": "clamp_min(\n    (\n        (\n            sum(rate(up_custom_query_duration_seconds_bucket{namespace=\"observatorium-stage\",query=\"rule-query-path-sli-100M-samples\",le=\"120\"}[28d]))\n            /\n            sum(rate(up_custom_query_duration_seconds_count{namespace=\"observatorium-stage\",query=\"rule-query-path-sli-100M-samples\"}[28d]))\n        ) - 0.90000000000000002\n    )\n    /\n    (1 - 0.90000000000000002), 0)\n",
                         "hide": false,
                         "interval": "",
                         "legendFormat": "",

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-rule-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-rule-query-availability-slo.yaml
@@ -3,8 +3,8 @@ kind: ServiceLevelObjective
 metadata:
   annotations:
     pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-    pyrra.dev/message: API /query handler is burning too much error budget to guarantee
-      availability SLOs.
+    pyrra.dev/message: API /query handler endpoint for rules evaluation is burning
+      too much error budget to guarantee availability SLOs.
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
   creationTimestamp: null
   labels:
@@ -14,8 +14,8 @@ metadata:
 spec:
   alerting:
     name: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
-  description: API /query handler is burning too much error budget to guarantee availability
-    SLOs.
+  description: API /query handler endpoint for rules evaluation is burning too much
+    error budget to guarantee availability SLOs.
   indicator:
     ratio:
       errors:

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-rule-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-rule-query-availability-slo.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query handler is burning too much error budget to guarantee
+      availability SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: mst-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-query-availability-slo
+spec:
+  alerting:
+    name: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+  description: API /query handler is burning too much error budget to guarantee availability
+    SLOs.
+  indicator:
+    ratio:
+      errors:
+        metric: http_requests_total{job="observatorium-ruler-query", handler="query",
+          code=~"^5..$"}
+      grouping: null
+      total:
+        metric: http_requests_total{job="observatorium-ruler-query", handler="query"}
+  target: "99"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-rule-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-rule-read-100M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 100M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: mst-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-100M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRulenReadLatency100MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 100M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$", le="120"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-rule-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-rule-read-10M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 100M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: mst-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-10M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRuleReadLatency10MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 100M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-10M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$", le="30"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-10M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-rule-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-production-api-metrics-rule-read-1M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 1M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: mst-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-1M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRuleReadLatency1MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 1M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$", le="10"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-rule-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-rule-query-availability-slo.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query handler is burning too much error budget to guarantee
+      availability SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: mst-stage
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-query-availability-slo
+spec:
+  alerting:
+    name: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+  description: API /query handler is burning too much error budget to guarantee availability
+    SLOs.
+  indicator:
+    ratio:
+      errors:
+        metric: http_requests_total{job="observatorium-ruler-query", handler="query",
+          code=~"^5..$"}
+      grouping: null
+      total:
+        metric: http_requests_total{job="observatorium-ruler-query", handler="query"}
+  target: "99"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-rule-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-rule-query-availability-slo.yaml
@@ -3,8 +3,8 @@ kind: ServiceLevelObjective
 metadata:
   annotations:
     pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-    pyrra.dev/message: API /query handler is burning too much error budget to guarantee
-      availability SLOs.
+    pyrra.dev/message: API /query handler endpoint for rules evaluation is burning
+      too much error budget to guarantee availability SLOs.
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
   creationTimestamp: null
   labels:
@@ -14,8 +14,8 @@ metadata:
 spec:
   alerting:
     name: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
-  description: API /query handler is burning too much error budget to guarantee availability
-    SLOs.
+  description: API /query handler endpoint for rules evaluation is burning too much
+    error budget to guarantee availability SLOs.
   indicator:
     ratio:
       errors:

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-rule-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-rule-read-100M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 100M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: mst-stage
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-100M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRulenReadLatency100MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 100M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-stage", http_code=~"^2..$", le="120"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-stage", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-rule-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-rule-read-10M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 100M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: mst-stage
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-10M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRuleReadLatency10MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 100M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-10M-samples",
+          namespace="observatorium-mst-stage", http_code=~"^2..$", le="30"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-10M-samples",
+          namespace="observatorium-mst-stage", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-rule-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/mst-stage-api-metrics-rule-read-1M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 1M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: mst-stage
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-1M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRuleReadLatency1MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 1M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-stage", http_code=~"^2..$", le="10"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-stage", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-rule-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-rule-query-availability-slo.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query handler is burning too much error budget to guarantee
+      availability SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: rhobsp02ue1-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-query-availability-slo
+spec:
+  alerting:
+    name: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+  description: API /query handler is burning too much error budget to guarantee availability
+    SLOs.
+  indicator:
+    ratio:
+      errors:
+        metric: http_requests_total{job="observatorium-ruler-query", handler="query",
+          code=~"^5..$"}
+      grouping: null
+      total:
+        metric: http_requests_total{job="observatorium-ruler-query", handler="query"}
+  target: "99"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-rule-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-rule-query-availability-slo.yaml
@@ -3,8 +3,8 @@ kind: ServiceLevelObjective
 metadata:
   annotations:
     pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-    pyrra.dev/message: API /query handler is burning too much error budget to guarantee
-      availability SLOs.
+    pyrra.dev/message: API /query handler endpoint for rules evaluation is burning
+      too much error budget to guarantee availability SLOs.
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
   creationTimestamp: null
   labels:
@@ -14,8 +14,8 @@ metadata:
 spec:
   alerting:
     name: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
-  description: API /query handler is burning too much error budget to guarantee availability
-    SLOs.
+  description: API /query handler endpoint for rules evaluation is burning too much
+    error budget to guarantee availability SLOs.
   indicator:
     ratio:
       errors:

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-rule-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-rule-read-100M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 100M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: rhobsp02ue1-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-100M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRulenReadLatency100MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 100M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$", le="120"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-rule-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-rule-read-10M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 100M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: rhobsp02ue1-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-10M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRuleReadLatency10MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 100M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-10M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$", le="30"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-10M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-rule-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/rhobsp02ue1-production-api-metrics-rule-read-1M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 1M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: rhobsp02ue1-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-1M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRuleReadLatency1MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 1M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$", le="10"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-mst-production", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-rule-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-rule-query-availability-slo.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query handler is burning too much error budget to guarantee
+      availability SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: telemeter-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-query-availability-slo
+spec:
+  alerting:
+    name: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+  description: API /query handler is burning too much error budget to guarantee availability
+    SLOs.
+  indicator:
+    ratio:
+      errors:
+        metric: http_requests_total{job="observatorium-ruler-query", handler="query",
+          code=~"^5..$"}
+      grouping: null
+      total:
+        metric: http_requests_total{job="observatorium-ruler-query", handler="query"}
+  target: "99"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-rule-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-rule-query-availability-slo.yaml
@@ -3,8 +3,8 @@ kind: ServiceLevelObjective
 metadata:
   annotations:
     pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-    pyrra.dev/message: API /query handler is burning too much error budget to guarantee
-      availability SLOs.
+    pyrra.dev/message: API /query handler endpoint for rules evaluation is burning
+      too much error budget to guarantee availability SLOs.
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
   creationTimestamp: null
   labels:
@@ -14,8 +14,8 @@ metadata:
 spec:
   alerting:
     name: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
-  description: API /query handler is burning too much error budget to guarantee availability
-    SLOs.
+  description: API /query handler endpoint for rules evaluation is burning too much
+    error budget to guarantee availability SLOs.
   indicator:
     ratio:
       errors:

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-rule-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-rule-read-100M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 100M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: telemeter-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-100M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRulenReadLatency100MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 100M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-production", http_code=~"^2..$", le="120"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-production", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-rule-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-rule-read-10M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 100M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: telemeter-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-10M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRuleReadLatency10MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 100M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-10M-samples",
+          namespace="observatorium-production", http_code=~"^2..$", le="30"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-10M-samples",
+          namespace="observatorium-production", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-rule-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-production-api-metrics-rule-read-1M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 1M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: telemeter-production
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-1M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRuleReadLatency1MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 1M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-production", http_code=~"^2..$", le="10"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-production", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-rule-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-rule-query-availability-slo.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query handler is burning too much error budget to guarantee
+      availability SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: telemeter-staging
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-query-availability-slo
+spec:
+  alerting:
+    name: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+  description: API /query handler is burning too much error budget to guarantee availability
+    SLOs.
+  indicator:
+    ratio:
+      errors:
+        metric: http_requests_total{job="observatorium-ruler-query", handler="query",
+          code=~"^5..$"}
+      grouping: null
+      total:
+        metric: http_requests_total{job="observatorium-ruler-query", handler="query"}
+  target: "99"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-rule-query-availability-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-rule-query-availability-slo.yaml
@@ -3,8 +3,8 @@ kind: ServiceLevelObjective
 metadata:
   annotations:
     pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-    pyrra.dev/message: API /query handler is burning too much error budget to guarantee
-      availability SLOs.
+    pyrra.dev/message: API /query handler endpoint for rules evaluation is burning
+      too much error budget to guarantee availability SLOs.
     pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
   creationTimestamp: null
   labels:
@@ -14,8 +14,8 @@ metadata:
 spec:
   alerting:
     name: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
-  description: API /query handler is burning too much error budget to guarantee availability
-    SLOs.
+  description: API /query handler endpoint for rules evaluation is burning too much
+    error budget to guarantee availability SLOs.
   indicator:
     ratio:
       errors:

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-rule-read-100M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-rule-read-100M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 100M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: telemeter-staging
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-100M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRulenReadLatency100MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 100M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-stage", http_code=~"^2..$", le="120"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-stage", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-rule-read-10M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-rule-read-10M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 100M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: telemeter-staging
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-10M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRuleReadLatency10MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 100M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-10M-samples",
+          namespace="observatorium-stage", http_code=~"^2..$", le="30"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-10M-samples",
+          namespace="observatorium-stage", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-rule-read-1M-latency-slo.yaml
+++ b/resources/observability/prometheusrules/pyrra/telemeter-staging-api-metrics-rule-read-1M-latency-slo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  annotations:
+    pyrra.dev/dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+    pyrra.dev/message: API /query endpoint for rules evaluation is burning too much
+      error budget for 1M samples, to guarantee latency SLOs.
+    pyrra.dev/runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+  creationTimestamp: null
+  labels:
+    instance: telemeter-staging
+    pyrra.dev/service: observatorium-api
+  name: api-metrics-rule-read-1M-latency-slo
+spec:
+  alerting:
+    name: APIMetricsRuleReadLatency1MErrorBudgetBurning
+  description: API /query endpoint for rules evaluation is burning too much error
+    budget for 1M samples, to guarantee latency SLOs.
+  indicator:
+    latency:
+      grouping: null
+      success:
+        metric: up_custom_query_duration_seconds_bucket{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-stage", http_code=~"^2..$", le="10"}
+      total:
+        metric: up_custom_query_duration_seconds_count{query="rule-query-path-sli-1M-samples",
+          namespace="observatorium-stage", http_code=~"^2..$"}
+  target: "90"
+  window: 28d
+status: {}

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -217,8 +217,8 @@ spec:
     - alert: SLOMetricAbsent
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: absent(http_requests_total{handler="query",job="observatorium-ruler-query"})
         == 1
@@ -291,8 +291,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (14 * (1-0.99)) and http_requests:burnrate1h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -309,8 +309,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (7 * (1-0.99)) and http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -327,8 +327,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (2 * (1-0.99)) and http_requests:burnrate1d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -345,8 +345,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (1 * (1-0.99)) and http_requests:burnrate4d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -2569,6 +2569,217 @@ spec:
         - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
       labels:
         slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-100M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        le: "120"
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-100M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-100M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-100M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-100M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
       record: pyrra_errors_total
   - interval: 2m30s
     name: api-metrics-read-1M-latency-slo-increase

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -205,6 +205,187 @@ spec:
         slo: api-metrics-write-availability-slo
       record: pyrra_errors_total
   - interval: 2m30s
+    name: api-metrics-rule-query-availability-slo-increase
+    rules:
+    - expr: sum by(code) (increase(http_requests_total{handler="query",job="observatorium-ruler-query"}[4w]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: absent(http_requests_total{handler="query",job="observatorium-ruler-query"})
+        == 1
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-query-availability-slo
+  - interval: 30s
+    name: api-metrics-rule-query-availability-slo
+    rules:
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[5m]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[5m]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate5m
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[30m]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[30m]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate30m
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[1h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[1h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate1h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[2h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[2h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate2h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[6h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[6h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate6h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[1d]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[1d]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate1d
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[4d]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[4d]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate4d
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate5m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (14 * (1-0.99)) and http_requests:burnrate1h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (14 * (1-0.99))
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 1h
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate30m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (7 * (1-0.99)) and http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (7 * (1-0.99))
+      for: 15m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 6h
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate2h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (2 * (1-0.99)) and http_requests:burnrate1d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (2 * (1-0.99))
+      for: 1h
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 1d
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (1 * (1-0.99)) and http_requests:burnrate4d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (1 * (1-0.99))
+      for: 3h
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 4d
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-query-availability-slo
+  - interval: 30s
+    name: api-metrics-rule-query-availability-slo-generic
+    rules:
+    - expr: "0.99"
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_window
+    - expr: 1 - sum(http_requests:increase4w{code=~"^5..$",handler="query",job="observatorium-ruler-query"}
+        or vector(0)) / sum(http_requests:increase4w{handler="query",job="observatorium-ruler-query"})
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_availability
+    - expr: sum(http_requests_total{handler="query",job="observatorium-ruler-query"})
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_requests_total
+    - expr: sum(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}
+        or vector(0))
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
     name: api-metrics-query-availability-slo-increase
     rules:
     - expr: sum by(code) (increase(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[4w]))
@@ -1966,6 +2147,428 @@ spec:
         - sum(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",le="5"})
       labels:
         slo: api-metrics-write-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-1M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        le: "10"
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-1M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-1M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-1M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-1M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-10M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[4w]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[4w]))
+      labels:
+        le: "30"
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-10M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-10M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[5m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[30m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[2h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[6h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[4d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/283e7002d85c08126681241df2fdb22b/mst-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-10M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-10M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
       record: pyrra_errors_total
   - interval: 2m30s
     name: api-metrics-read-1M-latency-slo-increase

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -205,6 +205,187 @@ spec:
         slo: api-metrics-write-availability-slo
       record: pyrra_errors_total
   - interval: 2m30s
+    name: api-metrics-rule-query-availability-slo-increase
+    rules:
+    - expr: sum by(code) (increase(http_requests_total{handler="query",job="observatorium-ruler-query"}[4w]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: absent(http_requests_total{handler="query",job="observatorium-ruler-query"})
+        == 1
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-query-availability-slo
+  - interval: 30s
+    name: api-metrics-rule-query-availability-slo
+    rules:
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[5m]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[5m]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate5m
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[30m]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[30m]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate30m
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[1h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[1h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate1h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[2h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[2h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate2h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[6h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[6h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate6h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[1d]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[1d]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate1d
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[4d]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[4d]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate4d
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate5m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (14 * (1-0.99)) and http_requests:burnrate1h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (14 * (1-0.99))
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 1h
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate30m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (7 * (1-0.99)) and http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (7 * (1-0.99))
+      for: 15m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 6h
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate2h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (2 * (1-0.99)) and http_requests:burnrate1d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (2 * (1-0.99))
+      for: 1h
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 1d
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (1 * (1-0.99)) and http_requests:burnrate4d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (1 * (1-0.99))
+      for: 3h
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 4d
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-query-availability-slo
+  - interval: 30s
+    name: api-metrics-rule-query-availability-slo-generic
+    rules:
+    - expr: "0.99"
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_window
+    - expr: 1 - sum(http_requests:increase4w{code=~"^5..$",handler="query",job="observatorium-ruler-query"}
+        or vector(0)) / sum(http_requests:increase4w{handler="query",job="observatorium-ruler-query"})
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_availability
+    - expr: sum(http_requests_total{handler="query",job="observatorium-ruler-query"})
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_requests_total
+    - expr: sum(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}
+        or vector(0))
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
     name: api-metrics-query-availability-slo-increase
     rules:
     - expr: sum by(code) (increase(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[4w]))
@@ -1966,6 +2147,428 @@ spec:
         - sum(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",le="5"})
       labels:
         slo: api-metrics-write-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-1M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        le: "10"
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-1M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-1M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[5m]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[30m]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1h]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[2h]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[6h]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1d]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[4d]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-1M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-1M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-10M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[4w]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[4w]))
+      labels:
+        le: "30"
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-10M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-10M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[5m]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[30m]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[1h]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[2h]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[6h]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[1d]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"}[4d]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-10M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-10M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
       record: pyrra_errors_total
   - interval: 2m30s
     name: api-metrics-read-1M-latency-slo-increase

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -217,8 +217,8 @@ spec:
     - alert: SLOMetricAbsent
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: absent(http_requests_total{handler="query",job="observatorium-ruler-query"})
         == 1
@@ -291,8 +291,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (14 * (1-0.99)) and http_requests:burnrate1h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -309,8 +309,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (7 * (1-0.99)) and http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -327,8 +327,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (2 * (1-0.99)) and http_requests:burnrate1d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -345,8 +345,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (1 * (1-0.99)) and http_requests:burnrate4d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -2569,6 +2569,217 @@ spec:
         - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-stage",query="rule-query-path-sli-10M-samples"})
       labels:
         slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-100M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        le: "120"
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-100M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-100M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[5m]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[30m]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1h]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[2h]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[6h]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[1d]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"}[4d]))
+      labels:
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/92520ea4d6976f30d1618164e186ef9b/mst-stage-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-mst-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-100M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-100M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-stage",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
       record: pyrra_errors_total
   - interval: 2m30s
     name: api-metrics-read-1M-latency-slo-increase

--- a/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
@@ -205,6 +205,187 @@ spec:
         slo: api-metrics-write-availability-slo
       record: pyrra_errors_total
   - interval: 2m30s
+    name: api-metrics-rule-query-availability-slo-increase
+    rules:
+    - expr: sum by(code) (increase(http_requests_total{handler="query",job="observatorium-ruler-query"}[4w]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: absent(http_requests_total{handler="query",job="observatorium-ruler-query"})
+        == 1
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-query-availability-slo
+  - interval: 30s
+    name: api-metrics-rule-query-availability-slo
+    rules:
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[5m]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[5m]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate5m
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[30m]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[30m]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate30m
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[1h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[1h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate1h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[2h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[2h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate2h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[6h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[6h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate6h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[1d]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[1d]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate1d
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[4d]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[4d]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate4d
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate5m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (14 * (1-0.99)) and http_requests:burnrate1h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (14 * (1-0.99))
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 1h
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate30m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (7 * (1-0.99)) and http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (7 * (1-0.99))
+      for: 15m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 6h
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate2h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (2 * (1-0.99)) and http_requests:burnrate1d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (2 * (1-0.99))
+      for: 1h
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 1d
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (1 * (1-0.99)) and http_requests:burnrate4d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (1 * (1-0.99))
+      for: 3h
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 4d
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-query-availability-slo
+  - interval: 30s
+    name: api-metrics-rule-query-availability-slo-generic
+    rules:
+    - expr: "0.99"
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_window
+    - expr: 1 - sum(http_requests:increase4w{code=~"^5..$",handler="query",job="observatorium-ruler-query"}
+        or vector(0)) / sum(http_requests:increase4w{handler="query",job="observatorium-ruler-query"})
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_availability
+    - expr: sum(http_requests_total{handler="query",job="observatorium-ruler-query"})
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_requests_total
+    - expr: sum(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}
+        or vector(0))
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
     name: api-metrics-query-availability-slo-increase
     rules:
     - expr: sum by(code) (increase(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-mst-api"}[4w]))
@@ -1966,6 +2147,428 @@ spec:
         - sum(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-mst-api",le="5"})
       labels:
         slo: api-metrics-write-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-1M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        le: "10"
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-1M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-1M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-1M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-1M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-10M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[4w]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[4w]))
+      labels:
+        le: "30"
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-10M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-10M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[5m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[30m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[2h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[6h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[1d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"}[4d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-10M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-10M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
       record: pyrra_errors_total
   - interval: 2m30s
     name: api-metrics-read-1M-latency-slo-increase

--- a/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
@@ -217,8 +217,8 @@ spec:
     - alert: SLOMetricAbsent
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: absent(http_requests_total{handler="query",job="observatorium-ruler-query"})
         == 1
@@ -291,8 +291,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (14 * (1-0.99)) and http_requests:burnrate1h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -309,8 +309,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (7 * (1-0.99)) and http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -327,8 +327,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (2 * (1-0.99)) and http_requests:burnrate1d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -345,8 +345,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (1 * (1-0.99)) and http_requests:burnrate4d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -2569,6 +2569,217 @@ spec:
         - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-mst-production",query="rule-query-path-sli-10M-samples"})
       labels:
         slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-100M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        le: "120"
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-100M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-100M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[5m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[30m]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[2h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[6h]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[1d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"}[4d]))
+      labels:
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/7f4df1c2d5518d5c3f2876ca9bb874a8/rhobsp02ue1-production-slos?orgId=1&refresh=10s&var-datasource=rhobsp02ue1-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-mst-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-100M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-100M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-mst-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
       record: pyrra_errors_total
   - interval: 2m30s
     name: api-metrics-read-1M-latency-slo-increase

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -975,8 +975,8 @@ spec:
     - alert: SLOMetricAbsent
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: absent(http_requests_total{handler="query",job="observatorium-ruler-query"})
         == 1
@@ -1049,8 +1049,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (14 * (1-0.99)) and http_requests:burnrate1h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -1067,8 +1067,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (7 * (1-0.99)) and http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -1085,8 +1085,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (2 * (1-0.99)) and http_requests:burnrate1d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -1103,8 +1103,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (1 * (1-0.99)) and http_requests:burnrate4d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -3327,6 +3327,217 @@ spec:
         - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"})
       labels:
         slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-100M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        le: "120"
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-100M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-100M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[5m]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[30m]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1h]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[2h]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[6h]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1d]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[4d]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-100M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-100M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
       record: pyrra_errors_total
   - interval: 2m30s
     name: api-metrics-read-1M-latency-slo-increase

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -963,6 +963,187 @@ spec:
         slo: api-metrics-write-availability-slo
       record: pyrra_errors_total
   - interval: 2m30s
+    name: api-metrics-rule-query-availability-slo-increase
+    rules:
+    - expr: sum by(code) (increase(http_requests_total{handler="query",job="observatorium-ruler-query"}[4w]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: absent(http_requests_total{handler="query",job="observatorium-ruler-query"})
+        == 1
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-query-availability-slo
+  - interval: 30s
+    name: api-metrics-rule-query-availability-slo
+    rules:
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[5m]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[5m]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate5m
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[30m]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[30m]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate30m
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[1h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[1h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate1h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[2h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[2h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate2h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[6h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[6h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate6h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[1d]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[1d]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate1d
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[4d]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[4d]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate4d
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate5m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (14 * (1-0.99)) and http_requests:burnrate1h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (14 * (1-0.99))
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 1h
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate30m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (7 * (1-0.99)) and http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (7 * (1-0.99))
+      for: 15m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 6h
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate2h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (2 * (1-0.99)) and http_requests:burnrate1d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (2 * (1-0.99))
+      for: 1h
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 1d
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (1 * (1-0.99)) and http_requests:burnrate4d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (1 * (1-0.99))
+      for: 3h
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 4d
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-query-availability-slo
+  - interval: 30s
+    name: api-metrics-rule-query-availability-slo-generic
+    rules:
+    - expr: "0.99"
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_window
+    - expr: 1 - sum(http_requests:increase4w{code=~"^5..$",handler="query",job="observatorium-ruler-query"}
+        or vector(0)) / sum(http_requests:increase4w{handler="query",job="observatorium-ruler-query"})
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_availability
+    - expr: sum(http_requests_total{handler="query",job="observatorium-ruler-query"})
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_requests_total
+    - expr: sum(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}
+        or vector(0))
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
     name: api-metrics-query-availability-slo-increase
     rules:
     - expr: sum by(code) (increase(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[4w]))
@@ -2724,6 +2905,428 @@ spec:
         - sum(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",le="5"})
       labels:
         slo: api-metrics-write-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-1M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        le: "10"
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-1M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-1M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[5m]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[30m]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1h]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[2h]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[6h]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[1d]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"}[4d]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-production
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-1M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-1M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-production",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-production",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-10M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[4w]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[4w]))
+      labels:
+        le: "30"
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-10M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-10M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[5m]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[30m]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[1h]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[2h]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[6h]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[1d]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"}[4d]))
+      labels:
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/f9fa7677fb4a2669f123f9a0f2234b47/telemeter-production-slos?orgId=1&refresh=10s&var-datasource=telemeter-prod-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-production
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-10M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-10M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-production",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-production",query="rule-query-path-sli-10M-samples"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
       record: pyrra_errors_total
   - interval: 2m30s
     name: api-metrics-read-1M-latency-slo-increase

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -975,8 +975,8 @@ spec:
     - alert: SLOMetricAbsent
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: absent(http_requests_total{handler="query",job="observatorium-ruler-query"})
         == 1
@@ -1049,8 +1049,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate5m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (14 * (1-0.99)) and http_requests:burnrate1h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -1067,8 +1067,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate30m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (7 * (1-0.99)) and http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -1085,8 +1085,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate2h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (2 * (1-0.99)) and http_requests:burnrate1d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -1103,8 +1103,8 @@ spec:
     - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
-        message: API /query handler is burning too much error budget to guarantee
-          availability SLOs.
+        message: API /query handler endpoint for rules evaluation is burning too much
+          error budget to guarantee availability SLOs.
         runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
       expr: http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
         > (1 * (1-0.99)) and http_requests:burnrate4d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
@@ -3327,6 +3327,217 @@ spec:
         - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"})
       labels:
         slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-100M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        le: "120"
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-100M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-100M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[5m]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[30m]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1h]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[2h]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[6h]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1d]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[4d]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-100M-latency-slo
+    - alert: APIMetricsRulenReadLatency100MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulenReadLatency100MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-100M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-100M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-100M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="120",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-100M-latency-slo
       record: pyrra_errors_total
   - interval: 2m30s
     name: api-metrics-read-1M-latency-slo-increase

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -963,6 +963,187 @@ spec:
         slo: api-metrics-write-availability-slo
       record: pyrra_errors_total
   - interval: 2m30s
+    name: api-metrics-rule-query-availability-slo-increase
+    rules:
+    - expr: sum by(code) (increase(http_requests_total{handler="query",job="observatorium-ruler-query"}[4w]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: absent(http_requests_total{handler="query",job="observatorium-ruler-query"})
+        == 1
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-query-availability-slo
+  - interval: 30s
+    name: api-metrics-rule-query-availability-slo
+    rules:
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[5m]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[5m]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate5m
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[30m]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[30m]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate30m
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[1h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[1h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate1h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[2h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[2h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate2h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[6h]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[6h]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate6h
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[1d]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[1d]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate1d
+    - expr: sum(rate(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}[4d]))
+        / sum(rate(http_requests_total{handler="query",job="observatorium-ruler-query"}[4d]))
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        service: observatorium-api
+        slo: api-metrics-rule-query-availability-slo
+      record: http_requests:burnrate4d
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate5m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (14 * (1-0.99)) and http_requests:burnrate1h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (14 * (1-0.99))
+      for: 2m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 1h
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate30m{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (7 * (1-0.99)) and http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (7 * (1-0.99))
+      for: 15m
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 6h
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate2h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (2 * (1-0.99)) and http_requests:burnrate1d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (2 * (1-0.99))
+      for: 1h
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 1d
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-query-availability-slo
+    - alert: APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query handler is burning too much error budget to guarantee
+          availability SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRulerQueryAvailabilityErrorBudgetBurning
+      expr: http_requests:burnrate6h{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (1 * (1-0.99)) and http_requests:burnrate4d{handler="query",job="observatorium-ruler-query",slo="api-metrics-rule-query-availability-slo"}
+        > (1 * (1-0.99))
+      for: 3h
+      labels:
+        handler: query
+        job: observatorium-ruler-query
+        long_burnrate_window: 4d
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-query-availability-slo
+  - interval: 30s
+    name: api-metrics-rule-query-availability-slo-generic
+    rules:
+    - expr: "0.99"
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_window
+    - expr: 1 - sum(http_requests:increase4w{code=~"^5..$",handler="query",job="observatorium-ruler-query"}
+        or vector(0)) / sum(http_requests:increase4w{handler="query",job="observatorium-ruler-query"})
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_availability
+    - expr: sum(http_requests_total{handler="query",job="observatorium-ruler-query"})
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_requests_total
+    - expr: sum(http_requests_total{code=~"^5..$",handler="query",job="observatorium-ruler-query"}
+        or vector(0))
+      labels:
+        slo: api-metrics-rule-query-availability-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
     name: api-metrics-query-availability-slo-increase
     rules:
     - expr: sum by(code) (increase(http_requests_total{group="metricsv1",handler="query",job="observatorium-observatorium-api"}[4w]))
@@ -2724,6 +2905,428 @@ spec:
         - sum(http_request_duration_seconds_bucket{code=~"^2..$",group="metricsv1",handler="receive",job="observatorium-observatorium-api",le="5"})
       labels:
         slo: api-metrics-write-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-1M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[4w]))
+      labels:
+        le: "10"
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-1M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-1M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[5m]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[30m]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1h]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[2h]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[6h]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[1d]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"}[4d]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-1M-latency-slo
+    - alert: APIMetricsRuleReadLatency1MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 1M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency1MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-stage
+        query: rule-query-path-sli-1M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-1M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-1M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples",slo="api-metrics-rule-read-1M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="10",namespace="observatorium-stage",query="rule-query-path-sli-1M-samples"})
+      labels:
+        slo: api-metrics-rule-read-1M-latency-slo
+      record: pyrra_errors_total
+  - interval: 2m30s
+    name: api-metrics-rule-read-10M-latency-slo-increase
+    rules:
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[4w]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - expr: sum by(http_code) (increase(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[4w]))
+      labels:
+        le: "30"
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:increase4w
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: SLOMetricAbsent
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: absent(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"})
+        == 1
+      for: 2m
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        slo: api-metrics-rule-read-10M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-10M-latency-slo
+    rules:
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[5m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[5m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[5m]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate5m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[30m]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[30m])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[30m]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate30m
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[1h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[1h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[1h]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[2h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[2h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[2h]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate2h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[6h]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[6h])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[6h]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate6h
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[1d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[1d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[1d]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate1d
+    - expr: (sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[4d]))
+        - sum(rate(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[4d])))
+        / sum(rate(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"}[4d]))
+      labels:
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: up_custom_query_duration_seconds:burnrate4d
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate5m{namespace="observatorium-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (14 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1h{namespace="observatorium-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (14 * (1-0.9))
+      for: 2m
+      labels:
+        long_burnrate_window: 1h
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 5m
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate30m{namespace="observatorium-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (7 * (1-0.9)) and up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (7 * (1-0.9))
+      for: 15m
+      labels:
+        long_burnrate_window: 6h
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: high
+        short_burnrate_window: 30m
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate2h{namespace="observatorium-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (2 * (1-0.9)) and up_custom_query_duration_seconds:burnrate1d{namespace="observatorium-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (2 * (1-0.9))
+      for: 1h
+      labels:
+        long_burnrate_window: 1d
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 2h
+        slo: api-metrics-rule-read-10M-latency-slo
+    - alert: APIMetricsRuleReadLatency10MErrorBudgetBurning
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/080e53f245a15445bdf777ae0e66945d/telemeter-staging-slos?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        message: API /query endpoint for rules evaluation is burning too much error
+          budget for 100M samples, to guarantee latency SLOs.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#APIMetricsRuleReadLatency10MErrorBudgetBurning
+      expr: up_custom_query_duration_seconds:burnrate6h{namespace="observatorium-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (1 * (1-0.9)) and up_custom_query_duration_seconds:burnrate4d{namespace="observatorium-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        > (1 * (1-0.9))
+      for: 3h
+      labels:
+        long_burnrate_window: 4d
+        namespace: observatorium-stage
+        query: rule-query-path-sli-10M-samples
+        service: observatorium-api
+        severity: warning
+        short_burnrate_window: 6h
+        slo: api-metrics-rule-read-10M-latency-slo
+  - interval: 30s
+    name: api-metrics-rule-read-10M-latency-slo-generic
+    rules:
+    - expr: "0.9"
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_objective
+    - expr: 2419200
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_window
+    - expr: sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"}
+        or vector(0)) / sum(up_custom_query_duration_seconds:increase4w{http_code=~"^2..$",le="",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples",slo="api-metrics-rule-read-10M-latency-slo"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_availability
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
+      record: pyrra_requests_total
+    - expr: sum(up_custom_query_duration_seconds_count{http_code=~"^2..$",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"})
+        - sum(up_custom_query_duration_seconds_bucket{http_code=~"^2..$",le="30",namespace="observatorium-stage",query="rule-query-path-sli-10M-samples"})
+      labels:
+        slo: api-metrics-rule-read-10M-latency-slo
       record: pyrra_errors_total
   - interval: 2m30s
     name: api-metrics-read-1M-latency-slo-increase

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -651,6 +651,118 @@ objects:
             name: observatorium-observatorium-up
           name: query-config
 - apiVersion: v1
+  data:
+    queries.yaml: |-
+      "queries":
+      - "name": "rule-query-path-sli-1M-samples"
+        "query": "avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[1h])"
+      - "name": "rule-query-path-sli-10M-samples"
+        "query": "avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[10h])"
+      - "name": "rule-query-path-sli-100M-samples"
+        "query": "avg_over_time(avalanche_metric_mmmmm_0_0{tenant_id=\"0fc2b00e-201b-4c17-b9f2-19d91adc4fd2\"}[100h])"
+  kind: ConfigMap
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/component: blackbox-prober
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: observatorium-up
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: master-2022-03-24-098c31a
+    name: observatorium-observatorium-up-ruler
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app.kubernetes.io/component: blackbox-prober
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: observatorium-up
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: master-2022-03-24-098c31a
+    name: observatorium-observatorium-up-ruler
+  spec:
+    replicas: ${{UP_REPLICAS}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: blackbox-prober
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-up
+        app.kubernetes.io/part-of: observatorium
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/component: blackbox-prober
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: observatorium-up
+          app.kubernetes.io/part-of: observatorium
+          app.kubernetes.io/version: master-2022-03-24-098c31a
+      spec:
+        containers:
+        - args:
+          - --duration=0
+          - --log.level=debug
+          - --endpoint-type=metrics
+          - --queries-file=/etc/up/queries.yaml
+          - --endpoint-read=http://observatorium-ruler-query.${OBSERVATORIUM_METRICS_NAMESPACE}.svc:9090
+          image: quay.io/observatorium/up:master-2022-03-24-098c31a
+          name: observatorium-up
+          ports:
+          - containerPort: 8080
+            name: http
+          resources:
+            limits:
+              cpu: ${UP_CPU_LIMIT}
+              memory: ${UP_MEMORY_LIMIT}
+            requests:
+              cpu: ${UP_CPU_REQUEST}
+              memory: ${UP_MEMORY_REQUEST}
+          volumeMounts:
+          - mountPath: /etc/up/
+            name: query-config
+            readOnly: false
+        volumes:
+        - configMap:
+            name: observatorium-observatorium-up-ruler
+          name: query-config
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/component: blackbox-prober
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: observatorium-up
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: master-2022-03-24-098c31a
+    name: observatorium-observatorium-up-ruler
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+    selector:
+      app.kubernetes.io/component: blackbox-prober
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: observatorium-up
+      app.kubernetes.io/part-of: observatorium
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    labels:
+      prometheus: app-sre
+    name: observatorium-up-ruler
+  spec:
+    endpoints:
+    - port: http
+    namespaceSelector:
+      matchNames: ${{NAMESPACES}}
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: blackbox-prober
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-up
+        app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
   kind: Service
   metadata:
     labels:


### PR DESCRIPTION
SLOs are updated to take into account the current deployment topology that splits the queriers for ad hoc queries and rules evaluation.

- availability and latencies SLOs are added for the rule-query 
- new observatorium-up deployment added to generate latency metrics
-> I could not reuse the current deployment as it targets the query frontend 