### PR TITLE
Add a starter for Rhelemeter docs 

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,3 +6,4 @@
 - [Observatorium Logs](./observatorium.md#observatorium-logs)
 - [Observatorium Metrics](./observatorium.md#observatorium-metrics)
 - [Telemeter](./telemeter.md)
+- [Rhelemeter](./rhelemeter.md)

--- a/docs/rhelemeter.md
+++ b/docs/rhelemeter.md
@@ -1,0 +1,6 @@
+# rhelemeter
+
+Rhelemeter is a specialized instance of [Telemeter](telemeter.md). While Telemeter receives metrics from OCP clusters, Rhelemeter 
+receives metrics from RHEL hosts.
+
+The source code and more details can be found at [its upstream repository](https://github.com/openshift/telemeter/tree/master/cmd/rhelemeter-server).

--- a/docs/telemeter.md
+++ b/docs/telemeter.md
@@ -1,12 +1,17 @@
 # telemeter
 
-Telemeter implements a Prometheus federation push client and server to allow isolated Prometheus instances that cannot be scraped from a central Prometheus to instead perform push federation to a central location.
+Telemeter implements a Prometheus federation push client and server to allow isolated Prometheus instances that cannot
+be scraped from a central Prometheus to instead perform push federation to a central location.
 
 In the context of OCP 4, telemeter is used to push cluster metrics to the 'infogw' prometheus.
 
 More info here: https://github.com/openshift/telemeter/
 
-Telemeter v2 motivaations and high-level design doc can be found [here](https://docs.google.com/document/d/1A9BUogtU3aNTV8hiTKbmn_kR-C2jSwo-07OyT3nm9bU). It is itself built on Observatorium, which is a general-purpose, scalable, multi-tenant, observability platform for ingesting and querying metrics and other observability signals. Its [documentation can be found on github](https://github.com/observatorium/docs)
+Telemeter v2 motivations and high-level design doc can be
+found [here](https://docs.google.com/document/d/1A9BUogtU3aNTV8hiTKbmn_kR-C2jSwo-07OyT3nm9bU). It is itself built on
+Observatorium, which is a general-purpose, scalable, multi-tenant, observability platform for ingesting and querying
+metrics and other observability signals.
+Its [documentation can be found on github](https://github.com/observatorium/docs)
 
 ![schema](telemeter.png)
 
@@ -14,30 +19,29 @@ Telemeter v2 motivaations and high-level design doc can be found [here](https://
 
 ## Endpoints
 
-| Endpoint | Description | URL |
-|---|---|---|
-| infogw | telemeter-server | https://infogw.api.openshift.com/ |
-| infogw-data | prometheus | https://infogw-data.api.openshift.com/ |
-| infogw-proxy | cortex proxy | https://infogw-proxy.api.openshift.com/ |
+| Endpoint     | Description      | URL                                     |
+|--------------|------------------|-----------------------------------------|
+| infogw       | telemeter-server | https://infogw.api.openshift.com/       |
+| infogw-data  | prometheus       | https://infogw-data.api.openshift.com/  |
+| infogw-proxy | cortex proxy     | https://infogw-proxy.api.openshift.com/ |
 
 ## Code
 
 ### telemeter
-| Resource | Location |
-|---|---|
-| Upstream | https://github.com/openshift/telemeter |
-| CI/CD | https://ci-int-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/telemeter/ |
-| saas repo | https://gitlab.cee.redhat.com/service/saas-telemeter |
+
+| Resource  | Location                                                               |
+|-----------|------------------------------------------------------------------------|
+| Upstream  | https://github.com/openshift/telemeter                                 |
 
 ### telemeter-proxy
-| Resource | Location |
-|---|---|
-| Config | https://github.com/observatorium/configuration |
-| CI/CD | https://ci-int-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/telemeter/ |
-| saas repo | https://gitlab.cee.redhat.com/service/saas-telemeter |
+
+| Resource  | Location                                                               |
+|-----------|------------------------------------------------------------------------|
+| Config    | https://github.com/observatorium/configuration                         |
 
 ## Dependencies
-| Dependency | Description |
-|---|---|
-| UHC | Authorization of client uploads |
-| UHC | UHC prometheus for subscription_labels federation |
+
+| Dependency | Description                                       |
+|------------|---------------------------------------------------|
+| UHC        | Authorization of client uploads                   |
+| UHC        | UHC prometheus for subscription_labels federation |


### PR DESCRIPTION
Mostly pointing to the documentation in the source repository (openshift/telemeter).

Took the opportunity to reformat Telemeter's documentation and prune some dead-links. 