### PR TITLE
[rhobs/stage]: fix monitors namespace and add rule-objstore cfg

### DIFF
--- a/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-compact-default-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-compact-default-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-compact-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-receive-ingestor-default-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-receive-ingestor-default-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-ruler-default-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-ruler-default-template.yaml
@@ -100,7 +100,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-ruler-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-store-default-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-store-default-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-api-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-api-template.yaml
@@ -116,7 +116,7 @@ objects:
       app.kubernetes.io/version: main
       prometheus: app-sre
     name: avalanche
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http
@@ -273,7 +273,7 @@ objects:
       app.kubernetes.io/version: "1.5"
       prometheus: app-sre
     name: observatorium-api-cache-memcached
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -579,7 +579,7 @@ objects:
       app.kubernetes.io/version: main-2023-12-06-62d7703
       prometheus: app-sre
     name: observatorium-api
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http-internal
@@ -807,7 +807,7 @@ objects:
       app.kubernetes.io/version: v2.0.0-rc.36
       prometheus: app-sre
     name: observatorium-gubernator
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http
@@ -994,7 +994,7 @@ objects:
       app.kubernetes.io/version: 9c789b9
       prometheus: app-sre
     name: observatorium-obsctl-reloader
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http
@@ -1769,7 +1769,7 @@ objects:
       app.kubernetes.io/version: v0.0.0
       prometheus: app-sre
     name: observatorium-up-query-frontend
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http
@@ -1897,7 +1897,7 @@ objects:
       app.kubernetes.io/version: v0.0.0
       prometheus: app-sre
     name: observatorium-up-query-rule
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http
@@ -1910,6 +1910,25 @@ objects:
         app.kubernetes.io/instance: observatorium
         app.kubernetes.io/name: observatorium-up
         app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  data:
+    config.yaml: |
+      type: S3
+      config:
+        bucket: $(OBJ_STORE_BUCKET)
+        endpoint: $(OBJ_STORE_ENDPOINT)
+        region: $(OBJ_STORE_REGION)
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: rules-storage
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: rules-objstore
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: main-2022-09-21-9df4d2c
+    name: observatorium-rules-objstore
+    namespace: rhobs
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -1919,9 +1938,9 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: ""
+      app.kubernetes.io/version: main-2022-09-21-9df4d2c
     name: observatorium-rules-objstore
-    namespace: observatorium
+    namespace: rhobs
   spec:
     replicas: 1
     selector:
@@ -1939,8 +1958,8 @@ objects:
           app.kubernetes.io/instance: observatorium
           app.kubernetes.io/name: rules-objstore
           app.kubernetes.io/part-of: observatorium
-          app.kubernetes.io/version: ""
-        namespace: observatorium
+          app.kubernetes.io/version: main-2022-09-21-9df4d2c
+        namespace: rhobs
       spec:
         affinity:
           podAntiAffinity:
@@ -1962,7 +1981,34 @@ objects:
         - args:
           - -log.format=logfmt
           - -log.level=warn
-          image: 'quay.io/observatorium/rules-objstore:'
+          - -objstore.config-file=/etc/rules-objstore/objstore/config.yaml
+          env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: aws_access_key_id
+                name: rhobs-rules-objstore-stage-s3
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: aws_secret_access_key
+                name: rhobs-rules-objstore-stage-s3
+          - name: OBJ_STORE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                key: bucket
+                name: rhobs-rules-objstore-stage-s3
+          - name: OBJ_STORE_REGION
+            valueFrom:
+              secretKeyRef:
+                key: aws_region
+                name: rhobs-rules-objstore-stage-s3
+          - name: OBJ_STORE_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                key: endpoint
+                name: rhobs-rules-objstore-stage-s3
+          image: quay.io/observatorium/rules-objstore:main-2022-09-21-9df4d2c
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10
@@ -1996,10 +2042,17 @@ objects:
               cpu: 50m
               memory: 200Mi
           terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /etc/rules-objstore/objstore
+            name: objstore
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: observatorium-rules-objstore
         terminationGracePeriodSeconds: 120
+        volumes:
+        - configMap:
+            name: observatorium-rules-objstore
+          name: objstore
 - apiVersion: v1
   kind: Service
   metadata:
@@ -2009,9 +2062,9 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: ""
+      app.kubernetes.io/version: main-2022-09-21-9df4d2c
     name: observatorium-rules-objstore
-    namespace: observatorium
+    namespace: rhobs
   spec:
     ports:
     - name: internal
@@ -2036,9 +2089,9 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: ""
+      app.kubernetes.io/version: main-2022-09-21-9df4d2c
     name: observatorium-rules-objstore
-    namespace: observatorium
+    namespace: rhobs
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
@@ -2048,9 +2101,9 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: ""
+      app.kubernetes.io/version: main-2022-09-21-9df4d2c
     name: observatorium-rules-objstore
