### PR TITLE
Expose S3 client performance flags for rclone

### DIFF
--- a/resources/operations/rclone-bucket-replicate/job-template.yaml
+++ b/resources/operations/rclone-bucket-replicate/job-template.yaml
@@ -74,8 +74,8 @@ objects:
                 - ${SOURCE_ENDPOINT}:${SOURCE_BUCKET}
                 - ${TARGET_ENDPOINT}:${TARGET_BUCKET}
                 - '--rc'
-                - '-v'
                 - '--rc-enable-metrics'
                 - '--rc-addr=:10902'
+                - '--s3-disable-http2' # Needed due to https://github.com/golang/go/issues/37373
           restartPolicy: Never
 

--- a/resources/operations/rclone-bucket-replicate/rclone-config-template.yaml
+++ b/resources/operations/rclone-bucket-replicate/rclone-config-template.yaml
@@ -16,11 +16,15 @@ parameters:
   - name: RCLONE_STATS_INTERVAL
     value: '30s'
   - name: RCLONE_LOG_LEVEL
-    value: '1'
+    value: '0'
   - name: RCLONE_PARALLEL_TRANSFERS
     value: '4'
   - name: RCLONE_PARALLEL_FILE_CHECKERS
     value: '8'
+  - name: RCLONE_S3_UPLOAD_CONCURRENCY
+    value: '8'
+  - name: RCLONE_S3_CHUNK_SIZE
+    value: '64M'
 
 objects:
   - apiVersion: v1
@@ -41,4 +45,8 @@ objects:
 
       # Checkers do the equality checking of files during a sync
       RCLONE_CHECKERS: ${RCLONE_PARALLEL_FILE_CHECKERS}
+
+      # AWS Client Specific Parameters
+      RCLONE_S3_UPLOAD_CONCURRENCY: ${RCLONE_S3_UPLOAD_CONCURRENCY}
+      RCLONE_S3_CHUNK_SIZE: ${RCLONE_S3_CHUNK_SIZE}
 


### PR DESCRIPTION
* Disabled http2 due to http2 streaming in net/http2 performance issues https://github.com/golang/go/issues/37373
* RCLONE_S3_UPLOAD_CONCURRENCY, RCLONE_S3_CHUNK_SIZE to improve parallelism and download efficiency