### PR TITLE
Fix serviceMonitor for telemeter's memcached

### DIFF
--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -619,10 +619,7 @@ objects:
       - ${NAMESPACE}
     selector:
       matchLabels:
-        app.kubernetes.io/component: telemeter-cache
-        app.kubernetes.io/instance: telemeter
         app.kubernetes.io/name: memcached
-        app.kubernetes.io/part-of: telemeter
 - apiVersion: apps/v1
   kind: StatefulSet
   metadata:

--- a/services/telemeter.libsonnet
+++ b/services/telemeter.libsonnet
@@ -148,10 +148,7 @@
         namespaceSelector+: { matchNames: [config.namespace] },
         selector+: {
           matchLabels+: {
-            'app.kubernetes.io/component': 'telemeter-cache',
-            'app.kubernetes.io/instance': 'telemeter',
             'app.kubernetes.io/name': 'memcached',
-            'app.kubernetes.io/part-of': 'telemeter',
           },
         },
       },


### PR DESCRIPTION
Removing invalid label selectors from serviceMonitor as the memcached service only contains the `app.kubernetes.io/name` label.