### PR TITLE
Fix telemeter's memcached serviceMonitor

### DIFF
--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -608,6 +608,7 @@ objects:
   metadata:
     labels:
       app.kubernetes.io/name: memcached
+      prometheus: app-sre
     name: memcached
   spec:
     endpoints:

--- a/services/telemeter.libsonnet
+++ b/services/telemeter.libsonnet
@@ -143,6 +143,11 @@
       imagePullSecrets+: [{ name: 'quay.io' }],
     },
     serviceMonitor+: {
+      metadata+: {
+        labels+: {
+          prometheus: 'app-sre',
+        },
+      },
       spec+: {
         jobLabel: 'app.kubernetes.io/component',
         namespaceSelector+: { matchNames: [config.namespace] },


### PR DESCRIPTION
Adds missing app-sre label to be catched by the prometheus operator.