### PR TITLE
Add insights-qa ssh key secret to host-metering e2e test template

### DIFF
--- a/tests/integration_tests/post-deploy-host-metering-job-template.yaml
+++ b/tests/integration_tests/post-deploy-host-metering-job-template.yaml
@@ -27,6 +27,11 @@ objects:
         - name: sel-shm
           emptyDir:
             medium: Memory
+        - name: insights-qa-private-key
+          secret:
+            secretName: insights-qa-private-key
+            defaultMode: 0400
+            optional: true
         containers:
         - name: rhobs-${NAME_STUB}-${IMAGE_TAG}-${UID}
           image: ${IQE_IMAGE}:${IQE_IMAGE_TAG}
@@ -89,12 +94,17 @@ objects:
           resources:
             limits:
               cpu: "1"
-              memory: 1.5Gi
+              memory: 2Gi
             requests:
-              cpu: 250m
-              memory: 512Mi
+              cpu: 500m
+              memory: 1Gi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          volumeMounts:
+            - name: insights-qa-private-key
+              readOnly: true
+              mountPath: /iqe_venv/.ssh/insights-qa.pem
+              subPath: insights-qa.pem
         - name: iqe-sel-${IMAGE_TAG}-${UID}
           image: ${IQE_SEL_IMAGE}
           env:
@@ -105,7 +115,7 @@ objects:
           resources:
             limits:
               cpu: 500m
-              memory: 2Gi
+              memory: 1.5Gi
             requests:
               cpu: 100m
               memory: 256Mi


### PR DESCRIPTION
Add the insights-qa ssh key to the host-metering e2e test template. The test container needs this key in order to connect to cloud VMs that are provisioned during the test run.