### PR TITLE
Add rhelemeter namespace to the Telemeter dashboard

### DIFF
--- a/crds/loki.grafana.com_alertingrules.libsonnet
+++ b/crds/loki.grafana.com_alertingrules.libsonnet
@@ -3,7 +3,7 @@
   kind: 'CustomResourceDefinition',
   metadata: {
     annotations: {
-      'controller-gen.kubebuilder.io/version': 'v0.11.3',
+      'controller-gen.kubebuilder.io/version': 'v0.13.0',
     },
     creationTimestamp: null,
     labels: {

--- a/crds/loki.grafana.com_recordingrules.libsonnet
+++ b/crds/loki.grafana.com_recordingrules.libsonnet
@@ -3,7 +3,7 @@
   kind: 'CustomResourceDefinition',
   metadata: {
     annotations: {
-      'controller-gen.kubebuilder.io/version': 'v0.11.3',
+      'controller-gen.kubebuilder.io/version': 'v0.13.0',
     },
     creationTimestamp: null,
     labels: {

--- a/docs/observatorium.md
+++ b/docs/observatorium.md
@@ -2,6 +2,10 @@
 
 Observatorium is a collection of services unified behind a single API to provide a scalable, multi-tenant observability platform for ingesting and querying logs and metrics and other observability signals. Its [documentation can be found on github](https://github.com/observatorium/docs)
 
+## Rate limits
+
+Observatorium implements rate limits through [Gubernator](https://github.com/mailgun/gubernator). The rate limits are configured per tenant in [app-interface](https://gitlab.cee.redhat.com/service/app-interface/blob/a711b7dbb690d8f7575d4614a89fb22a1ad68285/data/services/rhobs/observatorium-mst/cicd/saas-tenants.yaml#L40).
+
 # Observatorium Metrics
 
 Observatorium Metrics, which is a general-purpose, scalable, multi-tenant, observability platform for ingesting and querying metrics. Its [documentation can be found on github](https://github.com/observatorium/observatorium/blob/main/docs/design/metrics.md)

--- a/observability/dashboards/telemeter.libsonnet
+++ b/observability/dashboards/telemeter.libsonnet
@@ -2522,7 +2522,7 @@ function(datasource, namespace) {
               options: [],
               query: 'label_values(kube_pod_info, namespace)',
               refresh: 1,
-              regex: '^telemeter.*',
+              regex: '^telemeter.*|^rhelemeter.*',
               skipUrlSync: false,
               sort: 1,
               tagValuesQuery: '',

--- a/resources/crds/observatorium-logs-crds-template.yaml
+++ b/resources/crds/observatorium-logs-crds-template.yaml
@@ -7,7 +7,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: v0.11.3
+      controller-gen.kubebuilder.io/version: v0.13.0
     creationTimestamp: null
     labels:
       app.kubernetes.io/instance: loki-operator-v0.4.0
@@ -287,7 +287,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: v0.11.3
+      controller-gen.kubebuilder.io/version: v0.13.0
     creationTimestamp: null
     labels:
       app.kubernetes.io/instance: loki-operator-v0.4.0

--- a/resources/observability/grafana/observatorium/grafana-dashboard-telemeter.configmap.yaml
+++ b/resources/observability/grafana/observatorium/grafana-dashboard-telemeter.configmap.yaml
@@ -2815,7 +2815,7 @@ data:
             ],
             "query": "label_values(kube_pod_info, namespace)",
             "refresh": 1,
-            "regex": "^telemeter.*",
+            "regex": "^telemeter.*|^rhelemeter.*",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",


### PR DESCRIPTION
Most of the Telemeter dashboard can be reused for Rhelemeter, as both support the remote write handler. Any further improvements to this reusability can/may be done down the line. 

Upgrades to the Observatorium docs, logging CRDs and rules were necessary to pass the build.