### PR TITLE
Upgrade obsctl reloader mixin and regenerate alerts.

### DIFF
--- a/docs/sop/observatorium.md
+++ b/docs/sop/observatorium.md
@@ -922,7 +922,7 @@ The `obsctl-reloader` is most likely down, in a crashloop state.
 ### Steps
 
 - In the OSD console for specific cluster, check the pods belonging to the `obsctl-reloader` deployment and establish what is causing the crashloop.
-- Further actions will depend a lot on the root cause found and most likel be something we didn't go through before.
+- Further actions will depend a lot on the root cause found and most likely be something we didn't go through before.
 
 ## ObsCtlRulesStoreServerError
 

--- a/docs/sop/observatorium.md
+++ b/docs/sop/observatorium.md
@@ -34,6 +34,7 @@
 * [Observatorium Gubernator Alerts](#observatorium-gubernator-alerts)
   * [GubernatorIsDown](#gubernatorisdown)
 * [Observatorium Obsctl Reloader Alerts](#observatorium-obsctl-reloader-alerts)
+  * [ObsCtlIsDown](#obsctlisdown)
   * [ObsCtlRulesStoreServerError](#obsctlrulesstoreservererror)
   * [ObsCtlFetchRulesFailed](#obsctlfetchrulesfailed)
   * [ObsCtlRulesSetFailure](#obsctlrulessetfailure)
@@ -897,6 +898,31 @@ Observatorium rate-limiting service is not working.
 - Reach out to Observability Team (team-observability-platform@redhat.com), [`#forum-observatorium`](https://slack.com/app_redirect?channel=forum-observatorium) at CoreOS Slack, to get help in the investigation.
 
 # Observatorium Obsctl Reloader Alerts
+
+## ObsCtlIsDown
+
+### Impact
+
+Tenant's rules are not being pushed to Observatorium, so they might be stale.
+
+### Summary
+
+The `obsctl-reloader` is most likely down, in a crashloop state.
+
+### Severity
+
+`critical`
+
+### Access Required
+
+- Console access to the production clusters (this system is't used in staging) that runs Observatorium (currently [telemeter-prod-01 OSD](https://console-openshift-console.apps.telemeter-prod.a5j2.p1.openshiftapps.com/k8s/cluster/projects/observatorium-mst-production) and [rhobsp0ue1 OSD](https://console-openshift-console.apps.rhobsp02ue1.y9ya.p1.openshiftapps.com/)).
+- Edit access to the Observatorium namespaces:
+  - `observatorium-mst-production`
+
+### Steps
+
+- In the OSD console for specific cluster, check the pods belonging to the `obsctl-reloader` deployment and establish what is causing the crashloop.
+- Further actions will depend a lot on the root cause found and most likel be something we didn't go through before.
 
 ## ObsCtlRulesStoreServerError
 

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -395,8 +395,8 @@
           "subdir": "jsonnet/lib"
         }
       },
-      "version": "1df7a85a21606d7e1c42262a386dc6b377eb18b7",
-      "sum": "x00LDrH1x0wQWO95LiFaoUuFIPMWb1Acaem6ARPwaEk="
+      "version": "aaec99f0300f3f1aedeff02bd82a83bd420d09f2",
+      "sum": "K9M0QHkMKlSczKS9v43+i0VOCwFiH7Ysc4IuAfF6eS4="
     },
     {
       "source": {

--- a/resources/observability/prometheusrules/observatorium-obsctl-reloader-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-obsctl-reloader-production.prometheusrules.yaml
@@ -11,6 +11,19 @@ spec:
   groups:
   - name: obsctl-reloader.rules
     rules:
+    - alert: ObsCtlIsDown
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/no-dashboard/obsctl-reloader.rules?orgId=1&refresh=10s&var-datasource={{$externalLabels.cluster}}-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        description: obsctl-reloader is down.
+        message: obsctl-reloader is down.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#obsctlisdown
+        summary: obsctl-reloader is down. Tenants rules are not being reloaded.
+      expr: |
+        (up{job="rules-obsctl-reloader"} == 0)
+      for: 5m
+      labels:
+        service: telemeter
+        severity: critical
     - alert: ObsCtlRulesStoreServerError
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/no-dashboard/obsctl-reloader.rules?orgId=1&refresh=10s&var-datasource={{$externalLabels.cluster}}-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
@@ -23,7 +36,7 @@ spec:
           sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"5..|4..", job="rules-obsctl-reloader"}[5m])
         /
           sum(sum_over_time(obsctl_reloader_prom_rules_store_ops_total{job="rules-obsctl-reloader"}[5m]))
-        ) or vector(0)
+        )
         > 0.10
       for: 10m
       labels:
@@ -41,7 +54,7 @@ spec:
           sum_over_time(obsctl_reloader_prom_rule_set_failures_total{reason!="rules_store_error", job="rules-obsctl-reloader"}[5m])
         /
           sum_over_time(obsctl_reloader_prom_rule_set_total{job="rules-obsctl-reloader"}[5m])
-        ) or vector(0)
+        )
         > 0.10
       for: 10m
       labels:
@@ -59,7 +72,7 @@ spec:
           sum_over_time(obsctl_reloader_prom_rule_fetch_failures_total{job="rules-obsctl-reloader"}[5m])
         /
           sum_over_time(obsctl_reloader_prom_rule_fetches_total{job="rules-obsctl-reloader"}[5m])
-        ) or vector(0)
+        )
         > 0.20
       for: 5m
       labels:

