### PR TITLE
rhobs: remove receive controller service and probes

### DIFF
--- a/mimic.go
+++ b/mimic.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/bwplotka/mimic"
 	cfgobservatorium "github.com/rhobs/configuration/configuration/observatorium"
-	services "github.com/rhobs/configuration/services_go"
 )
 
 func main() {
@@ -16,6 +15,6 @@ func main() {
 	cfgobservatorium.GenerateRBAC(gen.With(".tmp", "tenants"))
 
 	// Generate the manifests for all observatorium instances.
-	services.Generate(gen.With("services"))
+	// services.Generate(gen.With("services"))
 
 }

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-receive-router-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-receive-router-template.yaml
@@ -67,13 +67,11 @@ objects:
                 fieldPath: metadata.namespace
           image: quay.io/observatorium/thanos-receive-controller:main-2023-09-22-f168dd7
           imagePullPolicy: IfNotPresent
-          livenessProbe: {}
           name: observatorium-thanos-receive-controller
           ports:
           - containerPort: 8080
             name: http
             protocol: TCP
-          readinessProbe: {}
           resources:
             limits:
               cpu: 24Mi
@@ -139,31 +137,13 @@ objects:
     name: observatorium-thanos-receive-controller
     namespace: rhobs
   roleRef:
-    apiGroup: rbac.authorization.k8s.io/v1
+    apiGroup: rbac.authorization.k8s.io
     kind: Role
     name: observatorium-thanos-receive-controller
   subjects:
   - kind: ServiceAccount
     name: observatorium-thanos-receive-controller
     namespace: rhobs
-- apiVersion: v1
-  kind: Service
-  metadata:
-    creationTimestamp: null
-    labels:
-      app.kubernetes.io/component: kubernetes-controller
-      app.kubernetes.io/instance: observatorium
-      app.kubernetes.io/name: thanos-receive-controller
-      app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: main-2023-09-22-f168dd7
-    name: observatorium-thanos-receive-controller
-    namespace: rhobs
-  spec:
-    selector:
-      app.kubernetes.io/component: kubernetes-controller
-      app.kubernetes.io/instance: observatorium
-      app.kubernetes.io/name: thanos-receive-controller
-      app.kubernetes.io/part-of: observatorium
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-receive-router-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-receive-router-template.yaml
@@ -67,13 +67,11 @@ objects:
                 fieldPath: metadata.namespace
           image: quay.io/observatorium/thanos-receive-controller:main-2023-09-22-f168dd7
           imagePullPolicy: IfNotPresent
-          livenessProbe: {}
           name: observatorium-thanos-receive-controller
           ports:
           - containerPort: 8080
             name: http
             protocol: TCP
-          readinessProbe: {}
           resources:
             limits:
               cpu: 24Mi
@@ -139,31 +137,13 @@ objects:
     name: observatorium-thanos-receive-controller
     namespace: rhobs
   roleRef:
-    apiGroup: rbac.authorization.k8s.io/v1
+    apiGroup: rbac.authorization.k8s.io
     kind: Role
     name: observatorium-thanos-receive-controller
   subjects:
   - kind: ServiceAccount
     name: observatorium-thanos-receive-controller
     namespace: rhobs
-- apiVersion: v1
-  kind: Service
-  metadata:
-    creationTimestamp: null
-    labels:
-      app.kubernetes.io/component: kubernetes-controller
-      app.kubernetes.io/instance: observatorium
-      app.kubernetes.io/name: thanos-receive-controller
-      app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: main-2023-09-22-f168dd7
-    name: observatorium-thanos-receive-controller
-    namespace: rhobs
-  spec:
-    selector:
-      app.kubernetes.io/component: kubernetes-controller
-      app.kubernetes.io/instance: observatorium
-      app.kubernetes.io/name: thanos-receive-controller
-      app.kubernetes.io/part-of: observatorium
 - apiVersion: v1
   kind: ServiceAccount
   metadata:


### PR DESCRIPTION
Fixing rhobs deploy errors on app-interface ci.
Temporarily unplugging automatic rhobs manifests generation while these fixes are implemented in observatorium.