-    namespace: observatorium
+    namespace: rhobs
   spec:
     endpoints:
     - port: internal

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-alertmanager-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-alertmanager-template.yaml
@@ -107,7 +107,7 @@ objects:
       app.kubernetes.io/version: v0.26.0
       prometheus: app-sre
     name: observatorium-alertmanager
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-frontend-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-frontend-template.yaml
@@ -174,7 +174,7 @@ objects:
       app.kubernetes.io/version: "1.5"
       prometheus: app-sre
     name: observatorium-thanos-query-range-cache-memcached
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -251,7 +251,7 @@ objects:
       app.kubernetes.io/version: v0.32.5
       prometheus: app-sre
     name: observatorium-thanos-query-frontend
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-rule-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-rule-template.yaml
@@ -91,7 +91,7 @@ objects:
       app.kubernetes.io/version: v0.32.5
       prometheus: app-sre
     name: observatorium-thanos-query-rule
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-template.yaml
@@ -91,7 +91,7 @@ objects:
       app.kubernetes.io/version: v0.32.5
       prometheus: app-sre
     name: observatorium-thanos-query
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-receive-router-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-receive-router-template.yaml
@@ -400,7 +400,7 @@ objects:
       app.kubernetes.io/version: v0.32.5
       prometheus: app-sre
     name: observatorium-thanos-receive-router
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-compact-rhel-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-compact-rhel-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-compact-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-receive-ingestor-rhel-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-receive-ingestor-rhel-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-ruler-rhel-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-ruler-rhel-template.yaml
@@ -100,7 +100,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-ruler-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-compact-telemeter-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-compact-telemeter-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-compact-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-receive-ingestor-telemeter-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-receive-ingestor-telemeter-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-ruler-telemeter-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-ruler-telemeter-template.yaml
@@ -232,7 +232,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-ruler-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-compact-default-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-compact-default-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-compact-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-receive-ingestor-default-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-receive-ingestor-default-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-ruler-default-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-ruler-default-template.yaml
@@ -100,7 +100,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-ruler-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-store-default-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-store-default-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-default
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-api-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-api-template.yaml
@@ -111,7 +111,6 @@ objects:
       app.kubernetes.io/version: main
       prometheus: app-sre
     name: avalanche
-    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -264,7 +263,6 @@ objects:
       app.kubernetes.io/version: "1.5"
       prometheus: app-sre
     name: observatorium-api-cache-memcached
-    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -555,7 +553,6 @@ objects:
       app.kubernetes.io/version: main-2023-12-06-62d7703
       prometheus: app-sre
     name: observatorium-api
-    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http-internal
@@ -776,7 +773,6 @@ objects:
       app.kubernetes.io/version: v2.0.0-rc.36
       prometheus: app-sre
     name: observatorium-gubernator
-    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -956,7 +952,6 @@ objects:
       app.kubernetes.io/version: 9c789b9
       prometheus: app-sre
     name: observatorium-obsctl-reloader
-    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -1116,7 +1111,6 @@ objects:
       app.kubernetes.io/version: v0.0.0
       prometheus: app-sre
     name: observatorium-up-query-frontend
-    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -1240,7 +1234,6 @@ objects:
       app.kubernetes.io/version: v0.0.0
       prometheus: app-sre
     name: observatorium-up-query-rule
-    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -1253,6 +1246,24 @@ objects:
         app.kubernetes.io/instance: observatorium
         app.kubernetes.io/name: observatorium-up
         app.kubernetes.io/part-of: observatorium
+- apiVersion: v1
+  data:
+    config.yaml: |
+      type: S3
+      config:
+        bucket: $(OBJ_STORE_BUCKET)
+        endpoint: $(OBJ_STORE_ENDPOINT)
+        region: $(OBJ_STORE_REGION)
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: rules-storage
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: rules-objstore
+      app.kubernetes.io/part-of: observatorium
+      app.kubernetes.io/version: main-2022-09-21-9df4d2c
+    name: observatorium-rules-objstore
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -1262,9 +1273,8 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: ""
+      app.kubernetes.io/version: main-2022-09-21-9df4d2c
     name: observatorium-rules-objstore
-    namespace: observatorium
   spec:
     replicas: 1
     selector:
@@ -1282,8 +1292,7 @@ objects:
           app.kubernetes.io/instance: observatorium
           app.kubernetes.io/name: rules-objstore
           app.kubernetes.io/part-of: observatorium
-          app.kubernetes.io/version: ""
-        namespace: observatorium
+          app.kubernetes.io/version: main-2022-09-21-9df4d2c
       spec:
         affinity:
           podAntiAffinity:
@@ -1305,7 +1314,29 @@ objects:
         - args:
           - -log.format=logfmt
           - -log.level=warn
