### PR TITLE
Update obsctl-reloader to be picked up by Prometheus

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -295,6 +295,8 @@ objects:
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
+    labels:
+      prometheus: app-sre
     name: rules-obsctl-reloader
   spec:
     endpoints:

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -224,7 +224,16 @@ local obsctlReloader = (import 'github.com/rhobs/obsctl-reloader/jsonnet/lib/obs
         optional: true,
       },
     ],
-  }),
+  }) + {
+    serviceMonitor+: {
+      metadata+: {
+        labels+: {
+          prometheus: 'app-sre',
+        },
+      },
+    },
+  },
+
 
   rulesSLOPrometheusRule: {
     apiVersion: 'monitoring.coreos.com/v1',


### PR DESCRIPTION
It was missing the `prometheus: app-sre` label.