### PR TITLE
Add gubernator dashboard

### DIFF
--- a/observability/dashboards/observatorium-gubernator.libsonnet
+++ b/observability/dashboards/observatorium-gubernator.libsonnet
@@ -2,16 +2,16 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
 local template = import 'grafonnet/template.libsonnet';
 
 function() {
-  local panel(title, description='', unit='reqps') =
+  local panel(title, description='', unit='short') =
     g.panel(title) {
       description: description,
-      fieldConfig: {
-        defaults: {
-          unit: unit,
-        },
-      },
+      fill: 1,
+      fillGradient: 0,
+      linewidth: 1,
       span: 0,
-    } + g.stack,
+      stack: true,
+      yaxes: g.yaxes(unit),
+    },
 
   local datasourcesRegex = '/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/',
   local labelMatchers = {
@@ -31,7 +31,7 @@ function() {
 
   dashboard:: {
     data:
-      g.dashboard('Observatorium / Gubernator')
+      g.dashboard('Observatorium - Gubernator')
       .addTemplate('namespace', 'gubernator_check_counter', 'namespace')
       .addRow(
         g.row('GetRateLimits API')

--- a/observability/dashboards/observatorium-gubernator.libsonnet
+++ b/observability/dashboards/observatorium-gubernator.libsonnet
@@ -149,14 +149,14 @@ function() {
           panel('Broadcast', 'Latency of of GLOBAL broadcasts to peers per percentiles', 'ms') +
           g.queryPanel(
             'avg by(quantile, job) (gubernator_broadcast_durations{%(nsAndJob)s}) * 1000' % labelMatchers,
-            '{{quantile}}th percentile {{job}}',
+            '{{quantile}}th percentile',
           )
         )
         .addPanel(
           panel('Async', 'Latency of of GLOBAL async sends per percentiles', 'ms') +
           g.queryPanel(
             'avg by(quantile, job) (gubernator_async_durations{%(nsAndJob)s}) * 1000' % labelMatchers,
-            '{{quantile}}th percentile {{job}}',
+            '{{quantile}}th percentile',
           )
         )
       )

--- a/observability/dashboards/observatorium-gubernator.libsonnet
+++ b/observability/dashboards/observatorium-gubernator.libsonnet
@@ -1,0 +1,120 @@
+// local am = (import '../config.libsonnet').alertmanager;
+// local utils = import 'github.com/thanos-io/thanos/mixin/lib/utils.libsonnet';
+local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
+local template = import 'grafonnet/template.libsonnet';
+
+function() {
+
+  local gubernator = self,
+  local intervalTemplate =
+    template.interval(
+      'interval',
+      '5m,10m,30m,1h,6h,12h,auto',
+      label='interval',
+      current='5m',
+    ),
+  local namespaceTemplate =
+    template.new(
+      name='namespace',
+      datasource='$datasource',
+      query='label_values(thanos_status, namespace)',
+      label='namespace',
+      allValues='.+',
+      current='',
+      hide='',
+      refresh=2,
+      includeAll=true,
+      sort=1
+    ),
+  local jobTemplate =
+    template.new(
+      name='job',
+      datasource='$datasource',
+      query='label_values(up{namespace="$namespace", job="observatorium-gubernator"}, job)',
+      label='job',
+      allValues='.+',
+      current='',
+      hide='',
+      refresh=2,
+      includeAll=true,
+      sort=1
+    ),
+
+  // Requests status/count
+  // gubernator_grpc_request_counts
+  // gubernator_grpc_request_duration
+  // gubernator_over_limit_counter
+  // Request Latencies
+  // gubernator_async_durations
+  // gubernator_asyncrequest_retries
+  // gubernator_broadcast_durations
+  // Gube Cache Status
+  // gubernator_cache_access_count
+  // gubernator_cache_size
+  // gubernator_check_counter
+  // gubernator_check_error_counter
+  // gubernator_concurrent_checks_counter
+  // gubernator_pool_queue_length
+  // gubernator_queue_length
+
+  dashboard:: {
+    data:
+      g.dashboard('Observatorium / Gubernator')
+      .addRow(
+        g.row('gRPC Requests GetRateLimits')
+        .addPanel(
+          g.panel('Rate of requests') { span: 0 } +
+          g.queryPanel(
+            [
+              'rate(gubernator_grpc_request_counts{namespace="$namespace", job="$job", method=".*/GetRateLimits"}[$interval])',
+            ],
+            [
+              '{{pod}}',
+            ]
+          ) +
+          g.stack
+        )
+        .addPanel(
+          g.panel('Rate of errors') { span: 0 } +
+          g.queryPanel(
+            [
+              'rate(gubernator_grpc_request_counts{namespace="$namespace", job="$job", method=".*/GetRateLimits", status="failed"}[$interval])',
+            ],
+            [
+              '{{pod}}',
+            ]
+          ) +
+          g.stack
+        .addPanel(
+          g.panel('Latencies') { span: 0 } +
+          g.queryPanel(
+            [
+              'gubernator_grpc_request_duration{namespace="$namespace", job="$job", method=".*/GetRateLimits", status="success"}[$interval])',
+            ],
+            [
+              '{{pod}}',
+            ]
+          ) +
+          g.stack
+        )
+      ) + {
+        templating+: {
+          list+: [
+            if variable.name == 'datasource'
+            then variable { regex: '/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/' }
+            else variable
+            for variable in super.list
+          ] + [namespaceTemplate, jobTemplate, intervalTemplate],
+        },
+      },
+  },
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: 'grafana-dashboard-obervatorium-gubernator',
+  },
+  data: {
+    'rhobs-instance-obervatorium-gubernator.json': std.manifestJsonEx($.dashboard.data, ' '),
+  },
+}

--- a/observability/dashboards/observatorium-gubernator.libsonnet
+++ b/observability/dashboards/observatorium-gubernator.libsonnet
@@ -27,6 +27,8 @@ function() {
       includeAll=true,
       sort=1
     ),
+  local container = 'gubernator',
+  local pod = 'observatorium-gubernator',
   local jobTemplate =
     template.new(
       name='job',
@@ -41,62 +43,196 @@ function() {
       sort=1
     ),
 
-  // Requests status/count
-  // gubernator_grpc_request_counts
-  // gubernator_grpc_request_duration
-  // gubernator_over_limit_counter
-  // Request Latencies
-  // gubernator_async_durations
-  // gubernator_asyncrequest_retries
-  // gubernator_broadcast_durations
-  // Gube Cache Status
-  // gubernator_cache_access_count
-  // gubernator_cache_size
-  // gubernator_check_counter
-  // gubernator_check_error_counter
-  // gubernator_concurrent_checks_counter
-  // gubernator_pool_queue_length
-  // gubernator_queue_length
+  local panel(title, description='', unit='reqps') =
+    g.panel(title) {
+      description: description,
+      fieldConfig: {
+        defaults: {
+          unit: unit,
+        },
+      },
+      span: 0,
+    } + g.stack,
+
+  local commonSelectors = 'namespace="$namespace", job="$job"',
+  local podSelector = 'observatorium-gubernator-.*',
+  local containerSelector = 'gubernator',
+
 
   dashboard:: {
     data:
       g.dashboard('Observatorium / Gubernator')
       .addRow(
-        g.row('gRPC Requests GetRateLimits')
+        g.row('GetRateLimits API')
         .addPanel(
-          g.panel('Rate of requests') { span: 0 } +
+          panel('Requests', 'Rate of gRPC requests to the API per second', 'reqps') +
           g.queryPanel(
-            [
-              'rate(gubernator_grpc_request_counts{namespace="$namespace", job="$job", method=".*/GetRateLimits"}[$interval])',
-            ],
-            [
-              '{{pod}}',
-            ]
-          ) +
-          g.stack
+            'sum by (job, method) (rate(gubernator_grpc_request_counts{%s, method=~".*/GetRateLimits"}[$interval]))' % commonSelectors,
+            '{{job}}',
+          )
         )
         .addPanel(
-          g.panel('Rate of errors') { span: 0 } +
+          panel('Errors', 'Rate of failed gRPC requests to the API per second', 'reqps') +
           g.queryPanel(
-            [
-              'rate(gubernator_grpc_request_counts{namespace="$namespace", job="$job", method=".*/GetRateLimits", status="failed"}[$interval])',
-            ],
-            [
-              '{{pod}}',
-            ]
-          ) +
-          g.stack
+            'sum by (job, method) (rate(gubernator_grpc_request_counts{%s, method=~".*/GetRateLimits", status="failed"}[$interval]))' % commonSelectors,
+            '{{status}} {{job}}',
+          )
+        )
         .addPanel(
-          g.panel('Latencies') { span: 0 } +
+          panel('Latencies', 'Latency of gRPC requests to the API per percentiles', 'ms') +
+          g.queryPanel(
+            'avg by(quantile, job) (gubernator_grpc_request_duration{%s, method=~".*/GetRateLimits"}) * 1000' % commonSelectors,
+            '{{quantile}}th percentile',
+          )
+        )
+        .addPanel(
+          panel('Over Limit requests rate', 'Rate of requests that resulted in rate limiting (over the limit) per second', 'reqps') +
+          g.queryPanel(
+            'sum by(job) (rate(gubernator_over_limit_counter{%s}[$interval]))' % commonSelectors,
+            '{{job}}',
+          )
+        )
+      )
+      .addRow(
+        g.row('GetPeerRateLimits API')
+        .addPanel(
+          panel('Requests', 'Rate of gRPC requests to the API per second', 'reqps') +
+          g.queryPanel(
+            'sum by (job, method) (rate(gubernator_grpc_request_counts{%s, method=~".*/GetPeerRateLimits"}[$interval]))' % commonSelectors,
+            '{{job}}',
+          )
+        )
+        .addPanel(
+          panel('Errors', 'Rate of failed gRPC requests to the API per second', 'reqps') +
+          g.queryPanel(
+            'sum by (job, method) (rate(gubernator_grpc_request_counts{%s, method=~".*/GetPeerRateLimits", status="failed"}[$interval]))' % commonSelectors,
+            '{{status}} {{job}}',
+          )
+        )
+        .addPanel(
+          panel('Latencies', 'Latency of gRPC requests to the API per percentiles', 'ms') +
+          g.queryPanel(
+            'avg by(quantile, job) (gubernator_grpc_request_duration{%s, method=~".*/GetPeerRateLimits"}) * 1000' % commonSelectors,
+            '{{quantile}}th percentile',
+          )
+        )
+      )
+      .addRow(
+        g.row('Queues')
+        .addPanel(
+          panel('getRateLimitsBatch queue length', 'The getRateLimitsBatch() queue length in PeerClient.  This represents rate checks queued by for batching to a remote peer.', '') +
+          g.queryPanel(
+            'sum by(job) (rate(gubernator_queue_length{%s}[$interval]))' % commonSelectors,
+            '{{job}}',
+          )
+        )
+        .addPanel(
+          panel('GetRateLimit queue length', 'The number of GetRateLimit requests queued up in GubernatorPool workers.', '') +
+          g.queryPanel(
+            'sum by(job) (rate(gubernator_pool_queue_length{%s}[$interval]))' % commonSelectors,
+            '{{job}}',
+          )
+        )
+      )
+      .addRow(
+        g.row('Cache')
+        .addPanel(
+          panel('Requests', 'Rate of cache requests per second', 'reqps') +
+          g.queryPanel(
+            'sum by(job) (rate(gubernator_cache_access_count{%s}[$interval]))' % commonSelectors,
+            '{{job}}',
+          )
+        )
+        .addPanel(
+          panel('Misses', 'Rate of cache misses per second', 'reqps') +
+          g.queryPanel(
+            'sum by(job) (rate(gubernator_cache_access_count{%s, type="miss"}[$interval])) / sum by(job) (rate(gubernator_cache_access_count{%s}[$interval]))' % [commonSelectors, commonSelectors],
+            '{{job}}',
+          )
+        )
+        .addPanel(
+          panel('Size', 'The number of items in LRU Cache which holds the rate limits.', '') +
+          g.queryPanel(
+            'sum by(job) (gubernator_cache_size{%s})' % commonSelectors,
+            '{{job}}',
+          )
+        )
+        .addPanel(
+          panel('Unexpired evictions', 'Rate of cache items which were evicted while unexpired per second.', 'reqps') +
+          g.queryPanel(
+            'sum by(job) (rate(gubernator_unexpired_evictions_count{%s}[$interval]))' % commonSelectors,
+            '{{job}}',
+          )
+        )
+      )
+      .addRow(
+        g.row('Other latencies')
+        .addPanel(
+          panel('Batch', 'Latency of batch send operations to a remote peer per percentiles', 'ms') +
+          g.queryPanel(
+            'avg by(quantile, job) (gubernator_batch_send_duration{%s}) * 1000' % commonSelectors,
+            '{{quantile}}th percentile',
+          )
+        )
+        .addPanel(
+          panel('Broadcast', 'Latency of of GLOBAL broadcasts to peers per percentiles', 'ms') +
+          g.queryPanel(
+            'avg by(quantile, job) (gubernator_broadcast_durations{%s}) * 1000' % commonSelectors,
+            '{{quantile}}th percentile {{job}}',
+          )
+        )
+        .addPanel(
+          panel('Async', 'Latency of of GLOBAL async sends per percentiles', 'ms') +
+          g.queryPanel(
+            'avg by(quantile, job) (gubernator_async_durations{%s}) * 1000' % commonSelectors,
+            '{{quantile}}th percentile {{job}}',
+          )
+        )
+      )
+      .addRow(
+        g.row('Resources usage')
+        .addPanel(
+          panel('Memory Usage', 'Memory usage of the Gubernator process', 'MiB') +
+          g.queryPanel(
+            '(container_memory_working_set_bytes{container="%s", pod=~"%s", namespace="$namespace"}) / 1024^2' % [
+              containerSelector,
+              podSelector,
+            ],
+            'memory usage system {{pod}}',
+          )
+        )
+        .addPanel(
+          panel('CPU Usage', 'CPU usage of the Gubernator process', 'percent') +
+          g.queryPanel(
+            'rate(process_cpu_seconds_total{container="%s", pod=~"%s", namespace="$namespace"}[$interval]) * 100' % [
+              containerSelector,
+              podSelector,
+            ],
+            'cpu usage system {{pod}}',
+          )
+        )
+        .addPanel(
+          panel('Pod/Container Restarts', 'Number of times the pod/container has restarted', '') +
+          g.queryPanel(
+            'sum by (pod) (kube_pod_container_status_restarts_total{container="%s", pod=~"%s", namespace="$namespace",})' % [
+              containerSelector,
+              podSelector,
+            ],
+            'pod restart count {{pod}}',
+          )
+        )
+        .addPanel(
+          panel('Network Usage', 'Network usage of the Gubernator process', 'binBps') +
           g.queryPanel(
             [
-              'gubernator_grpc_request_duration{namespace="$namespace", job="$job", method=".*/GetRateLimits", status="success"}[$interval])',
+              'sum by (pod) (rate(container_network_receive_bytes_total{pod=~"%s", namespace="$namespace"}[$interval]))' % podSelector,
+              'sum by (pod) (rate(container_network_transmit_bytes_total{pod=~"%s", namespace="$namespace"}[$interval]))' % podSelector,
             ],
             [
-              '{{pod}}',
+              'network traffic in {{pod}}',
+              'network traffic out {{pod}}',
             ]
-          ) +
-          g.stack
+          )
         )
       ) + {
         templating+: {

--- a/observability/dashboards/observatorium-gubernator.libsonnet
+++ b/observability/dashboards/observatorium-gubernator.libsonnet
@@ -172,7 +172,7 @@ function() {
         .addPanel(
           panel('CPU Usage', 'CPU usage of the Gubernator process', 'percent') +
           g.queryPanel(
-            'rate(process_cpu_seconds_total{%(container)s, %(pod)s, %(ns)s}[$interval]) * 100' % labelMatchers,
+            'rate(container_cpu_usage_seconds_total{%(container)s, %(pod)s, %(ns)s}[$interval]) * 100' % labelMatchers,
             'cpu usage system {{pod}}',
           )
         )

--- a/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
+++ b/observability/dashboards/rhobs-instance-utilization-overview.libsonnet
@@ -32,7 +32,7 @@ function() {
     template.new(
       name='job',
       datasource='$datasource',
-      query='label_values(up{namespace="$namespace", job=~"observatorium-thanos-.*|observatorium-ruler-query.*"}, job)',
+      query='label_values(up{namespace="$namespace", job=~"observatorium-thanos-.*|observatorium-ruler-query.*|observatorium-gubernator"}, job)',
       label='job',
       allValues='.+',
       current='',
@@ -618,6 +618,7 @@ function() {
         g.row('Gubernator Overview')
         .addPanel(
           g.panel('Rate of gRPC requests', 'Shows count of gRPC requests to gubernator') +
+          g.addDashboardLink(thanos.gubernator.dashboard.title) +
           g.queryPanel(
             [
               'sum(rate(gubernator_grpc_request_counts{namespace="$namespace",job=~"$job"}[$__rate_interval])) by (namespace,job,pod)',
@@ -630,6 +631,7 @@ function() {
         )
         .addPanel(
           g.panel('Rate of errors in gRPC requests', 'Shows count of errors in gRPC requests to gubernator') { span:: 0 } +
+          g.addDashboardLink(thanos.gubernator.dashboard.title) +
           g.queryPanel(
             [
               'sum(rate(gubernator_grpc_request_counts{status="failed",namespace="$namespace",job=~"$job"}[$__rate_interval])) by (namespace,job,pod)',
@@ -642,6 +644,7 @@ function() {
         )
         .addPanel(
           g.panel('Duration of gRPC requests', 'Shows duration of gRPC requests to gubernator') +
+          g.addDashboardLink(thanos.gubernator.dashboard.title) +
           g.queryPanel(
             [
               'gubernator_grpc_request_duration{quantile="0.99", namespace="$namespace",job=~"$job"}',
@@ -656,6 +659,7 @@ function() {
         )
         .addPanel(
           g.panel('Local queue of rate checks', 'Shows the number of rate checks in the local queue') +
+          g.addDashboardLink(thanos.gubernator.dashboard.title) +
           g.queryPanel(
             [
               'gubernator_pool_queue_length{namespace="$namespace",job=~"$job"}',
@@ -667,6 +671,7 @@ function() {
         )
         .addPanel(
           g.panel('Peer queue of rate checks', 'Shows the number of rate checks in the peer queue') +
+          g.addDashboardLink(thanos.gubernator.dashboard.title) +
           g.queryPanel(
             [
               'gubernator_queue_length{namespace="$namespace",job=~"$job"}',
@@ -677,17 +682,21 @@ function() {
           ) { span:: 0 }
         )
         .addPanel(
+          g.addDashboardLink(thanos.gubernator.dashboard.title) +
           memoryUsagePanel(thanos.gubernator.dashboard.container, thanos.gubernator.dashboard.pod) +
           { yaxes: g.yaxes('bytes') } +
           g.stack
         )
         .addPanel(
+          g.addDashboardLink(thanos.gubernator.dashboard.title) +
           cpuUsagePanel(thanos.gubernator.dashboard.container, thanos.gubernator.dashboard.pod)
         )
         .addPanel(
+          g.addDashboardLink(thanos.gubernator.dashboard.title) +
           podRestartPanel(thanos.gubernator.dashboard.container, thanos.gubernator.dashboard.pod)
         )
         .addPanel(
+          g.addDashboardLink(thanos.gubernator.dashboard.title) +
           networkUsagePanel(thanos.gubernator.dashboard.pod) +
           g.stack +
           { yaxes: g.yaxes('binBps') }

--- a/observability/grafana.jsonnet
+++ b/observability/grafana.jsonnet
@@ -75,7 +75,7 @@ local dashboards =
   { 'grafana-dashboard-tracing-otel.configmap': (import 'dashboards/opentelemetry.libsonnet')(obsDatasource, obsTraces) } +
   { 'grafana-dashboard-tracing-jaeger.configmap': (import 'dashboards/tracing.libsonnet')(obsDatasource, obsTraces) } +
   { 'grafana-dashboard-rhobs-instance-utilization-overview.configmap': (import 'dashboards/rhobs-instance-utilization-overview.libsonnet')() } +
-  { 'grafana-dashboard-rules-objstore.configmap': (import 'dashboards/rules-objstore.libsonnet')() };
+  { 'grafana-dashboard-rules-objstore.configmap': (import 'dashboards/rules-objstore.libsonnet')() } +
   { 'grafana-dashboard-observatorium-gubernator.configmap': (import 'dashboards/observatorium-gubernator.libsonnet')() };
 {
   [name]: dashboards[name] {

--- a/observability/grafana.jsonnet
+++ b/observability/grafana.jsonnet
@@ -76,6 +76,7 @@ local dashboards =
   { 'grafana-dashboard-tracing-jaeger.configmap': (import 'dashboards/tracing.libsonnet')(obsDatasource, obsTraces) } +
   { 'grafana-dashboard-rhobs-instance-utilization-overview.configmap': (import 'dashboards/rhobs-instance-utilization-overview.libsonnet')() } +
   { 'grafana-dashboard-rules-objstore.configmap': (import 'dashboards/rules-objstore.libsonnet')() };
+  { 'grafana-dashboard-observatorium-gubernator.configmap': (import 'dashboards/observatorium-gubernator.libsonnet')() };
 {
   [name]: dashboards[name] {
     metadata+: {

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
@@ -64,7 +64,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetRateLimits\"}[$interval]))",
+           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"observatorium-gubernator\", method=~\".*/GetRateLimits\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{job}}",
@@ -156,7 +156,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetRateLimits\", status=\"failed\"}[$interval]))",
+           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"observatorium-gubernator\", method=~\".*/GetRateLimits\", status=\"failed\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{status}} {{job}}",
@@ -248,7 +248,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "avg by(quantile, job) (gubernator_grpc_request_duration{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetRateLimits\"}) * 1000",
+           "expr": "avg by(quantile, job) (gubernator_grpc_request_duration{namespace=\"$namespace\", job=\"observatorium-gubernator\", method=~\".*/GetRateLimits\"}) * 1000",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{quantile}}th percentile",
@@ -340,7 +340,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by(job) (rate(gubernator_over_limit_counter{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+           "expr": "sum by(job) (rate(gubernator_over_limit_counter{namespace=\"$namespace\", job=\"observatorium-gubernator\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{job}}",
@@ -444,7 +444,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetPeerRateLimits\"}[$interval]))",
+           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"observatorium-gubernator\", method=~\".*/GetPeerRateLimits\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{job}}",
@@ -536,7 +536,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetPeerRateLimits\", status=\"failed\"}[$interval]))",
+           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"observatorium-gubernator\", method=~\".*/GetPeerRateLimits\", status=\"failed\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{status}} {{job}}",
@@ -628,7 +628,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "avg by(quantile, job) (gubernator_grpc_request_duration{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetPeerRateLimits\"}) * 1000",
+           "expr": "avg by(quantile, job) (gubernator_grpc_request_duration{namespace=\"$namespace\", job=\"observatorium-gubernator\", method=~\".*/GetPeerRateLimits\"}) * 1000",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{quantile}}th percentile",
@@ -732,7 +732,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by(job) (rate(gubernator_queue_length{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+           "expr": "sum by(job) (rate(gubernator_queue_length{namespace=\"$namespace\", job=\"observatorium-gubernator\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{job}}",
@@ -824,7 +824,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by(job) (rate(gubernator_pool_queue_length{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+           "expr": "sum by(job) (rate(gubernator_pool_queue_length{namespace=\"$namespace\", job=\"observatorium-gubernator\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{job}}",
@@ -928,7 +928,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by(job) (rate(gubernator_cache_access_count{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+           "expr": "sum by(job) (rate(gubernator_cache_access_count{namespace=\"$namespace\", job=\"observatorium-gubernator\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{job}}",
@@ -1020,7 +1020,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by(job) (rate(gubernator_cache_access_count{{\"container\": \"container=\\\"gubernator\\\"\", \"job\": \"job=\\\"$job\\\"\", \"ns\": \"namespace=\\\"$namespace\\\"\", \"nsAndJob\": \"namespace=\\\"$namespace\\\", job=\\\"$job\\\"\", \"pod\": \"pod=~\\\"observatorium-gubernator-.*\\\"\"}, type=\"miss\"}[$interval])) / sum by(job) (rate(gubernator_cache_access_count{{\"container\": \"container=\\\"gubernator\\\"\", \"job\": \"job=\\\"$job\\\"\", \"ns\": \"namespace=\\\"$namespace\\\"\", \"nsAndJob\": \"namespace=\\\"$namespace\\\", job=\\\"$job\\\"\", \"pod\": \"pod=~\\\"observatorium-gubernator-.*\\\"\"}}[$interval]))",
+           "expr": "sum by(job) (rate(gubernator_cache_access_count{namespace=\"$namespace\", job=\"observatorium-gubernator\", type=\"miss\"}[$interval])) / sum by(job) (rate(gubernator_cache_access_count{namespace=\"$namespace\", job=\"observatorium-gubernator\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{job}}",
@@ -1112,7 +1112,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by(job) (gubernator_cache_size{namespace=\"$namespace\", job=\"$job\"})",
+           "expr": "sum by(job) (gubernator_cache_size{namespace=\"$namespace\", job=\"observatorium-gubernator\"})",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{job}}",
@@ -1204,7 +1204,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by(job) (rate(gubernator_unexpired_evictions_count{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+           "expr": "sum by(job) (rate(gubernator_unexpired_evictions_count{namespace=\"$namespace\", job=\"observatorium-gubernator\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{job}}",
@@ -1308,7 +1308,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "avg by(quantile, job) (gubernator_batch_send_duration{namespace=\"$namespace\", job=\"$job\"}) * 1000",
+           "expr": "avg by(quantile, job) (gubernator_batch_send_duration{namespace=\"$namespace\", job=\"observatorium-gubernator\"}) * 1000",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{quantile}}th percentile",
@@ -1400,7 +1400,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "avg by(quantile, job) (gubernator_broadcast_durations{namespace=\"$namespace\", job=\"$job\"}) * 1000",
+           "expr": "avg by(quantile, job) (gubernator_broadcast_durations{namespace=\"$namespace\", job=\"observatorium-gubernator\"}) * 1000",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{quantile}}th percentile {{job}}",
@@ -1492,7 +1492,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "avg by(quantile, job) (gubernator_async_durations{namespace=\"$namespace\", job=\"$job\"}) * 1000",
+           "expr": "avg by(quantile, job) (gubernator_async_durations{namespace=\"$namespace\", job=\"observatorium-gubernator\"}) * 1000",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "{{quantile}}th percentile {{job}}",
@@ -1596,7 +1596,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "(container_memory_working_set_bytes{container=\"gubernator\", pod=~\"observatorium-gubernator-.*\", namespace=\"$namespace\") / 1024^2",
+           "expr": "container_memory_working_set_bytes{container=\"gubernator\", pod=~\"observatorium-gubernator.*\", namespace=\"$namespace\"} / 1024^2",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "memory usage system {{pod}}",
@@ -1688,7 +1688,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "rate(process_cpu_seconds_total{container=\"gubernator\", pod=~\"observatorium-gubernator-.*\", namespace=\"$namespace\"}[$interval]) * 100",
+           "expr": "rate(process_cpu_seconds_total{container=\"gubernator\", pod=~\"observatorium-gubernator.*\", namespace=\"$namespace\"}[$interval]) * 100",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "cpu usage system {{pod}}",
@@ -1780,7 +1780,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by (pod) (kube_pod_container_status_restarts_total{container=\"gubernator\", pod=~\"observatorium-gubernator-.*\", namespace=\"$namespace\"})",
+           "expr": "sum by (pod) (kube_pod_container_status_restarts_total{container=\"gubernator\", pod=~\"observatorium-gubernator.*\", namespace=\"$namespace\"})",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "pod restart count {{pod}}",
@@ -1872,7 +1872,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "sum by (pod) (rate(container_network_receive_bytes_total{pod=~\"observatorium-gubernator-.*\", namespace=\"$namespace\"}[$interval]))",
+           "expr": "sum by (pod) (rate(container_network_receive_bytes_total{pod=~\"observatorium-gubernator.*\", namespace=\"$namespace\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "network traffic in {{pod}}",
@@ -1880,7 +1880,7 @@ data:
            "step": 10
           },
           {
-           "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{pod=~\"observatorium-gubernator-.*\", namespace=\"$namespace\"}[$interval]))",
+           "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{pod=~\"observatorium-gubernator.*\", namespace=\"$namespace\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "network traffic out {{pod}}",
@@ -1957,71 +1957,28 @@ data:
         ],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
-        "type": "datasource"
-       },
-       {
-        "current": {
-         "text": "default",
-         "value": "default"
-        },
-        "hide": 0,
-        "label": null,
-        "name": "datasource",
-        "options": [
-
-        ],
-        "query": "prometheus",
-        "refresh": 1,
         "regex": "/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/",
         "type": "datasource"
        },
        {
-        "allValue": ".+",
+        "allValue": null,
         "current": {
-         "text": "",
-         "value": ""
+         "text": "prod",
+         "value": "prod"
         },
         "datasource": "$datasource",
         "hide": 0,
-        "includeAll": true,
+        "includeAll": false,
         "label": "namespace",
         "multi": false,
         "name": "namespace",
         "options": [
 
         ],
-        "query": "label_values(thanos_status, namespace)",
-        "refresh": 2,
+        "query": "label_values(gubernator_check_counter, namespace)",
+        "refresh": 1,
         "regex": "",
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [
-
-        ],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-       },
-       {
-        "allValue": ".+",
-        "current": {
-         "text": "",
-         "value": ""
-        },
-        "datasource": "$datasource",
-        "hide": 0,
-        "includeAll": true,
-        "label": "job",
-        "multi": false,
-        "name": "job",
-        "options": [
-
-        ],
-        "query": "label_values(up{namespace=\"$namespace\", job=\"observatorium-gubernator\"}, job)",
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
+        "sort": 2,
         "tagValuesQuery": "",
         "tags": [
 

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
@@ -29,12 +29,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Rate of gRPC requests to the API per second",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "reqps"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 1,
          "legend": {
           "avg": false,
@@ -46,7 +42,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -95,7 +91,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "reqps",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -121,12 +117,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Rate of failed gRPC requests to the API per second",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "reqps"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 2,
          "legend": {
           "avg": false,
@@ -138,7 +130,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -187,7 +179,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "reqps",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -213,12 +205,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Latency of gRPC requests to the API per percentiles",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "ms"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 3,
          "legend": {
           "avg": false,
@@ -230,7 +218,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -279,7 +267,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "ms",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -305,12 +293,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Rate of requests that resulted in rate limiting (over the limit) per second",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "reqps"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 4,
          "legend": {
           "avg": false,
@@ -322,7 +306,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -371,7 +355,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "reqps",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -409,12 +393,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Rate of gRPC requests to the API per second",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "reqps"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 5,
          "legend": {
           "avg": false,
@@ -426,7 +406,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -475,7 +455,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "reqps",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -501,12 +481,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Rate of failed gRPC requests to the API per second",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "reqps"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 6,
          "legend": {
           "avg": false,
@@ -518,7 +494,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -567,7 +543,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "reqps",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -593,12 +569,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Latency of gRPC requests to the API per percentiles",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "ms"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 7,
          "legend": {
           "avg": false,
@@ -610,7 +582,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -659,7 +631,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "ms",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -697,12 +669,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "The getRateLimitsBatch() queue length in PeerClient.  This represents rate checks queued by for batching to a remote peer.",
-         "fieldConfig": {
-          "defaults": {
-           "unit": ""
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 8,
          "legend": {
           "avg": false,
@@ -714,7 +682,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -763,7 +731,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -789,12 +757,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "The number of GetRateLimit requests queued up in GubernatorPool workers.",
-         "fieldConfig": {
-          "defaults": {
-           "unit": ""
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 9,
          "legend": {
           "avg": false,
@@ -806,7 +770,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -855,7 +819,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -893,12 +857,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Rate of cache requests per second",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "reqps"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 10,
          "legend": {
           "avg": false,
@@ -910,7 +870,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -959,7 +919,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "reqps",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -985,12 +945,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Rate of cache misses per second",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "reqps"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 11,
          "legend": {
           "avg": false,
@@ -1002,7 +958,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -1051,7 +1007,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "reqps",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -1077,12 +1033,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "The number of items in LRU Cache which holds the rate limits.",
-         "fieldConfig": {
-          "defaults": {
-           "unit": ""
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 12,
          "legend": {
           "avg": false,
@@ -1094,7 +1046,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -1143,7 +1095,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -1169,12 +1121,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Rate of cache items which were evicted while unexpired per second.",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "reqps"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 13,
          "legend": {
           "avg": false,
@@ -1186,7 +1134,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -1235,7 +1183,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "reqps",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -1273,12 +1221,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Latency of batch send operations to a remote peer per percentiles",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "ms"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 14,
          "legend": {
           "avg": false,
@@ -1290,7 +1234,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -1339,7 +1283,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "ms",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -1365,12 +1309,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Latency of of GLOBAL broadcasts to peers per percentiles",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "ms"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 15,
          "legend": {
           "avg": false,
@@ -1382,7 +1322,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -1431,7 +1371,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "ms",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -1457,12 +1397,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Latency of of GLOBAL async sends per percentiles",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "ms"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 16,
          "legend": {
           "avg": false,
@@ -1474,7 +1410,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -1523,7 +1459,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "ms",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -1561,12 +1497,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Memory usage of the Gubernator process",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "MiB"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 17,
          "legend": {
           "avg": false,
@@ -1578,7 +1510,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -1627,7 +1559,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "MiB",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -1653,12 +1585,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "CPU usage of the Gubernator process",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "percent"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 18,
          "legend": {
           "avg": false,
@@ -1670,7 +1598,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -1719,7 +1647,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "percent",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -1745,12 +1673,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Number of times the pod/container has restarted",
-         "fieldConfig": {
-          "defaults": {
-           "unit": ""
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 19,
          "legend": {
           "avg": false,
@@ -1762,7 +1686,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -1811,7 +1735,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -1837,12 +1761,8 @@ data:
          "dashes": false,
          "datasource": "$datasource",
          "description": "Network usage of the Gubernator process",
-         "fieldConfig": {
-          "defaults": {
-           "unit": "binBps"
-          }
-         },
-         "fill": 10,
+         "fill": 1,
+         "fillGradient": 0,
          "id": 20,
          "legend": {
           "avg": false,
@@ -1854,7 +1774,7 @@ data:
           "values": false
          },
          "lines": true,
-         "linewidth": 0,
+         "linewidth": 1,
          "links": [
 
          ],
@@ -1911,7 +1831,7 @@ data:
          },
          "yaxes": [
           {
-           "format": "short",
+           "format": "binBps",
            "label": null,
            "logBase": 1,
            "max": null,
@@ -2034,7 +1954,7 @@ data:
       ]
      },
      "timezone": "utc",
-     "title": "Observatorium / Gubernator",
+     "title": "Observatorium - Gubernator",
      "uid": "",
      "version": 0
     }

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
@@ -1,0 +1,268 @@
+apiVersion: v1
+data:
+  rhobs-instance-obervatorium-gubernator.json: |-
+    {
+     "annotations": {
+      "list": [
+
+      ]
+     },
+     "editable": true,
+     "gnetId": null,
+     "graphTooltip": 0,
+     "hideControls": false,
+     "links": [
+
+     ],
+     "refresh": "10s",
+     "rows": [
+      {
+       "collapse": false,
+       "height": "250px",
+       "panels": [
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "fill": 10,
+         "id": 1,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 12,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"$job\", method=\".*/GetRateLimits\"}[$interval])",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "rate of requests",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Rate of requests",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        }
+       ],
+       "repeat": null,
+       "repeatIteration": null,
+       "repeatRowId": null,
+       "showTitle": true,
+       "title": "gRPC Requests GetRateLimits",
+       "titleSize": "h6"
+      }
+     ],
+     "schemaVersion": 14,
+     "style": "dark",
+     "tags": [
+
+     ],
+     "templating": {
+      "list": [
+       {
+        "current": {
+         "text": "default",
+         "value": "default"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "datasource",
+        "options": [
+
+        ],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+       },
+       {
+        "current": {
+         "text": "default",
+         "value": "default"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "datasource",
+        "options": [
+
+        ],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/^rhobs.*|telemeter-prod-01-prometheus|app-sre-stage-01-prometheus/",
+        "type": "datasource"
+       },
+       {
+        "allValue": ".+",
+        "current": {
+         "text": "",
+         "value": ""
+        },
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": true,
+        "label": "namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [
+
+        ],
+        "query": "label_values(thanos_status, namespace)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [
+
+        ],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+       },
+       {
+        "allValue": ".+",
+        "current": {
+         "text": "",
+         "value": ""
+        },
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": true,
+        "label": "job",
+        "multi": false,
+        "name": "job",
+        "options": [
+
+        ],
+        "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-gubernator.*\"}, job)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [
+
+        ],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+       },
+       {
+        "auto": true,
+        "auto_count": 300,
+        "auto_min": "10s",
+        "current": {
+         "text": "5m",
+         "value": "5m"
+        },
+        "hide": 0,
+        "label": "interval",
+        "name": "interval",
+        "query": "5m,10m,30m,1h,6h,12h",
+        "refresh": 2,
+        "type": "interval"
+       }
+      ]
+     },
+     "time": {
+      "from": "now-1h",
+      "to": "now"
+     },
+     "timepicker": {
+      "refresh_intervals": [
+       "5s",
+       "10s",
+       "30s",
+       "1m",
+       "5m",
+       "15m",
+       "30m",
+       "1h",
+       "2h",
+       "1d"
+      ],
+      "time_options": [
+       "5m",
+       "15m",
+       "1h",
+       "6h",
+       "12h",
+       "24h",
+       "2d",
+       "7d",
+       "30d"
+      ]
+     },
+     "timezone": "utc",
+     "title": "Observatorium / Gubernator",
+     "uid": "",
+     "version": 0
+    }
+kind: ConfigMap
+metadata:
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/Observatorium
+  labels:
+    grafana_dashboard: "true"
+  name: grafana-dashboard-obervatorium-gubernator

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
@@ -28,6 +28,12 @@ data:
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
+         "description": "Rate of gRPC requests to the API per second",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "reqps"
+          }
+         },
          "fill": 10,
          "id": 1,
          "legend": {
@@ -53,15 +59,15 @@ data:
 
          ],
          "spaceLength": 10,
-         "span": 12,
+         "span": 3,
          "stack": true,
          "steppedLine": false,
          "targets": [
           {
-           "expr": "rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"$job\", method=\".*/GetRateLimits\"}[$interval])",
+           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetRateLimits\"}[$interval]))",
            "format": "time_series",
            "intervalFactor": 2,
-           "legendFormat": "rate of requests",
+           "legendFormat": "{{job}}",
            "legendLink": null,
            "step": 10
           }
@@ -71,7 +77,283 @@ data:
          ],
          "timeFrom": null,
          "timeShift": null,
-         "title": "Rate of requests",
+         "title": "Requests",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Rate of failed gRPC requests to the API per second",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "reqps"
+          }
+         },
+         "fill": 10,
+         "id": 2,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetRateLimits\", status=\"failed\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{status}} {{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Errors",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Latency of gRPC requests to the API per percentiles",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "ms"
+          }
+         },
+         "fill": 10,
+         "id": 3,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "avg by(quantile, job) (gubernator_grpc_request_duration{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetRateLimits\"}) * 1000",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{quantile}}th percentile",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Latencies",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Rate of requests that resulted in rate limiting (over the limit) per second",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "reqps"
+          }
+         },
+         "fill": 10,
+         "id": 4,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by(job) (rate(gubernator_over_limit_counter{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Over Limit requests rate",
          "tooltip": {
           "shared": false,
           "sort": 0,
@@ -111,7 +393,1547 @@ data:
        "repeatIteration": null,
        "repeatRowId": null,
        "showTitle": true,
-       "title": "gRPC Requests GetRateLimits",
+       "title": "GetRateLimits API",
+       "titleSize": "h6"
+      },
+      {
+       "collapse": false,
+       "height": "250px",
+       "panels": [
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Rate of gRPC requests to the API per second",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "reqps"
+          }
+         },
+         "fill": 10,
+         "id": 5,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetPeerRateLimits\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Requests",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Rate of failed gRPC requests to the API per second",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "reqps"
+          }
+         },
+         "fill": 10,
+         "id": 6,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (job, method) (rate(gubernator_grpc_request_counts{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetPeerRateLimits\", status=\"failed\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{status}} {{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Errors",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Latency of gRPC requests to the API per percentiles",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "ms"
+          }
+         },
+         "fill": 10,
+         "id": 7,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "avg by(quantile, job) (gubernator_grpc_request_duration{namespace=\"$namespace\", job=\"$job\", method=~\".*/GetPeerRateLimits\"}) * 1000",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{quantile}}th percentile",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Latencies",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        }
+       ],
+       "repeat": null,
+       "repeatIteration": null,
+       "repeatRowId": null,
+       "showTitle": true,
+       "title": "GetPeerRateLimits API",
+       "titleSize": "h6"
+      },
+      {
+       "collapse": false,
+       "height": "250px",
+       "panels": [
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "The getRateLimitsBatch() queue length in PeerClient.  This represents rate checks queued by for batching to a remote peer.",
+         "fieldConfig": {
+          "defaults": {
+           "unit": ""
+          }
+         },
+         "fill": 10,
+         "id": 8,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 6,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by(job) (rate(gubernator_queue_length{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "getRateLimitsBatch queue length",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "The number of GetRateLimit requests queued up in GubernatorPool workers.",
+         "fieldConfig": {
+          "defaults": {
+           "unit": ""
+          }
+         },
+         "fill": 10,
+         "id": 9,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 6,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by(job) (rate(gubernator_pool_queue_length{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "GetRateLimit queue length",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        }
+       ],
+       "repeat": null,
+       "repeatIteration": null,
+       "repeatRowId": null,
+       "showTitle": true,
+       "title": "Queues",
+       "titleSize": "h6"
+      },
+      {
+       "collapse": false,
+       "height": "250px",
+       "panels": [
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Rate of cache requests per second",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "reqps"
+          }
+         },
+         "fill": 10,
+         "id": 10,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by(job) (rate(gubernator_cache_access_count{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Requests",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Rate of cache misses per second",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "reqps"
+          }
+         },
+         "fill": 10,
+         "id": 11,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by(job) (rate(gubernator_cache_access_count{{\"container\": \"container=\\\"gubernator\\\"\", \"job\": \"job=\\\"$job\\\"\", \"ns\": \"namespace=\\\"$namespace\\\"\", \"nsAndJob\": \"namespace=\\\"$namespace\\\", job=\\\"$job\\\"\", \"pod\": \"pod=~\\\"observatorium-gubernator-.*\\\"\"}, type=\"miss\"}[$interval])) / sum by(job) (rate(gubernator_cache_access_count{{\"container\": \"container=\\\"gubernator\\\"\", \"job\": \"job=\\\"$job\\\"\", \"ns\": \"namespace=\\\"$namespace\\\"\", \"nsAndJob\": \"namespace=\\\"$namespace\\\", job=\\\"$job\\\"\", \"pod\": \"pod=~\\\"observatorium-gubernator-.*\\\"\"}}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Misses",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "The number of items in LRU Cache which holds the rate limits.",
+         "fieldConfig": {
+          "defaults": {
+           "unit": ""
+          }
+         },
+         "fill": 10,
+         "id": 12,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by(job) (gubernator_cache_size{namespace=\"$namespace\", job=\"$job\"})",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Size",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Rate of cache items which were evicted while unexpired per second.",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "reqps"
+          }
+         },
+         "fill": 10,
+         "id": 13,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by(job) (rate(gubernator_unexpired_evictions_count{namespace=\"$namespace\", job=\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Unexpired evictions",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        }
+       ],
+       "repeat": null,
+       "repeatIteration": null,
+       "repeatRowId": null,
+       "showTitle": true,
+       "title": "Cache",
+       "titleSize": "h6"
+      },
+      {
+       "collapse": false,
+       "height": "250px",
+       "panels": [
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Latency of batch send operations to a remote peer per percentiles",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "ms"
+          }
+         },
+         "fill": 10,
+         "id": 14,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "avg by(quantile, job) (gubernator_batch_send_duration{namespace=\"$namespace\", job=\"$job\"}) * 1000",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{quantile}}th percentile",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Batch",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Latency of of GLOBAL broadcasts to peers per percentiles",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "ms"
+          }
+         },
+         "fill": 10,
+         "id": 15,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "avg by(quantile, job) (gubernator_broadcast_durations{namespace=\"$namespace\", job=\"$job\"}) * 1000",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{quantile}}th percentile {{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Broadcast",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Latency of of GLOBAL async sends per percentiles",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "ms"
+          }
+         },
+         "fill": 10,
+         "id": 16,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 4,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "avg by(quantile, job) (gubernator_async_durations{namespace=\"$namespace\", job=\"$job\"}) * 1000",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{quantile}}th percentile {{job}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Async",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        }
+       ],
+       "repeat": null,
+       "repeatIteration": null,
+       "repeatRowId": null,
+       "showTitle": true,
+       "title": "Other latencies",
+       "titleSize": "h6"
+      },
+      {
+       "collapse": false,
+       "height": "250px",
+       "panels": [
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Memory usage of the Gubernator process",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "MiB"
+          }
+         },
+         "fill": 10,
+         "id": 17,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "(container_memory_working_set_bytes{container=\"gubernator\", pod=~\"observatorium-gubernator-.*\", namespace=\"$namespace\") / 1024^2",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "memory usage system {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Memory Usage",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "CPU usage of the Gubernator process",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "percent"
+          }
+         },
+         "fill": 10,
+         "id": 18,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "rate(process_cpu_seconds_total{container=\"gubernator\", pod=~\"observatorium-gubernator-.*\", namespace=\"$namespace\"}[$interval]) * 100",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "cpu usage system {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "CPU Usage",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Number of times the pod/container has restarted",
+         "fieldConfig": {
+          "defaults": {
+           "unit": ""
+          }
+         },
+         "fill": 10,
+         "id": 19,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (pod) (kube_pod_container_status_restarts_total{container=\"gubernator\", pod=~\"observatorium-gubernator-.*\", namespace=\"$namespace\"})",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "pod restart count {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Pod/Container Restarts",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        },
+        {
+         "aliasColors": {
+
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "Network usage of the Gubernator process",
+         "fieldConfig": {
+          "defaults": {
+           "unit": "binBps"
+          }
+         },
+         "fill": 10,
+         "id": 20,
+         "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+         },
+         "lines": true,
+         "linewidth": 0,
+         "links": [
+
+         ],
+         "nullPointMode": "null as zero",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+
+         ],
+         "spaceLength": 10,
+         "span": 3,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+          {
+           "expr": "sum by (pod) (rate(container_network_receive_bytes_total{pod=~\"observatorium-gubernator-.*\", namespace=\"$namespace\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "network traffic in {{pod}}",
+           "legendLink": null,
+           "step": 10
+          },
+          {
+           "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{pod=~\"observatorium-gubernator-.*\", namespace=\"$namespace\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "network traffic out {{pod}}",
+           "legendLink": null,
+           "step": 10
+          }
+         ],
+         "thresholds": [
+
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Network Usage",
+         "tooltip": {
+          "shared": false,
+          "sort": 0,
+          "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": [
+
+          ]
+         },
+         "yaxes": [
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": 0,
+           "show": true
+          },
+          {
+           "format": "short",
+           "label": null,
+           "logBase": 1,
+           "max": null,
+           "min": null,
+           "show": false
+          }
+         ]
+        }
+       ],
+       "repeat": null,
+       "repeatIteration": null,
+       "repeatRowId": null,
+       "showTitle": true,
+       "title": "Resources usage",
        "titleSize": "h6"
       }
      ],
@@ -196,7 +2018,7 @@ data:
         "options": [
 
         ],
-        "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-gubernator.*\"}, job)",
+        "query": "label_values(up{namespace=\"$namespace\", job=\"observatorium-gubernator\"}, job)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
@@ -1616,7 +1616,7 @@ data:
          "steppedLine": false,
          "targets": [
           {
-           "expr": "rate(process_cpu_seconds_total{container=\"gubernator\", pod=~\"observatorium-gubernator.*\", namespace=\"$namespace\"}[$interval]) * 100",
+           "expr": "rate(container_cpu_usage_seconds_total{container=\"gubernator\", pod=~\"observatorium-gubernator.*\", namespace=\"$namespace\"}[$interval]) * 100",
            "format": "time_series",
            "intervalFactor": 2,
            "legendFormat": "cpu usage system {{pod}}",

--- a/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-observatorium-gubernator.configmap.yaml
@@ -1343,7 +1343,7 @@ data:
            "expr": "avg by(quantile, job) (gubernator_broadcast_durations{namespace=\"$namespace\", job=\"observatorium-gubernator\"}) * 1000",
            "format": "time_series",
            "intervalFactor": 2,
-           "legendFormat": "{{quantile}}th percentile {{job}}",
+           "legendFormat": "{{quantile}}th percentile",
            "legendLink": null,
            "step": 10
           }
@@ -1431,7 +1431,7 @@ data:
            "expr": "avg by(quantile, job) (gubernator_async_durations{namespace=\"$namespace\", job=\"observatorium-gubernator\"}) * 1000",
            "format": "time_series",
            "intervalFactor": 2,
-           "legendFormat": "{{quantile}}th percentile {{job}}",
+           "legendFormat": "{{quantile}}th percentile",
            "legendLink": null,
            "step": 10
           }

--- a/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-rhobs-instance-utilization-overview.configmap.yaml
@@ -6944,7 +6944,13 @@ data:
          "lines": true,
          "linewidth": 0,
          "links": [
-
+          {
+           "dashboard": "Observatorium - Gubernator",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Observatorium - Gubernator",
+           "type": "dashboard"
+          }
          ],
          "nullPointMode": "null as zero",
          "percentage": false,
@@ -7030,7 +7036,13 @@ data:
          "lines": true,
          "linewidth": 0,
          "links": [
-
+          {
+           "dashboard": "Observatorium - Gubernator",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Observatorium - Gubernator",
+           "type": "dashboard"
+          }
          ],
          "nullPointMode": "null as zero",
          "percentage": false,
@@ -7116,7 +7128,13 @@ data:
          "lines": true,
          "linewidth": 1,
          "links": [
-
+          {
+           "dashboard": "Observatorium - Gubernator",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Observatorium - Gubernator",
+           "type": "dashboard"
+          }
          ],
          "nullPointMode": "null as zero",
          "percentage": false,
@@ -7210,7 +7228,13 @@ data:
          "lines": true,
          "linewidth": 1,
          "links": [
-
+          {
+           "dashboard": "Observatorium - Gubernator",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Observatorium - Gubernator",
+           "type": "dashboard"
+          }
          ],
          "nullPointMode": "null as zero",
          "percentage": false,
@@ -7296,7 +7320,13 @@ data:
          "lines": true,
          "linewidth": 1,
          "links": [
-
+          {
+           "dashboard": "Observatorium - Gubernator",
+           "includeVars": true,
+           "keepTime": true,
+           "title": "Observatorium - Gubernator",
+           "type": "dashboard"
+          }
          ],
          "nullPointMode": "null as zero",
          "percentage": false,
@@ -8283,7 +8313,7 @@ data:
         "options": [
 
         ],
-        "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-thanos-.*|observatorium-ruler-query.*\"}, job)",
+        "query": "label_values(up{namespace=\"$namespace\", job=~\"observatorium-thanos-.*|observatorium-ruler-query.*|observatorium-gubernator\"}, job)",
         "refresh": 2,
         "regex": "",
         "sort": 1,


### PR DESCRIPTION
Adds new Gubernator dashboard.
Tried to simplify the jsonnet file. 
Only the process_cpu metric is not working. I do not know why it isn't generated.

Here is the dashboard: https://grafana.stage.devshift.net/d/q24ceK3Vz/observatorium-gubernator?orgId=1&refresh=10s&var-datasource=app-sre-stage-01-prometheus&var-namespace=observatorium-mst-stage&var-interval=5m