-          image: 'quay.io/observatorium/rules-objstore:'
+          - -objstore.config-file=/etc/rules-objstore/objstore/config.yaml
+          env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: aws_secret_access_key
+          - name: OBJ_STORE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                key: bucket
+          - name: OBJ_STORE_REGION
+            valueFrom:
+              secretKeyRef:
+                key: aws_region
+          - name: OBJ_STORE_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                key: endpoint
+          image: quay.io/observatorium/rules-objstore:main-2022-09-21-9df4d2c
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10
@@ -1339,10 +1370,17 @@ objects:
               cpu: 50m
               memory: 200Mi
           terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /etc/rules-objstore/objstore
+            name: objstore
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: observatorium-rules-objstore
         terminationGracePeriodSeconds: 120
+        volumes:
+        - configMap:
+            name: observatorium-rules-objstore
+          name: objstore
 - apiVersion: v1
   kind: Service
   metadata:
@@ -1352,9 +1390,8 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: ""
+      app.kubernetes.io/version: main-2022-09-21-9df4d2c
     name: observatorium-rules-objstore
-    namespace: observatorium
   spec:
     ports:
     - name: internal
@@ -1379,9 +1416,8 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: ""
+      app.kubernetes.io/version: main-2022-09-21-9df4d2c
     name: observatorium-rules-objstore
-    namespace: observatorium
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
@@ -1391,9 +1427,8 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: rules-objstore
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: ""
+      app.kubernetes.io/version: main-2022-09-21-9df4d2c
     name: observatorium-rules-objstore
-    namespace: observatorium
   spec:
     endpoints:
     - port: internal

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-alertmanager-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-alertmanager-template.yaml
@@ -107,7 +107,7 @@ objects:
       app.kubernetes.io/version: v0.26.0
       prometheus: app-sre
     name: observatorium-alertmanager
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-frontend-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-frontend-template.yaml
@@ -174,7 +174,7 @@ objects:
       app.kubernetes.io/version: "1.5"
       prometheus: app-sre
     name: observatorium-thanos-query-range-cache-memcached
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -251,7 +251,7 @@ objects:
       app.kubernetes.io/version: v0.32.4
       prometheus: app-sre
     name: observatorium-thanos-query-frontend
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-rule-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-rule-template.yaml
@@ -91,7 +91,7 @@ objects:
       app.kubernetes.io/version: v0.32.4
       prometheus: app-sre
     name: observatorium-thanos-query-rule
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-template.yaml
@@ -91,7 +91,7 @@ objects:
       app.kubernetes.io/version: v0.32.4
       prometheus: app-sre
     name: observatorium-thanos-query
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-receive-router-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-receive-router-template.yaml
@@ -395,7 +395,7 @@ objects:
       app.kubernetes.io/version: v0.32.4
       prometheus: app-sre
     name: observatorium-thanos-receive-router
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-compact-rhel-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-compact-rhel-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-compact-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-receive-ingestor-rhel-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-receive-ingestor-rhel-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-ruler-rhel-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-ruler-rhel-template.yaml
@@ -100,7 +100,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-ruler-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-rhel
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-compact-telemeter-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-compact-telemeter-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-compact-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-receive-ingestor-telemeter-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-receive-ingestor-telemeter-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-ruler-telemeter-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-ruler-telemeter-template.yaml
@@ -100,7 +100,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-ruler-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-telemeter
-    namespace: openshift-customer-monitoring
+    namespace: rhobs
   spec:
     endpoints:
     - port: http

--- a/services_go/instances/rhobs/rhobs.go
+++ b/services_go/instances/rhobs/rhobs.go
@@ -174,6 +174,7 @@ func stageConfig() observatorium.Observatorium {
 			UpQueriesTenant:              tenantsMapping[DefaultInstanceName][rhobsTenantName],
 			ObsCtlReloaderManagedTenants: []string{string(rhobsTenantName), string(osdTenantName), string(appsreTenantName), string(rhtapTenantName)},
 			Tenants:                      makeObsTenants(tenants),
+			RuleObjStoreSecret:           "rhobs-rules-objstore-stage-s3",
 		},
 		MetricsInstances: observatorium.ObservatoriumMetrics{
 			Namespace:                 "rhobs",

--- a/services_go/observatorium/helpers.go
+++ b/services_go/observatorium/helpers.go
@@ -14,7 +14,6 @@ import (
 
 // postProcessServiceMonitor updates the service monitor to work with the app-sre prometheus.
 func postProcessServiceMonitor(serviceMonitor *monv1.ServiceMonitor, namespaceSelector string) {
-	serviceMonitor.ObjectMeta.Namespace = monitoringNamespace
 	serviceMonitor.Spec.NamespaceSelector.MatchNames = []string{namespaceSelector}
 	serviceMonitor.ObjectMeta.Labels["prometheus"] = "app-sre"
 }


### PR DESCRIPTION
ServiceMonitors were deployed in a wrong namespace, changing for rhobs.
Add objstore config to rlues-objstore.