--- a/resources/observability/prometheusrules/observatorium-obsctl-reloader-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/observatorium-obsctl-reloader-stage.prometheusrules.yaml
@@ -11,6 +11,19 @@ spec:
   groups:
   - name: obsctl-reloader.rules
     rules:
+    - alert: ObsCtlIsDown
+      annotations:
+        dashboard: https://grafana.app-sre.devshift.net/d/no-dashboard/obsctl-reloader.rules?orgId=1&refresh=10s&var-datasource={{$externalLabels.cluster}}-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
+        description: obsctl-reloader is down.
+        message: obsctl-reloader is down.
+        runbook: https://github.com/rhobs/configuration/blob/main/docs/sop/observatorium.md#obsctlisdown
+        summary: obsctl-reloader is down. Tenants rules are not being reloaded.
+      expr: |
+        (up{job="rules-obsctl-reloader"} == 0)
+      for: 5m
+      labels:
+        service: telemeter
+        severity: high
     - alert: ObsCtlRulesStoreServerError
       annotations:
         dashboard: https://grafana.app-sre.devshift.net/d/no-dashboard/obsctl-reloader.rules?orgId=1&refresh=10s&var-datasource={{$externalLabels.cluster}}-prometheus&var-namespace={{$labels.namespace}}&var-job=All&var-pod=All&var-interval=5m
@@ -23,7 +36,7 @@ spec:
           sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"5..|4..", job="rules-obsctl-reloader"}[5m])
         /
           sum(sum_over_time(obsctl_reloader_prom_rules_store_ops_total{job="rules-obsctl-reloader"}[5m]))
-        ) or vector(0)
+        )
         > 0.10
       for: 10m
       labels:
@@ -41,7 +54,7 @@ spec:
           sum_over_time(obsctl_reloader_prom_rule_set_failures_total{reason!="rules_store_error", job="rules-obsctl-reloader"}[5m])
         /
           sum_over_time(obsctl_reloader_prom_rule_set_total{job="rules-obsctl-reloader"}[5m])
-        ) or vector(0)
+        )
         > 0.10
       for: 10m
       labels:
@@ -59,7 +72,7 @@ spec:
           sum_over_time(obsctl_reloader_prom_rule_fetch_failures_total{job="rules-obsctl-reloader"}[5m])
         /
           sum_over_time(obsctl_reloader_prom_rule_fetches_total{job="rules-obsctl-reloader"}[5m])
-        ) or vector(0)
+        )
         > 0.20
       for: 5m
       labels:


### PR DESCRIPTION
This add the latest fixes to the `or vector(0)` false positives and the new absent alert.