### PR TITLE
Decrease severity of SLO absent alerts

### DIFF
--- a/configuration/observatorium/slo.go
+++ b/configuration/observatorium/slo.go
@@ -683,8 +683,15 @@ func makePrometheusRule(envName rhobsInstanceEnv, objs []pyrrav1alpha1.ServiceLe
 	// We do not want to page on SLO alerts until we're comfortable with how frequently
 	// they fire.
 	// Ticket: https://issues.redhat.com/browse/RHOBS-781
+	// We also do not want to send noise to app-sre Slack when the SLOMetricAbsent alert
+	// fires, as the metrics we use for the SLOs are sometimes unitialized for a long time.
+	// For example, some SLOS on API endpoints with low traffic sometimes trigger this.
 	for i := range grp {
 		for j := range grp[i].Rules {
+			if grp[i].Rules[j].Alert == "SLOMetricAbsent" {
+				grp[i].Rules[j].Labels["severity"] = "medium"
+				continue
+			}
 			if v, ok := grp[i].Rules[j].Labels["severity"]; ok {
 				if v == "critical" {
 					grp[i].Rules[j].Labels["severity"] = "high"

--- a/resources/observability/prometheusrules/rhobs-slos-logs-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-logs-mst-production.prometheusrules.yaml
@@ -33,7 +33,7 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-write-availability-slo
   - interval: 30s
     name: api-logs-write-availability-slo
@@ -212,7 +212,7 @@ spec:
       labels:
         group: logsv1
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-query-availability-slo
   - interval: 30s
     name: api-logs-query-availability-slo
@@ -382,7 +382,7 @@ spec:
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-query-range-availability-slo
   - interval: 30s
     name: api-logs-query-range-availability-slo
@@ -563,7 +563,7 @@ spec:
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-tail-availability-slo
   - interval: 30s
     name: api-logs-tail-availability-slo
@@ -744,7 +744,7 @@ spec:
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-prom-tail-availability-slo
   - interval: 30s
     name: api-logs-prom-tail-availability-slo
@@ -933,7 +933,7 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-write-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -948,7 +948,7 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-write-latency-slo
   - interval: 30s
     name: api-logs-write-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-logs-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-logs-mst-stage.prometheusrules.yaml
@@ -33,7 +33,7 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-write-availability-slo
   - interval: 30s
     name: api-logs-write-availability-slo
@@ -212,7 +212,7 @@ spec:
       labels:
         group: logsv1
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-query-availability-slo
   - interval: 30s
     name: api-logs-query-availability-slo
@@ -382,7 +382,7 @@ spec:
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-query-range-availability-slo
   - interval: 30s
     name: api-logs-query-range-availability-slo
@@ -563,7 +563,7 @@ spec:
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-tail-availability-slo
   - interval: 30s
     name: api-logs-tail-availability-slo
@@ -744,7 +744,7 @@ spec:
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-prom-tail-availability-slo
   - interval: 30s
     name: api-logs-prom-tail-availability-slo
@@ -933,7 +933,7 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-write-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -948,7 +948,7 @@ spec:
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
-        severity: high
+        severity: medium
         slo: api-logs-write-latency-slo
   - interval: 30s
     name: api-logs-write-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -35,7 +35,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-availability-slo
   - interval: 30s
     name: api-metrics-write-availability-slo
@@ -229,7 +229,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-query-availability-slo
   - interval: 30s
     name: api-metrics-query-availability-slo
@@ -423,7 +423,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
     name: api-metrics-query-range-availability-slo
@@ -619,7 +619,7 @@ spec:
         job: observatorium-observatorium-mst-api
         method: PUT
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
     name: api-rules-raw-write-availability-slo
@@ -826,7 +826,7 @@ spec:
         job: observatorium-observatorium-mst-api
         method: GET
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
     name: api-rules-raw-read-availability-slo
@@ -1033,7 +1033,7 @@ spec:
         job: observatorium-observatorium-mst-api
         method: GET
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-read-availability-slo
   - interval: 30s
     name: api-rules-read-availability-slo
@@ -1236,7 +1236,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-sync-availability-slo
   - interval: 30s
     name: api-rules-sync-availability-slo
@@ -1419,7 +1419,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-alerting-availability-slo
   - interval: 30s
     name: api-alerting-availability-slo
@@ -1594,7 +1594,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-alerting-notif-availability-slo
   - interval: 30s
     name: api-alerting-notif-availability-slo
@@ -1775,7 +1775,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -1791,7 +1791,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-latency-slo
   - interval: 30s
     name: api-metrics-write-latency-slo
@@ -1998,7 +1998,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2013,7 +2013,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-read-1M-latency-slo
@@ -2209,7 +2209,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2224,7 +2224,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-read-10M-latency-slo
@@ -2420,7 +2420,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2435,7 +2435,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -227,7 +227,7 @@ spec:
         handler: query
         job: observatorium-ruler-query
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-query-availability-slo
   - interval: 30s
     name: api-metrics-rule-query-availability-slo
@@ -2179,7 +2179,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-1M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2194,7 +2194,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-1M-latency-slo
@@ -2390,7 +2390,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-10M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2405,7 +2405,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-10M-latency-slo
@@ -2601,7 +2601,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-100M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2616,7 +2616,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -35,7 +35,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-availability-slo
   - interval: 30s
     name: api-metrics-write-availability-slo
@@ -229,7 +229,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-query-availability-slo
   - interval: 30s
     name: api-metrics-query-availability-slo
@@ -423,7 +423,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
     name: api-metrics-query-range-availability-slo
@@ -619,7 +619,7 @@ spec:
         job: observatorium-observatorium-mst-api
         method: PUT
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
     name: api-rules-raw-write-availability-slo
@@ -826,7 +826,7 @@ spec:
         job: observatorium-observatorium-mst-api
         method: GET
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
     name: api-rules-raw-read-availability-slo
@@ -1033,7 +1033,7 @@ spec:
         job: observatorium-observatorium-mst-api
         method: GET
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-read-availability-slo
   - interval: 30s
     name: api-rules-read-availability-slo
@@ -1236,7 +1236,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-sync-availability-slo
   - interval: 30s
     name: api-rules-sync-availability-slo
@@ -1419,7 +1419,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-alerting-availability-slo
   - interval: 30s
     name: api-alerting-availability-slo
@@ -1594,7 +1594,7 @@ spec:
       labels:
         namespace: observatorium-mst-stage
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-alerting-notif-availability-slo
   - interval: 30s
     name: api-alerting-notif-availability-slo
@@ -1775,7 +1775,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -1791,7 +1791,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-latency-slo
   - interval: 30s
     name: api-metrics-write-latency-slo
@@ -1998,7 +1998,7 @@ spec:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2013,7 +2013,7 @@ spec:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-read-1M-latency-slo
@@ -2209,7 +2209,7 @@ spec:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2224,7 +2224,7 @@ spec:
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-read-10M-latency-slo
@@ -2420,7 +2420,7 @@ spec:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2435,7 +2435,7 @@ spec:
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -227,7 +227,7 @@ spec:
         handler: query
         job: observatorium-ruler-query
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-query-availability-slo
   - interval: 30s
     name: api-metrics-rule-query-availability-slo
@@ -2179,7 +2179,7 @@ spec:
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-1M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2194,7 +2194,7 @@ spec:
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-1M-latency-slo
@@ -2390,7 +2390,7 @@ spec:
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-10M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2405,7 +2405,7 @@ spec:
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-10M-latency-slo
@@ -2601,7 +2601,7 @@ spec:
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-100M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2616,7 +2616,7 @@ spec:
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
@@ -35,7 +35,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-availability-slo
   - interval: 30s
     name: api-metrics-write-availability-slo
@@ -229,7 +229,7 @@ spec:
         handler: query
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-query-availability-slo
   - interval: 30s
     name: api-metrics-query-availability-slo
@@ -423,7 +423,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
     name: api-metrics-query-range-availability-slo
@@ -619,7 +619,7 @@ spec:
         job: observatorium-observatorium-mst-api
         method: PUT
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
     name: api-rules-raw-write-availability-slo
@@ -826,7 +826,7 @@ spec:
         job: observatorium-observatorium-mst-api
         method: GET
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
     name: api-rules-raw-read-availability-slo
@@ -1033,7 +1033,7 @@ spec:
         job: observatorium-observatorium-mst-api
         method: GET
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-read-availability-slo
   - interval: 30s
     name: api-rules-read-availability-slo
@@ -1236,7 +1236,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-sync-availability-slo
   - interval: 30s
     name: api-rules-sync-availability-slo
@@ -1419,7 +1419,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-alerting-availability-slo
   - interval: 30s
     name: api-alerting-availability-slo
@@ -1594,7 +1594,7 @@ spec:
       labels:
         namespace: observatorium-mst-production
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-alerting-notif-availability-slo
   - interval: 30s
     name: api-alerting-notif-availability-slo
@@ -1775,7 +1775,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -1791,7 +1791,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-mst-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-latency-slo
   - interval: 30s
     name: api-metrics-write-latency-slo
@@ -1998,7 +1998,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2013,7 +2013,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-read-1M-latency-slo
@@ -2209,7 +2209,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2224,7 +2224,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-read-10M-latency-slo
@@ -2420,7 +2420,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2435,7 +2435,7 @@ spec:
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
@@ -227,7 +227,7 @@ spec:
         handler: query
         job: observatorium-ruler-query
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-query-availability-slo
   - interval: 30s
     name: api-metrics-rule-query-availability-slo
@@ -2179,7 +2179,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-1M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2194,7 +2194,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-1M-latency-slo
@@ -2390,7 +2390,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-10M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2405,7 +2405,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-10M-latency-slo
@@ -2601,7 +2601,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-100M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2616,7 +2616,7 @@ spec:
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -985,7 +985,7 @@ spec:
         handler: query
         job: observatorium-ruler-query
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-query-availability-slo
   - interval: 30s
     name: api-metrics-rule-query-availability-slo
@@ -2937,7 +2937,7 @@ spec:
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-1M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2952,7 +2952,7 @@ spec:
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-1M-latency-slo
@@ -3148,7 +3148,7 @@ spec:
         namespace: observatorium-production
         query: rule-query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-10M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -3163,7 +3163,7 @@ spec:
         namespace: observatorium-production
         query: rule-query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-10M-latency-slo
@@ -3359,7 +3359,7 @@ spec:
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-100M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -3374,7 +3374,7 @@ spec:
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -31,7 +31,7 @@ spec:
       labels:
         route: telemeter-server-upload
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-upload-availability-slo
@@ -199,7 +199,7 @@ spec:
       labels:
         route: telemeter-server-metrics-v1-receive
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-receive-availability-slo
@@ -377,7 +377,7 @@ spec:
         handler: upload
         job: telemeter-server
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -392,7 +392,7 @@ spec:
         handler: upload
         job: telemeter-server
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -588,7 +588,7 @@ spec:
         handler: receive
         job: telemeter-server
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -603,7 +603,7 @@ spec:
         handler: receive
         job: telemeter-server
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -793,7 +793,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-availability-slo
   - interval: 30s
     name: api-metrics-write-availability-slo
@@ -987,7 +987,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-query-availability-slo
   - interval: 30s
     name: api-metrics-query-availability-slo
@@ -1181,7 +1181,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
     name: api-metrics-query-range-availability-slo
@@ -1377,7 +1377,7 @@ spec:
         job: observatorium-observatorium-api
         method: PUT
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
     name: api-rules-raw-write-availability-slo
@@ -1584,7 +1584,7 @@ spec:
         job: observatorium-observatorium-api
         method: GET
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
     name: api-rules-raw-read-availability-slo
@@ -1791,7 +1791,7 @@ spec:
         job: observatorium-observatorium-api
         method: GET
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-read-availability-slo
   - interval: 30s
     name: api-rules-read-availability-slo
@@ -1994,7 +1994,7 @@ spec:
       labels:
         namespace: observatorium-metrics-production
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-sync-availability-slo
   - interval: 30s
     name: api-rules-sync-availability-slo
@@ -2177,7 +2177,7 @@ spec:
       labels:
         namespace: observatorium-metrics-production
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-alerting-availability-slo
   - interval: 30s
     name: api-alerting-availability-slo
@@ -2352,7 +2352,7 @@ spec:
       labels:
         namespace: observatorium-metrics-production
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-alerting-notif-availability-slo
   - interval: 30s
     name: api-alerting-notif-availability-slo
@@ -2533,7 +2533,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2549,7 +2549,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-latency-slo
   - interval: 30s
     name: api-metrics-write-latency-slo
@@ -2756,7 +2756,7 @@ spec:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2771,7 +2771,7 @@ spec:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-read-1M-latency-slo
@@ -2967,7 +2967,7 @@ spec:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2982,7 +2982,7 @@ spec:
         namespace: observatorium-production
         query: query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-read-10M-latency-slo
@@ -3178,7 +3178,7 @@ spec:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -3193,7 +3193,7 @@ spec:
         namespace: observatorium-production
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -985,7 +985,7 @@ spec:
         handler: query
         job: observatorium-ruler-query
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-query-availability-slo
   - interval: 30s
     name: api-metrics-rule-query-availability-slo
@@ -2937,7 +2937,7 @@ spec:
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-1M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2952,7 +2952,7 @@ spec:
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-1M-latency-slo
@@ -3148,7 +3148,7 @@ spec:
         namespace: observatorium-stage
         query: rule-query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-10M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -3163,7 +3163,7 @@ spec:
         namespace: observatorium-stage
         query: rule-query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-10M-latency-slo
@@ -3359,7 +3359,7 @@ spec:
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-100M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -3374,7 +3374,7 @@ spec:
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-rule-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-rule-read-100M-latency-slo

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -31,7 +31,7 @@ spec:
       labels:
         route: telemeter-server-upload
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-upload-availability-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-upload-availability-slo
@@ -199,7 +199,7 @@ spec:
       labels:
         route: telemeter-server-metrics-v1-receive
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-receive-availability-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-receive-availability-slo
@@ -377,7 +377,7 @@ spec:
         handler: upload
         job: telemeter-server
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -392,7 +392,7 @@ spec:
         handler: upload
         job: telemeter-server
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-upload-latency-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-upload-latency-slo
@@ -588,7 +588,7 @@ spec:
         handler: receive
         job: telemeter-server
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -603,7 +603,7 @@ spec:
         handler: receive
         job: telemeter-server
         service: telemeter
-        severity: high
+        severity: medium
         slo: rhobs-telemeter-server-metrics-receive-latency-slo
   - interval: 30s
     name: rhobs-telemeter-server-metrics-receive-latency-slo
@@ -793,7 +793,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-availability-slo
   - interval: 30s
     name: api-metrics-write-availability-slo
@@ -987,7 +987,7 @@ spec:
         handler: query
         job: observatorium-observatorium-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-query-availability-slo
   - interval: 30s
     name: api-metrics-query-availability-slo
@@ -1181,7 +1181,7 @@ spec:
         handler: query_range
         job: observatorium-observatorium-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-query-range-availability-slo
   - interval: 30s
     name: api-metrics-query-range-availability-slo
@@ -1377,7 +1377,7 @@ spec:
         job: observatorium-observatorium-api
         method: PUT
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-raw-write-availability-slo
   - interval: 30s
     name: api-rules-raw-write-availability-slo
@@ -1584,7 +1584,7 @@ spec:
         job: observatorium-observatorium-api
         method: GET
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-raw-read-availability-slo
   - interval: 30s
     name: api-rules-raw-read-availability-slo
@@ -1791,7 +1791,7 @@ spec:
         job: observatorium-observatorium-api
         method: GET
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-read-availability-slo
   - interval: 30s
     name: api-rules-read-availability-slo
@@ -1994,7 +1994,7 @@ spec:
       labels:
         namespace: observatorium-metrics-stage
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-rules-sync-availability-slo
   - interval: 30s
     name: api-rules-sync-availability-slo
@@ -2177,7 +2177,7 @@ spec:
       labels:
         namespace: observatorium-metrics-stage
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-alerting-availability-slo
   - interval: 30s
     name: api-alerting-availability-slo
@@ -2352,7 +2352,7 @@ spec:
       labels:
         namespace: observatorium-metrics-stage
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-alerting-notif-availability-slo
   - interval: 30s
     name: api-alerting-notif-availability-slo
@@ -2533,7 +2533,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2549,7 +2549,7 @@ spec:
         handler: receive
         job: observatorium-observatorium-api
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-write-latency-slo
   - interval: 30s
     name: api-metrics-write-latency-slo
@@ -2756,7 +2756,7 @@ spec:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-1M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2771,7 +2771,7 @@ spec:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-1M-latency-slo
   - interval: 30s
     name: api-metrics-read-1M-latency-slo
@@ -2967,7 +2967,7 @@ spec:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-10M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -2982,7 +2982,7 @@ spec:
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-10M-latency-slo
   - interval: 30s
     name: api-metrics-read-10M-latency-slo
@@ -3178,7 +3178,7 @@ spec:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-100M-latency-slo
     - alert: SLOMetricAbsent
       annotations:
@@ -3193,7 +3193,7 @@ spec:
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
         service: observatorium-api
-        severity: high
+        severity: medium
         slo: api-metrics-read-100M-latency-slo
   - interval: 30s
     name: api-metrics-read-100M-latency-slo


### PR DESCRIPTION
Medium severity will send pings only to our Slack channel.