### PR TITLE
Add post-deploy host-metering e2e test template

### DIFF
--- a/tests/integration_tests/post-deploy-host-metering-job-template.yaml
+++ b/tests/integration_tests/post-deploy-host-metering-job-template.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhobs-${NAME_STUB}
+objects:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: rhobs-${NAME_STUB}-${UID}
+    annotations:
+      "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
+      "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+    labels:
+      image-tag: ${IMAGE_TAG}
+      iqe-image-tag: ${IQE_IMAGE_TAG}
+      iqe-env: ${ENV_FOR_DYNACONF}
+      iqe-plugin: ${IQE_PLUGINS}
+  spec:
+    backoffLimit: 0
+    template:
+      spec:
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        restartPolicy: Never
+        volumes:
+        - name: sel-shm
+          emptyDir:
+            medium: Memory
+        containers:
+        - name: rhobs-${NAME_STUB}-${IMAGE_TAG}-${UID}
+          image: ${IQE_IMAGE}:${IQE_IMAGE_TAG}
+          imagePullPolicy: Always
+          args:
+          - run
+          env:
+          - name: ENV_FOR_DYNACONF
+            value: ${ENV_FOR_DYNACONF}
+          - name: DYNACONF_MAIN__use_beta
+            value: ${USE_BETA}
+          - name: IQE_IBUTSU_SOURCE
+            value: rhobs-saas-${IMAGE_TAG}-${UID}
+          - name: IQE_BROWSERLOG
+            value: ${IQE_BROWSERLOG}
+          - name: IQE_NETLOG
+            value: ${IQE_NETLOG}
+          - name: IQE_PLUGINS
+            value: ${IQE_PLUGINS}
+          - name: IQE_MARKER_EXPRESSION
+            value: ${IQE_MARKER_EXPRESSION}
+          - name: IQE_FILTER_EXPRESSION
+            value: ${IQE_FILTER_EXPRESSION}
+          - name: IQE_LOG_LEVEL
+            value: ${IQE_LOG_LEVEL}
+          - name: IQE_REQUIREMENTS
+            value: ${IQE_REQUIREMENTS}
+          - name: IQE_REQUIREMENTS_PRIORITY
+            value: ${IQE_REQUIREMENTS_PRIORITY}
+          - name: IQE_TEST_IMPORTANCE
+            value: ${IQE_TEST_IMPORTANCE}
+          - name: DYNACONF_IQE_VAULT_LOADER_ENABLED
+            value: "true"
+          - name: DYNACONF_IQE_VAULT_VERIFY
+            value: "true"
+          - name: DYNACONF_IQE_VAULT_URL
+            valueFrom:
+              secretKeyRef:
+                key: url
+                name: iqe-vault
+                optional: true
+          - name: DYNACONF_IQE_VAULT_MOUNT_POINT
+            valueFrom:
+              secretKeyRef:
+                key: mountPoint
+                name: iqe-vault
+                optional: true
+          - name: DYNACONF_IQE_VAULT_ROLE_ID
+            valueFrom:
+              secretKeyRef:
+                key: roleId
+                name: iqe-vault
+                optional: true
+          - name: DYNACONF_IQE_VAULT_SECRET_ID
+            valueFrom:
+              secretKeyRef:
+                key: secretId
+                name: iqe-vault
+                optional: true
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1.5Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        - name: iqe-sel-${IMAGE_TAG}-${UID}
+          image: ${IQE_SEL_IMAGE}
+          env:
+            - name: _JAVA_OPTIONS
+              value: ${SELENIUM_JAVA_OPTS}
+            - name: VNC_GEOMETRY
+              value: ${VNC_GEOMETRY}
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - name: sel-shm
+              mountPath: /dev/shm
+parameters:
+- name: IMAGE_TAG
+  value: ''
+- name: UID
+  description: "Unique job name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"
+- name: IQE_IMAGE
+  description: "container image path for the iqe plugin"
+  value: quay.io/cloudservices/iqe-tests
+- name: IQE_IMAGE_TAG
+  description: "container image tag for iqe plugin"
+  value: 'hms-integration'
+- name: ENV_FOR_DYNACONF
+  value: stage_proxy
+- name: USE_BETA
+  value: "true"
+- name: IQE_PLUGINS
+  value: hms_integration
+- name: IQE_MARKER_EXPRESSION
+  value: 'host_metering'
+- name: IQE_FILTER_EXPRESSION
+  value: ''
+- name: IQE_LOG_LEVEL
+  value: info
+- name: IQE_REQUIREMENTS
+  value: ''
+- name: IQE_REQUIREMENTS_PRIORITY
+  value: ''
+- name: IQE_TEST_IMPORTANCE
+  value: ''
+- name: IQE_SEL_IMAGE
+  value: 'quay.io/redhatqe/selenium-standalone:ff_91.9.1esr_chrome_103.0.5060.114'
+- name: IQE_BROWSERLOG
+  value: "1"
+- name: IQE_NETLOG
+  value: "1"
+- name: NAME_STUB
+  value: 'e2e-metering-tests'
+- name: SELENIUM_JAVA_OPTS
+  value: ''
+- name: VNC_GEOMETRY
+  value: '1920x1080'


### PR DESCRIPTION
Add new test job template, for use by host-metering post-deployment integration tests. (Saas deployments will be added in app-interface.)

https://issues.redhat.com/browse/HMS-2515
