### PR TITLE
Remove `exhaustion` label from SLO rules

### DIFF
--- a/configuration/observatorium/slo.go
+++ b/configuration/observatorium/slo.go
@@ -744,6 +744,7 @@ func makePrometheusRule(envName rhobsInstanceEnv, objs []pyrrav1alpha1.ServiceLe
 				delete(grp[i].Rules[j].Labels, "le")
 				delete(grp[i].Rules[j].Labels, "client")
 				delete(grp[i].Rules[j].Labels, "container")
+				delete(grp[i].Rules[j].Labels, "exhaustion")
 
 				// Hack for AM alert labels.
 				if v, ok := grp[i].Rules[j].Labels["service"]; ok && v == "observatorium-alertmanager" {

--- a/resources/observability/prometheusrules/rhobs-slos-logs-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-logs-mst-production.prometheusrules.yaml
@@ -105,7 +105,6 @@ spec:
         > (14 * (1-0.95))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -124,7 +123,6 @@ spec:
         > (7 * (1-0.95))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -143,7 +141,6 @@ spec:
         > (2 * (1-0.95))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -162,7 +159,6 @@ spec:
         > (1 * (1-0.95))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -281,7 +277,6 @@ spec:
         > (14 * (1-0.95))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: logsv1
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
@@ -299,7 +294,6 @@ spec:
         > (7 * (1-0.95))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: logsv1
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
@@ -317,7 +311,6 @@ spec:
         > (2 * (1-0.95))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: logsv1
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
@@ -335,7 +328,6 @@ spec:
         > (1 * (1-0.95))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: logsv1
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
@@ -462,7 +454,6 @@ spec:
         > (14 * (1-0.95))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -481,7 +472,6 @@ spec:
         > (7 * (1-0.95))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -500,7 +490,6 @@ spec:
         > (2 * (1-0.95))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -519,7 +508,6 @@ spec:
         > (1 * (1-0.95))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -647,7 +635,6 @@ spec:
         > (14 * (1-0.95))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
@@ -666,7 +653,6 @@ spec:
         > (7 * (1-0.95))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
@@ -685,7 +671,6 @@ spec:
         > (2 * (1-0.95))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
@@ -704,7 +689,6 @@ spec:
         > (1 * (1-0.95))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
@@ -832,7 +816,6 @@ spec:
         > (14 * (1-0.95))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
@@ -851,7 +834,6 @@ spec:
         > (7 * (1-0.95))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
@@ -870,7 +852,6 @@ spec:
         > (2 * (1-0.95))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
@@ -889,7 +870,6 @@ spec:
         > (1 * (1-0.95))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
@@ -1047,7 +1027,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -1066,7 +1045,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -1085,7 +1063,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -1104,7 +1081,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api

--- a/resources/observability/prometheusrules/rhobs-slos-logs-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-logs-mst-stage.prometheusrules.yaml
@@ -105,7 +105,6 @@ spec:
         > (14 * (1-0.95))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -124,7 +123,6 @@ spec:
         > (7 * (1-0.95))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -143,7 +141,6 @@ spec:
         > (2 * (1-0.95))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -162,7 +159,6 @@ spec:
         > (1 * (1-0.95))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -281,7 +277,6 @@ spec:
         > (14 * (1-0.95))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: logsv1
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1h
@@ -299,7 +294,6 @@ spec:
         > (7 * (1-0.95))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: logsv1
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 6h
@@ -317,7 +311,6 @@ spec:
         > (2 * (1-0.95))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: logsv1
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 1d
@@ -335,7 +328,6 @@ spec:
         > (1 * (1-0.95))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: logsv1
         job: observatorium-observatorium-mst-api
         long_burnrate_window: 4d
@@ -462,7 +454,6 @@ spec:
         > (14 * (1-0.95))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -481,7 +472,6 @@ spec:
         > (7 * (1-0.95))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -500,7 +490,6 @@ spec:
         > (2 * (1-0.95))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -519,7 +508,6 @@ spec:
         > (1 * (1-0.95))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: logsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -647,7 +635,6 @@ spec:
         > (14 * (1-0.95))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
@@ -666,7 +653,6 @@ spec:
         > (7 * (1-0.95))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
@@ -685,7 +671,6 @@ spec:
         > (2 * (1-0.95))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
@@ -704,7 +689,6 @@ spec:
         > (1 * (1-0.95))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: logsv1
         handler: tail
         job: observatorium-observatorium-mst-api
@@ -832,7 +816,6 @@ spec:
         > (14 * (1-0.95))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
@@ -851,7 +834,6 @@ spec:
         > (7 * (1-0.95))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
@@ -870,7 +852,6 @@ spec:
         > (2 * (1-0.95))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
@@ -889,7 +870,6 @@ spec:
         > (1 * (1-0.95))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: logsv1
         handler: prom_tail
         job: observatorium-observatorium-mst-api
@@ -1047,7 +1027,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -1066,7 +1045,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -1085,7 +1063,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api
@@ -1104,7 +1081,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         group: logsv1
         handler: push
         job: observatorium-observatorium-mst-api

--- a/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-production.prometheusrules.yaml
@@ -114,7 +114,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -134,7 +133,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -154,7 +152,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -174,7 +171,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -308,7 +304,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 1h
@@ -327,7 +322,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 6h
@@ -346,7 +340,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 1d
@@ -365,7 +358,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 4d
@@ -507,7 +499,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -527,7 +518,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -547,7 +537,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -567,7 +556,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -710,7 +698,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -730,7 +717,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -750,7 +736,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -770,7 +755,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -922,7 +906,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -943,7 +926,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -964,7 +946,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -985,7 +966,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -1138,7 +1118,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1159,7 +1138,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1180,7 +1158,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1201,7 +1178,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1343,7 +1319,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1361,7 +1336,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1379,7 +1353,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1397,7 +1370,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1528,7 +1500,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1546,7 +1517,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1564,7 +1534,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1582,7 +1551,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1705,7 +1673,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1723,7 +1690,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1741,7 +1707,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1759,7 +1724,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1927,7 +1891,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -1947,7 +1910,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -1967,7 +1929,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -1987,7 +1948,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -2151,7 +2111,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2170,7 +2129,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2189,7 +2147,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2208,7 +2165,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2371,7 +2327,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
@@ -2390,7 +2345,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
@@ -2409,7 +2363,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
@@ -2428,7 +2381,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
@@ -2591,7 +2543,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2610,7 +2561,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2629,7 +2579,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2648,7 +2597,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2811,7 +2759,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -2830,7 +2777,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -2849,7 +2795,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -2868,7 +2813,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -3031,7 +2975,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
@@ -3050,7 +2993,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
@@ -3069,7 +3011,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
@@ -3088,7 +3029,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
@@ -3251,7 +3191,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -3270,7 +3209,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -3289,7 +3227,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -3308,7 +3245,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples

--- a/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml
@@ -114,7 +114,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -134,7 +133,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -154,7 +152,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -174,7 +171,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -308,7 +304,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 1h
@@ -327,7 +322,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 6h
@@ -346,7 +340,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 1d
@@ -365,7 +358,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 4d
@@ -507,7 +499,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -527,7 +518,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -547,7 +537,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -567,7 +556,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -710,7 +698,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -730,7 +717,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -750,7 +736,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -770,7 +755,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -922,7 +906,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -943,7 +926,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -964,7 +946,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -985,7 +966,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -1138,7 +1118,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1159,7 +1138,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1180,7 +1158,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1201,7 +1178,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1343,7 +1319,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1361,7 +1336,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1379,7 +1353,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1397,7 +1370,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1528,7 +1500,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1546,7 +1517,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1564,7 +1534,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1582,7 +1551,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1705,7 +1673,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1723,7 +1690,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1741,7 +1707,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1759,7 +1724,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         service: observatorium-api
@@ -1927,7 +1891,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -1947,7 +1910,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -1967,7 +1929,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -1987,7 +1948,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -2151,7 +2111,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
@@ -2170,7 +2129,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
@@ -2189,7 +2147,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
@@ -2208,7 +2165,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
@@ -2371,7 +2327,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-10M-samples
@@ -2390,7 +2345,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-10M-samples
@@ -2409,7 +2363,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-10M-samples
@@ -2428,7 +2381,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-10M-samples
@@ -2591,7 +2543,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
@@ -2610,7 +2561,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
@@ -2629,7 +2579,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
@@ -2648,7 +2597,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: rule-query-path-sli-1M-samples
@@ -2811,7 +2759,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
@@ -2830,7 +2777,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
@@ -2849,7 +2795,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
@@ -2868,7 +2813,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
@@ -3031,7 +2975,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
@@ -3050,7 +2993,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
@@ -3069,7 +3011,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
@@ -3088,7 +3029,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-10M-samples
@@ -3251,7 +3191,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
@@ -3270,7 +3209,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
@@ -3289,7 +3227,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples
@@ -3308,7 +3245,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-stage
         query: query-path-sli-1M-samples

--- a/resources/observability/prometheusrules/rhobs-slos-rhelemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhelemeter-production.prometheusrules.yaml
@@ -96,7 +96,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         route: rhelemeter-server-metrics-v1-receive
         service: rhelemeter
@@ -114,7 +113,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         route: rhelemeter-server-metrics-v1-receive
         service: rhelemeter
@@ -132,7 +130,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         route: rhelemeter-server-metrics-v1-receive
         service: rhelemeter
@@ -150,7 +147,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         route: rhelemeter-server-metrics-v1-receive
         service: rhelemeter
@@ -312,7 +308,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         handler: receive
         job: rhelemeter-server
         long_burnrate_window: 1h
@@ -331,7 +326,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         handler: receive
         job: rhelemeter-server
         long_burnrate_window: 6h
@@ -350,7 +344,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         handler: receive
         job: rhelemeter-server
         long_burnrate_window: 1d
@@ -369,7 +362,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         handler: receive
         job: rhelemeter-server
         long_burnrate_window: 4d

--- a/resources/observability/prometheusrules/rhobs-slos-rhelemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhelemeter-stage.prometheusrules.yaml
@@ -96,7 +96,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         route: rhelemeter-server-metrics-v1-receive
         service: rhelemeter
@@ -114,7 +113,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         route: rhelemeter-server-metrics-v1-receive
         service: rhelemeter
@@ -132,7 +130,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         route: rhelemeter-server-metrics-v1-receive
         service: rhelemeter
@@ -150,7 +147,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         route: rhelemeter-server-metrics-v1-receive
         service: rhelemeter
@@ -312,7 +308,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         handler: receive
         job: rhelemeter-server
         long_burnrate_window: 1h
@@ -331,7 +326,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         handler: receive
         job: rhelemeter-server
         long_burnrate_window: 6h
@@ -350,7 +344,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         handler: receive
         job: rhelemeter-server
         long_burnrate_window: 1d
@@ -369,7 +362,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         handler: receive
         job: rhelemeter-server
         long_burnrate_window: 4d

--- a/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-rhobsp02ue1-prod.prometheusrules.yaml
@@ -114,7 +114,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -134,7 +133,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -154,7 +152,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -174,7 +171,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -308,7 +304,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 1h
@@ -327,7 +322,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 6h
@@ -346,7 +340,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 1d
@@ -365,7 +358,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 4d
@@ -507,7 +499,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -527,7 +518,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -547,7 +537,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -567,7 +556,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: query
         job: observatorium-observatorium-mst-api
@@ -710,7 +698,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -730,7 +717,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -750,7 +736,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -770,7 +755,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-mst-api
@@ -922,7 +906,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -943,7 +926,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -964,7 +946,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -985,7 +966,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-mst-api
@@ -1138,7 +1118,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1159,7 +1138,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1180,7 +1158,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1201,7 +1178,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-mst-api
@@ -1343,7 +1319,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1361,7 +1336,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1379,7 +1353,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1397,7 +1370,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1528,7 +1500,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1546,7 +1517,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1564,7 +1534,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1582,7 +1551,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1705,7 +1673,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1723,7 +1690,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1741,7 +1707,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1759,7 +1724,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         service: observatorium-api
@@ -1927,7 +1891,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -1947,7 +1910,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -1967,7 +1929,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -1987,7 +1948,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-mst-api
@@ -2151,7 +2111,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2170,7 +2129,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2189,7 +2147,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2208,7 +2165,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2371,7 +2327,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
@@ -2390,7 +2345,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
@@ -2409,7 +2363,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
@@ -2428,7 +2381,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-10M-samples
@@ -2591,7 +2543,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2610,7 +2561,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2629,7 +2579,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2648,7 +2597,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: rule-query-path-sli-1M-samples
@@ -2811,7 +2759,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -2830,7 +2777,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -2849,7 +2795,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -2868,7 +2813,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -3031,7 +2975,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
@@ -3050,7 +2993,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
@@ -3069,7 +3011,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
@@ -3088,7 +3029,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-10M-samples
@@ -3251,7 +3191,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -3270,7 +3209,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -3289,7 +3227,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples
@@ -3308,7 +3245,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-mst-production
         query: query-path-sli-1M-samples

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-production.prometheusrules.yaml
@@ -96,7 +96,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         route: telemeter-server-upload
         service: telemeter
@@ -114,7 +113,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         route: telemeter-server-upload
         service: telemeter
@@ -132,7 +130,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         route: telemeter-server-upload
         service: telemeter
@@ -150,7 +147,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         route: telemeter-server-upload
         service: telemeter
@@ -312,7 +308,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         handler: upload
         job: telemeter-server
         long_burnrate_window: 1h
@@ -331,7 +326,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         handler: upload
         job: telemeter-server
         long_burnrate_window: 6h
@@ -350,7 +344,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         handler: upload
         job: telemeter-server
         long_burnrate_window: 1d
@@ -369,7 +362,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         handler: upload
         job: telemeter-server
         long_burnrate_window: 4d
@@ -493,7 +485,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         route: telemeter-server-metrics-v1-receive
         service: telemeter
@@ -511,7 +502,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         route: telemeter-server-metrics-v1-receive
         service: telemeter
@@ -529,7 +519,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         route: telemeter-server-metrics-v1-receive
         service: telemeter
@@ -547,7 +536,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         route: telemeter-server-metrics-v1-receive
         service: telemeter
@@ -709,7 +697,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         handler: receive
         job: telemeter-server
         long_burnrate_window: 1h
@@ -728,7 +715,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         handler: receive
         job: telemeter-server
         long_burnrate_window: 6h
@@ -747,7 +733,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         handler: receive
         job: telemeter-server
         long_burnrate_window: 1d
@@ -766,7 +751,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         handler: receive
         job: telemeter-server
         long_burnrate_window: 4d
@@ -908,7 +892,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -928,7 +911,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -948,7 +930,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -968,7 +949,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -1102,7 +1082,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 1h
@@ -1121,7 +1100,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 6h
@@ -1140,7 +1118,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 1d
@@ -1159,7 +1136,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 4d
@@ -1301,7 +1277,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
@@ -1321,7 +1296,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
@@ -1341,7 +1315,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
@@ -1361,7 +1334,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
@@ -1504,7 +1476,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
@@ -1524,7 +1495,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
@@ -1544,7 +1514,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
@@ -1564,7 +1533,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
@@ -1716,7 +1684,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1737,7 +1704,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1758,7 +1724,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1779,7 +1744,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1932,7 +1896,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
@@ -1953,7 +1916,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
@@ -1974,7 +1936,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
@@ -1995,7 +1956,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
@@ -2137,7 +2097,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2155,7 +2114,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2173,7 +2131,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2191,7 +2148,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2322,7 +2278,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2340,7 +2295,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2358,7 +2312,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2376,7 +2329,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2499,7 +2451,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2517,7 +2468,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2535,7 +2485,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2553,7 +2502,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-metrics-production
         service: observatorium-api
@@ -2721,7 +2669,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -2741,7 +2688,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -2761,7 +2707,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -2781,7 +2726,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -2945,7 +2889,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
@@ -2964,7 +2907,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
@@ -2983,7 +2925,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
@@ -3002,7 +2943,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
@@ -3165,7 +3105,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: rule-query-path-sli-10M-samples
@@ -3184,7 +3123,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: rule-query-path-sli-10M-samples
@@ -3203,7 +3141,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: rule-query-path-sli-10M-samples
@@ -3222,7 +3159,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: rule-query-path-sli-10M-samples
@@ -3385,7 +3321,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
@@ -3404,7 +3339,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
@@ -3423,7 +3357,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
@@ -3442,7 +3375,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: rule-query-path-sli-1M-samples
@@ -3605,7 +3537,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
@@ -3624,7 +3555,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
@@ -3643,7 +3573,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
@@ -3662,7 +3591,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
@@ -3825,7 +3753,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-10M-samples
@@ -3844,7 +3771,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-10M-samples
@@ -3863,7 +3789,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-10M-samples
@@ -3882,7 +3807,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-10M-samples
@@ -4045,7 +3969,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
@@ -4064,7 +3987,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-production
         query: query-path-sli-1M-samples
@@ -4083,7 +4005,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-production
         query: query-path-sli-1M-samples
@@ -4102,7 +4023,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-production
         query: query-path-sli-1M-samples

--- a/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
+++ b/resources/observability/prometheusrules/rhobs-slos-telemeter-stage.prometheusrules.yaml
@@ -96,7 +96,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         route: telemeter-server-upload
         service: telemeter
@@ -114,7 +113,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         route: telemeter-server-upload
         service: telemeter
@@ -132,7 +130,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         route: telemeter-server-upload
         service: telemeter
@@ -150,7 +147,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         route: telemeter-server-upload
         service: telemeter
@@ -312,7 +308,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         handler: upload
         job: telemeter-server
         long_burnrate_window: 1h
@@ -331,7 +326,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         handler: upload
         job: telemeter-server
         long_burnrate_window: 6h
@@ -350,7 +344,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         handler: upload
         job: telemeter-server
         long_burnrate_window: 1d
@@ -369,7 +362,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         handler: upload
         job: telemeter-server
         long_burnrate_window: 4d
@@ -493,7 +485,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         route: telemeter-server-metrics-v1-receive
         service: telemeter
@@ -511,7 +502,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         route: telemeter-server-metrics-v1-receive
         service: telemeter
@@ -529,7 +519,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         route: telemeter-server-metrics-v1-receive
         service: telemeter
@@ -547,7 +536,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         route: telemeter-server-metrics-v1-receive
         service: telemeter
@@ -709,7 +697,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         handler: receive
         job: telemeter-server
         long_burnrate_window: 1h
@@ -728,7 +715,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         handler: receive
         job: telemeter-server
         long_burnrate_window: 6h
@@ -747,7 +733,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         handler: receive
         job: telemeter-server
         long_burnrate_window: 1d
@@ -766,7 +751,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         handler: receive
         job: telemeter-server
         long_burnrate_window: 4d
@@ -908,7 +892,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -928,7 +911,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -948,7 +930,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -968,7 +949,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -1102,7 +1082,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 1h
@@ -1121,7 +1100,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 6h
@@ -1140,7 +1118,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 1d
@@ -1159,7 +1136,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         handler: query
         job: observatorium-ruler-query
         long_burnrate_window: 4d
@@ -1301,7 +1277,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
@@ -1321,7 +1296,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
@@ -1341,7 +1315,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
@@ -1361,7 +1334,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: query
         job: observatorium-observatorium-api
@@ -1504,7 +1476,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
@@ -1524,7 +1495,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
@@ -1544,7 +1514,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
@@ -1564,7 +1533,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: query_range
         job: observatorium-observatorium-api
@@ -1716,7 +1684,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1737,7 +1704,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1758,7 +1724,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1779,7 +1744,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: rules-raw
         job: observatorium-observatorium-api
@@ -1932,7 +1896,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
@@ -1953,7 +1916,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
@@ -1974,7 +1936,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
@@ -1995,7 +1956,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: rules
         job: observatorium-observatorium-api
@@ -2137,7 +2097,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2155,7 +2114,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2173,7 +2131,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2191,7 +2148,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2322,7 +2278,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2340,7 +2295,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2358,7 +2312,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2376,7 +2329,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2499,7 +2451,6 @@ spec:
         > (14 * (1-0.99))
       for: 2m0s
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2517,7 +2468,6 @@ spec:
         > (7 * (1-0.99))
       for: 15m0s
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2535,7 +2485,6 @@ spec:
         > (2 * (1-0.99))
       for: 1h0m0s
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2553,7 +2502,6 @@ spec:
         > (1 * (1-0.99))
       for: 3h0m0s
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-metrics-stage
         service: observatorium-api
@@ -2721,7 +2669,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -2741,7 +2688,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -2761,7 +2707,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -2781,7 +2726,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         group: metricsv1
         handler: receive
         job: observatorium-observatorium-api
@@ -2945,7 +2889,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
@@ -2964,7 +2907,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
@@ -2983,7 +2925,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
@@ -3002,7 +2943,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
@@ -3165,7 +3105,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: rule-query-path-sli-10M-samples
@@ -3184,7 +3123,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: rule-query-path-sli-10M-samples
@@ -3203,7 +3141,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: rule-query-path-sli-10M-samples
@@ -3222,7 +3159,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: rule-query-path-sli-10M-samples
@@ -3385,7 +3321,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
@@ -3404,7 +3339,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
@@ -3423,7 +3357,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
@@ -3442,7 +3375,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: rule-query-path-sli-1M-samples
@@ -3605,7 +3537,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
@@ -3624,7 +3555,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
@@ -3643,7 +3573,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
@@ -3662,7 +3591,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
@@ -3825,7 +3753,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
@@ -3844,7 +3771,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
@@ -3863,7 +3789,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
@@ -3882,7 +3807,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-10M-samples
@@ -4045,7 +3969,6 @@ spec:
         > (14 * (1-0.9))
       for: 2m
       labels:
-        exhaustion: 2d
         long_burnrate_window: 1h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
@@ -4064,7 +3987,6 @@ spec:
         > (7 * (1-0.9))
       for: 15m
       labels:
-        exhaustion: 4d
         long_burnrate_window: 6h
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
@@ -4083,7 +4005,6 @@ spec:
         > (2 * (1-0.9))
       for: 1h
       labels:
-        exhaustion: 2w
         long_burnrate_window: 1d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples
@@ -4102,7 +4023,6 @@ spec:
         > (1 * (1-0.9))
       for: 3h
       labels:
-        exhaustion: 4w
         long_burnrate_window: 4d
         namespace: observatorium-stage
         query: query-path-sli-1M-samples


### PR DESCRIPTION
This is added by new versions of Pyrra and it's not in the schema accepted by app-sre, which makes the build fail over there.