### PR TITLE
Adding store.limits for Receive pods in base template

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2085,6 +2085,8 @@ objects:
           - --receive.grpc-compression=none
           - --receive.hashrings-algorithm=${THANOS_RECEIVE_HASHRINGS_ALGORITHM}
           - --receive.hashrings-file-refresh-interval=5s
+          - --store.limits.request-series=${THANOS_RECEIVE_REQUEST_SERIES_LIMIT}
+          - --store.limits.request-samples=${THANOS_RECEIVE_REQUEST_SAMPLES_LIMIT}
           env:
           - name: NAME
             valueFrom:
@@ -4752,6 +4754,10 @@ parameters:
   value: hashmod
 - name: THANOS_RECEIVE_LIMIT_CONFIG
   value: '{"write":{"default":{"request":{"samples_limit":0,"series_limit":0,"size_bytes_limit":0}},"global":{"max_concurrency":0}}}'
+- name: THANOS_RECEIVE_REQUEST_SERIES_LIMIT
+  value: "0"
+- name: THANOS_RECEIVE_REQUEST_SAMPLES_LIMIT
+  value: "0"
 - name: THANOS_RULE_SYNCER_IMAGE
   value: quay.io/observatorium/thanos-rule-syncer
 - name: THANOS_RULE_SYNCER_IMAGE_TAG

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -458,6 +458,8 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                         '--receive.grpc-compression=none',
                         '--receive.hashrings-algorithm=${THANOS_RECEIVE_HASHRINGS_ALGORITHM}',
                         '--receive.hashrings-file-refresh-interval=5s',
+                        '--store.limits.request-series=${THANOS_RECEIVE_REQUEST_SERIES_LIMIT}',
+                        '--store.limits.request-samples=${THANOS_RECEIVE_REQUEST_SAMPLES_LIMIT}',
                       ],
                       env+: s3EnvVars + [{
                         name: 'DEBUG',

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -119,6 +119,8 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_RECEIVE_HASHRING_SERVICE_NAME', value: 'observatorium-thanos-receive-default' },
     { name: 'THANOS_RECEIVE_HASHRINGS_ALGORITHM', value: 'hashmod' },
     { name: 'THANOS_RECEIVE_LIMIT_CONFIG', value: std.manifestJsonMinified(defaultReceiveLimits) },
+    { name: 'THANOS_RECEIVE_REQUEST_SERIES_LIMIT', value: '0' },
+    { name: 'THANOS_RECEIVE_REQUEST_SAMPLES_LIMIT', value: '0' },
     { name: 'THANOS_RULE_SYNCER_IMAGE', value: 'quay.io/observatorium/thanos-rule-syncer' },
     { name: 'THANOS_RULE_SYNCER_IMAGE_TAG', value: 'main-2022-09-14-338f9ec' },
     { name: 'THANOS_RULER_CPU_LIMIT', value: '1' },


### PR DESCRIPTION
Exposing two additional flags on receive pods for: 

```
      --store.limits.request-samples=0
                                 The maximum samples allowed for a single
                                 Series request, The Series call fails if
                                 this limit is exceeded. 0 means no limit.
                                 NOTE: For efficiency the limit is internally
                                 implemented as 'chunks limit' considering each
                                 chunk contains a maximum of 120 samples.
      --store.limits.request-series=0
                                 The maximum series allowed for a single Series
                                 request. The Series call fails if this limit is
                                 exceeded. 0 means no limit.
```