### PR TITLE
[rhobs]: fix store cache config with units.Bytes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,4 +83,4 @@ require (
 )
 
 // Delete when https://github.com/observatorium/observatorium/pull/543 is merged to main branch
-replace github.com/observatorium/observatorium => github.com/thibaultmg/observatorium v0.0.0-20231030100738-39cab44afecc
+replace github.com/observatorium/observatorium => github.com/thibaultmg/observatorium v0.0.0-20231109122152-cc47e5be397b

--- a/go.sum
+++ b/go.sum
@@ -1253,8 +1253,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
-github.com/thibaultmg/observatorium v0.0.0-20231030100738-39cab44afecc h1:ANgwiT2bEIUB1yrIp5ml6dIMdpXXPJL0dRBv+kCOM78=
-github.com/thibaultmg/observatorium v0.0.0-20231030100738-39cab44afecc/go.mod h1:P+7t9O8AitkuZjUhXC4LHw4iwAzTpIrs0tHz8X3xTvM=
+github.com/thibaultmg/observatorium v0.0.0-20231109122152-cc47e5be397b h1:HDy/lsnObTgZgeNnq/ZUwQ+5unJdR4gvd3JOKMarQKM=
+github.com/thibaultmg/observatorium v0.0.0-20231109122152-cc47e5be397b/go.mod h1:P+7t9O8AitkuZjUhXC4LHw4iwAzTpIrs0tHz8X3xTvM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=

--- a/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-store-default-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-store-default-template.yaml
@@ -621,7 +621,7 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 5MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
           - --log.format=logfmt
@@ -646,11 +646,11 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 1MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
             max_chunks_get_range_requests: 3
-            metafile_max_size: 1048576
+            metafile_max_size: 1MiB
             metafile_exists_ttl: 2h0m0s
             metafile_doesnt_exist_ttl: 15m0s
             metafile_content_ttl: 24h0m0s

--- a/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
@@ -621,7 +621,7 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 5MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
           - --log.format=logfmt
@@ -646,11 +646,11 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 1MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
             max_chunks_get_range_requests: 3
-            metafile_max_size: 1048576
+            metafile_max_size: 1MiB
             metafile_exists_ttl: 2h0m0s
             metafile_doesnt_exist_ttl: 15m0s
             metafile_content_ttl: 24h0m0s

--- a/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
@@ -621,7 +621,7 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 5MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
           - --log.format=logfmt
@@ -646,11 +646,11 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 1MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
             max_chunks_get_range_requests: 3
-            metafile_max_size: 1048576
+            metafile_max_size: 1MiB
             metafile_exists_ttl: 2h0m0s
             metafile_doesnt_exist_ttl: 15m0s
             metafile_content_ttl: 24h0m0s

--- a/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-store-default-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-store-default-template.yaml
@@ -621,7 +621,7 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 5MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
           - --log.format=logfmt
@@ -646,11 +646,11 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 1MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
             max_chunks_get_range_requests: 3
-            metafile_max_size: 1048576
+            metafile_max_size: 1MiB
             metafile_exists_ttl: 2h0m0s
             metafile_doesnt_exist_ttl: 15m0s
             metafile_content_ttl: 24h0m0s

--- a/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
@@ -621,7 +621,7 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 5MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
           - --log.format=logfmt
@@ -646,11 +646,11 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 1MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
             max_chunks_get_range_requests: 3
-            metafile_max_size: 1048576
+            metafile_max_size: 1MiB
             metafile_exists_ttl: 2h0m0s
             metafile_doesnt_exist_ttl: 15m0s
             metafile_content_ttl: 24h0m0s

--- a/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
@@ -621,7 +621,7 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 5MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
           - --log.format=logfmt
@@ -646,11 +646,11 @@ objects:
               max_async_concurrency: 1000
               max_async_buffer_size: 2500000
               max_get_multi_concurrency: 1000
-              max_item_size: 5242880
+              max_item_size: 1MiB
               max_get_multi_batch_size: 100000
               dns_provider_update_interval: 10s
             max_chunks_get_range_requests: 3
-            metafile_max_size: 1048576
+            metafile_max_size: 1MiB
             metafile_exists_ttl: 2h0m0s
             metafile_doesnt_exist_ttl: 15m0s
             metafile_content_ttl: 24h0m0s

--- a/services_go/observatorium/metrics.go
+++ b/services_go/observatorium/metrics.go
@@ -22,7 +22,6 @@ import (
 	thanostime "github.com/observatorium/observatorium/configuration_go/schemas/thanos/time"
 	trclient "github.com/observatorium/observatorium/configuration_go/schemas/thanos/tracing/client"
 	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/tracing/jaeger"
-	"github.com/observatorium/observatorium/configuration_go/schemas/thanos/units"
 	routev1 "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -547,7 +546,7 @@ func (o ObservatoriumMetrics) makeStore(instanceCfg *ObservatoriumMetricsInstanc
 		MaxGetMultiBatchSize:      100000,
 		MaxGetMultiConcurrency:    1000,
 		MaxIdleConnections:        2500,
-		MaxItemSize:               5 * 1024 * 1024,
+		MaxItemSize:               "5MiB",
 		Timeout:                   2 * time.Second,
 	})
 	memCache := cache.NewBucketCacheConfig(memcachedclientcfg.MemcachedClientConfig{
@@ -560,11 +559,11 @@ func (o ObservatoriumMetrics) makeStore(instanceCfg *ObservatoriumMetricsInstanc
 		MaxGetMultiBatchSize:      100000,
 		MaxGetMultiConcurrency:    1000,
 		MaxIdleConnections:        2500,
-		MaxItemSize:               5 * 1024 * 1024,
+		MaxItemSize:               "1MiB",
 		Timeout:                   2 * time.Second,
 	})
 	memCache.MaxChunksGetRangeRequests = 3
-	memCache.MetafileMaxSize = 1 * units.MiB
+	memCache.MetafileMaxSize = "1MiB"
 	memCache.MetafileExistsTTL = 2 * time.Hour
 	memCache.MetafileDoesntExistTTL = 15 * time.Minute
 	memCache.MetafileContentTTL = 24 * time.Hour


### PR DESCRIPTION
The cache config struct is marchalled by some yaml lib that does not call the Stringer interface for fields, except for time.Time. Updated the observatorium dependency to the commit that implements this change: units.Bytes -> string