### PR TITLE
[rhobs]: remove unsupported memcached security group

### DIFF
--- a/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-store-default-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-store-default-template.yaml
@@ -95,9 +95,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-bucket-cache-memcached-default
         terminationGracePeriodSeconds: 120
 - apiVersion: v1
@@ -289,9 +286,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-index-cache-memcached-default
         terminationGracePeriodSeconds: 120
 - apiVersion: v1

--- a/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
@@ -95,9 +95,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-bucket-cache-memcached-rhel
         terminationGracePeriodSeconds: 120
 - apiVersion: v1
@@ -289,9 +286,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-index-cache-memcached-rhel
         terminationGracePeriodSeconds: 120
 - apiVersion: v1

--- a/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
@@ -95,9 +95,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-bucket-cache-memcached-telemeter
         terminationGracePeriodSeconds: 120
 - apiVersion: v1
@@ -289,9 +286,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-index-cache-memcached-telemeter
         terminationGracePeriodSeconds: 120
 - apiVersion: v1

--- a/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-store-default-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-store-default-template.yaml
@@ -95,9 +95,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-bucket-cache-memcached-default
         terminationGracePeriodSeconds: 120
 - apiVersion: v1
@@ -289,9 +286,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-index-cache-memcached-default
         terminationGracePeriodSeconds: 120
 - apiVersion: v1

--- a/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
@@ -95,9 +95,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-bucket-cache-memcached-rhel
         terminationGracePeriodSeconds: 120
 - apiVersion: v1
@@ -289,9 +286,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-index-cache-memcached-rhel
         terminationGracePeriodSeconds: 120
 - apiVersion: v1

--- a/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
@@ -95,9 +95,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-bucket-cache-memcached-telemeter
         terminationGracePeriodSeconds: 120
 - apiVersion: v1
@@ -289,9 +286,6 @@ objects:
           terminationMessagePolicy: FallbackToLogsOnError
         nodeSelector:
           kubernetes.io/os: linux
-        securityContext:
-          fsGroup: 65534
-          runAsUser: 65534
         serviceAccountName: observatorium-thanos-store-index-cache-memcached-telemeter
         terminationGracePeriodSeconds: 120
 - apiVersion: v1

--- a/services_go/observatorium/metrics.go
+++ b/services_go/observatorium/metrics.go
@@ -696,6 +696,7 @@ func (o ObservatoriumMetrics) makeStoreCache(name, component, instanceName strin
 	memcachedDeployment.Namespace = o.Namespace
 	memcachedDeployment.Replicas = 1
 	delete(memcachedDeployment.PodResources.Limits, corev1.ResourceCPU)
+	memcachedDeployment.SecurityContext = nil
 	memcachedDeployment.PodResources.Requests[corev1.ResourceCPU] = resource.MustParse("500m")
 	memcachedDeployment.PodResources.Requests[corev1.ResourceMemory] = resource.MustParse("2Gi")
 	memcachedDeployment.PodResources.Limits[corev1.ResourceMemory] = resource.MustParse("3Gi")


### PR DESCRIPTION
Fixing error:

```
provider restricted-v2: .containers[0].runAsUser: Invalid value: 65534: must be in the ranges: [1001920000, 1001929999], provider restricted-v2: .containers[1].runAsUser: Invalid value: 65534: must be in the ranges: [1001920000, 1001929999], provider restricted: .spec.securityContext.fsGroup: Invalid value:
```