### PR TITLE
STOR-1277: Whitelist SELinux metrics

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -1,6 +1,7 @@
 [
   "{__name__=\":apiserver_v1_image_imports:sum\"}",
   "{__name__=\"ALERTS\",alertstate=\"firing\"}",
+  "{__name__=\"acm_console_page_count:sum\", page=~\"overview-classic|overview-fleet|search|search-details|clusters|application|governance\"}",
   "{__name__=\"acm_managed_cluster_info\"}",
   "{__name__=\"apiserver_list_watch_request_success_total:rate:sum\", verb=~\"LIST|WATCH\"}",
   "{__name__=\"appsvcs:cores_by_product:sum\"}",
@@ -51,6 +52,10 @@
   "{__name__=\"cluster:velero_restore_total:max\"}",
   "{__name__=\"cluster:virt_platform_nodes:sum\"}",
   "{__name__=\"cluster:vmi_request_cpu_cores:sum\"}",
+  "{__name__=\"cluster:volume_manager_selinux_pod_context_mismatch_total\"}",
+  "{__name__=\"cluster:volume_manager_selinux_volume_context_mismatch_errors_total\"}",
+  "{__name__=\"cluster:volume_manager_selinux_volume_context_mismatch_warnings_total\"}",
+  "{__name__=\"cluster:volume_manager_selinux_volumes_admitted_total\"}",
   "{__name__=\"cluster:vsphere_csi_migration:max\"}",
   "{__name__=\"cluster:vsphere_esxi_version_total:sum\"}",
   "{__name__=\"cluster:vsphere_infrastructure_failure_domains:max\"}",

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -95,6 +95,7 @@ objects:
           - --memcached=memcached-2.memcached.${NAMESPACE}.svc.cluster.local:11211
           - --whitelist={__name__=":apiserver_v1_image_imports:sum"}
           - --whitelist={__name__="alerts",alertstate="firing"}
+          - --whitelist={__name__="acm_console_page_count:sum", page=~"overview-classic|overview-fleet|search|search-details|clusters|application|governance"}
           - --whitelist={__name__="acm_managed_cluster_info"}
           - --whitelist={__name__="apiserver_list_watch_request_success_total:rate:sum", verb=~"LIST|WATCH"}
           - --whitelist={__name__="appsvcs:cores_by_product:sum"}
@@ -145,6 +146,10 @@ objects:
           - --whitelist={__name__="cluster:velero_restore_total:max"}
           - --whitelist={__name__="cluster:virt_platform_nodes:sum"}
           - --whitelist={__name__="cluster:vmi_request_cpu_cores:sum"}
+          - --whitelist={__name__="cluster:volume_manager_selinux_pod_context_mismatch_total"}
+          - --whitelist={__name__="cluster:volume_manager_selinux_volume_context_mismatch_errors_total"}
+          - --whitelist={__name__="cluster:volume_manager_selinux_volume_context_mismatch_warnings_total"}
+          - --whitelist={__name__="cluster:volume_manager_selinux_volumes_admitted_total"}
           - --whitelist={__name__="cluster:vsphere_csi_migration:max"}
           - --whitelist={__name__="cluster:vsphere_esxi_version_total:sum"}
           - --whitelist={__name__="cluster:vsphere_infrastructure_failure_domains:max"}
@@ -359,6 +364,7 @@ objects:
           - --memcached=memcached-2.memcached.${NAMESPACE}.svc.cluster.local:11211
           - --whitelist={__name__=":apiserver_v1_image_imports:sum"}
           - --whitelist={__name__="alerts",alertstate="firing"}
+          - --whitelist={__name__="acm_console_page_count:sum", page=~"overview-classic|overview-fleet|search|search-details|clusters|application|governance"}
           - --whitelist={__name__="acm_managed_cluster_info"}
           - --whitelist={__name__="apiserver_list_watch_request_success_total:rate:sum", verb=~"LIST|WATCH"}
           - --whitelist={__name__="appsvcs:cores_by_product:sum"}
@@ -409,6 +415,10 @@ objects:
           - --whitelist={__name__="cluster:velero_restore_total:max"}
           - --whitelist={__name__="cluster:virt_platform_nodes:sum"}
           - --whitelist={__name__="cluster:vmi_request_cpu_cores:sum"}
+          - --whitelist={__name__="cluster:volume_manager_selinux_pod_context_mismatch_total"}
+          - --whitelist={__name__="cluster:volume_manager_selinux_volume_context_mismatch_errors_total"}
+          - --whitelist={__name__="cluster:volume_manager_selinux_volume_context_mismatch_warnings_total"}
+          - --whitelist={__name__="cluster:volume_manager_selinux_volumes_admitted_total"}
           - --whitelist={__name__="cluster:vsphere_csi_migration:max"}
           - --whitelist={__name__="cluster:vsphere_esxi_version_total:sum"}
           - --whitelist={__name__="cluster:vsphere_infrastructure_failure_domains:max"}


### PR DESCRIPTION
Run `make whitelisted_metrics && make` to get new SELinux metrics into telemetry whitelist.

Approval from Metrics folks: https://issues.redhat.com/browse/STOR-1277, https://github.com/openshift/cluster-storage-operator/pull/422#pullrequestreview-1752989792 and https://github.com/openshift/cluster-monitoring-operator/pull/2155

It generated also `acm_console_page_count:sum` that I am not interested in, but I trust your generator scripts.