### PR TITLE
[rhobs/stage]: fix service monitor and ruler

### DIFF
--- a/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-compact-default-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-compact-default-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-compact-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-receive-ingestor-default-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-receive-ingestor-default-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-ruler-default-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-ruler-default-template.yaml
@@ -100,7 +100,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-ruler-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -184,6 +184,7 @@ objects:
         - args:
           - rule
           - --alert.label-drop=rule_replica
+          - --alertmanagers.url=http://observatorium-alertmanager.rhobs.svc.cluster.local:9093
           - --data-dir=/var/thanos/ruler
           - --label=rule_replica="$(NAME)"
           - --log.format=logfmt
@@ -293,22 +294,6 @@ objects:
           volumeMounts:
           - mountPath: /etc/thanos-rule-syncer
             name: rule-syncer
-        - args:
-          - -volume-dir=/etc/thanos-rule-syncer
-          - -webhook-url=http://localhost:10902/-/reload
-          image: quay.io/openshift/origin-configmap-reloader:4.5.0
-          name: configmap-reloader
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-          - mountPath: /etc/thanos/rules/observatorium-rules
-            name: observatorium-rules
         - args:
           - -provider=openshift
           - -https-address=:8443

--- a/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-store-default-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/default/observatorium-metrics-store-default-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-api-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-api-template.yaml
@@ -116,7 +116,7 @@ objects:
       app.kubernetes.io/version: main
       prometheus: app-sre
     name: avalanche
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -273,7 +273,7 @@ objects:
       app.kubernetes.io/version: "1.5"
       prometheus: app-sre
     name: observatorium-api-cache-memcached
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -579,7 +579,7 @@ objects:
       app.kubernetes.io/version: main-2023-12-06-62d7703
       prometheus: app-sre
     name: observatorium-api
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http-internal
@@ -807,7 +807,7 @@ objects:
       app.kubernetes.io/version: v2.0.0-rc.36
       prometheus: app-sre
     name: observatorium-gubernator
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -994,7 +994,7 @@ objects:
       app.kubernetes.io/version: 9c789b9
       prometheus: app-sre
     name: observatorium-obsctl-reloader
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -1769,7 +1769,7 @@ objects:
       app.kubernetes.io/version: v0.0.0
       prometheus: app-sre
     name: observatorium-up-query-frontend
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -1897,7 +1897,7 @@ objects:
       app.kubernetes.io/version: v0.0.0
       prometheus: app-sre
     name: observatorium-up-query-rule
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-alertmanager-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-alertmanager-template.yaml
@@ -107,7 +107,7 @@ objects:
       app.kubernetes.io/version: v0.26.0
       prometheus: app-sre
     name: observatorium-alertmanager
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-frontend-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-frontend-template.yaml
@@ -174,7 +174,7 @@ objects:
       app.kubernetes.io/version: "1.5"
       prometheus: app-sre
     name: observatorium-thanos-query-range-cache-memcached
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -251,7 +251,7 @@ objects:
       app.kubernetes.io/version: v0.32.5
       prometheus: app-sre
     name: observatorium-thanos-query-frontend
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-rule-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-rule-template.yaml
@@ -91,7 +91,7 @@ objects:
       app.kubernetes.io/version: v0.32.5
       prometheus: app-sre
     name: observatorium-thanos-query-rule
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-query-template.yaml
@@ -91,7 +91,7 @@ objects:
       app.kubernetes.io/version: v0.32.5
       prometheus: app-sre
     name: observatorium-thanos-query
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-receive-router-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-metrics-receive-router-template.yaml
@@ -400,7 +400,7 @@ objects:
       app.kubernetes.io/version: v0.32.5
       prometheus: app-sre
     name: observatorium-thanos-receive-router
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-compact-rhel-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-compact-rhel-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-compact-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-receive-ingestor-rhel-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-receive-ingestor-rhel-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-ruler-rhel-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-ruler-rhel-template.yaml
@@ -100,7 +100,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-ruler-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -184,6 +184,7 @@ objects:
         - args:
           - rule
           - --alert.label-drop=rule_replica
+          - --alertmanagers.url=http://observatorium-alertmanager.rhobs.svc.cluster.local:9093
           - --data-dir=/var/thanos/ruler
           - --label=rule_replica="$(NAME)"
           - --log.format=logfmt
@@ -293,22 +294,6 @@ objects:
           volumeMounts:
           - mountPath: /etc/thanos-rule-syncer
             name: rule-syncer
-        - args:
-          - -volume-dir=/etc/thanos-rule-syncer
-          - -webhook-url=http://localhost:10902/-/reload
-          image: quay.io/openshift/origin-configmap-reloader:4.5.0
-          name: configmap-reloader
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-          - mountPath: /etc/thanos/rules/observatorium-rules
-            name: observatorium-rules
         - args:
           - -provider=openshift
           - -https-address=:8443

--- a/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-compact-telemeter-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-compact-telemeter-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-compact-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-receive-ingestor-telemeter-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-receive-ingestor-telemeter-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-ruler-telemeter-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-ruler-telemeter-template.yaml
@@ -232,7 +232,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-ruler-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -316,6 +316,7 @@ objects:
         - args:
           - rule
           - --alert.label-drop=rule_replica
+          - --alertmanagers.url=http://observatorium-alertmanager.rhobs.svc.cluster.local:9093
           - --data-dir=/var/thanos/ruler
           - --label=rule_replica="$(NAME)"
           - --log.format=logfmt
@@ -429,22 +430,6 @@ objects:
           - mountPath: /etc/thanos-rule-syncer
             name: rule-syncer
         - args:
-          - -volume-dir=/etc/thanos-rule-syncer
-          - -webhook-url=http://localhost:10902/-/reload
-          image: quay.io/openshift/origin-configmap-reloader:4.5.0
-          name: configmap-reloader
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-          - mountPath: /etc/thanos/rules/observatorium-rules
-            name: observatorium-rules
-        - args:
           - -provider=openshift
           - -https-address=:8443
           - -http-address=
@@ -522,6 +507,22 @@ objects:
               cpu: 32m
               memory: 64Mi
           terminationMessagePolicy: FallbackToLogsOnError
+        - args:
+          - -volume-dir=/etc/thanos-rule-syncer
+          - -webhook-url=http://localhost:10902/-/reload
+          image: quay.io/openshift/origin-configmap-reloader:4.5.0
+          name: configmap-reloader
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /etc/thanos/rules/observatorium-rules
+            name: observatorium-rules
         nodeSelector:
           kubernetes.io/os: linux
         serviceAccountName: observatorium-thanos-ruler-telemeter

--- a/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-compact-default-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-compact-default-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-compact-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-receive-ingestor-default-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-receive-ingestor-default-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-ruler-default-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-ruler-default-template.yaml
@@ -100,7 +100,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-ruler-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -184,6 +184,7 @@ objects:
         - args:
           - rule
           - --alert.label-drop=rule_replica
+          - --alertmanagers.url=http://observatorium-alertmanager.rhobs.svc.cluster.local:9093
           - --data-dir=/var/thanos/ruler
           - --label=rule_replica="$(NAME)"
           - --log.format=logfmt
@@ -293,22 +294,6 @@ objects:
           volumeMounts:
           - mountPath: /etc/thanos-rule-syncer
             name: rule-syncer
-        - args:
-          - -volume-dir=/etc/thanos-rule-syncer
-          - -webhook-url=http://localhost:10902/-/reload
-          image: quay.io/openshift/origin-configmap-reloader:4.5.0
-          name: configmap-reloader
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-          - mountPath: /etc/thanos/rules/observatorium-rules
-            name: observatorium-rules
         - args:
           - -provider=openshift
           - -https-address=:8443

--- a/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-store-default-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/default/observatorium-metrics-store-default-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: default
       prometheus: app-sre
     name: observatorium-thanos-store-default
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-api-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-api-template.yaml
@@ -111,6 +111,7 @@ objects:
       app.kubernetes.io/version: main
       prometheus: app-sre
     name: avalanche
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -263,6 +264,7 @@ objects:
       app.kubernetes.io/version: "1.5"
       prometheus: app-sre
     name: observatorium-api-cache-memcached
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -553,6 +555,7 @@ objects:
       app.kubernetes.io/version: main-2023-12-06-62d7703
       prometheus: app-sre
     name: observatorium-api
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http-internal
@@ -773,6 +776,7 @@ objects:
       app.kubernetes.io/version: v2.0.0-rc.36
       prometheus: app-sre
     name: observatorium-gubernator
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -952,6 +956,7 @@ objects:
       app.kubernetes.io/version: 9c789b9
       prometheus: app-sre
     name: observatorium-obsctl-reloader
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -1111,6 +1116,7 @@ objects:
       app.kubernetes.io/version: v0.0.0
       prometheus: app-sre
     name: observatorium-up-query-frontend
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -1234,6 +1240,7 @@ objects:
       app.kubernetes.io/version: v0.0.0
       prometheus: app-sre
     name: observatorium-up-query-rule
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-alertmanager-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-alertmanager-template.yaml
@@ -107,7 +107,7 @@ objects:
       app.kubernetes.io/version: v0.26.0
       prometheus: app-sre
     name: observatorium-alertmanager
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-frontend-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-frontend-template.yaml
@@ -174,7 +174,7 @@ objects:
       app.kubernetes.io/version: "1.5"
       prometheus: app-sre
     name: observatorium-thanos-query-range-cache-memcached
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -251,7 +251,7 @@ objects:
       app.kubernetes.io/version: v0.32.4
       prometheus: app-sre
     name: observatorium-thanos-query-frontend
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-rule-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-rule-template.yaml
@@ -91,7 +91,7 @@ objects:
       app.kubernetes.io/version: v0.32.4
       prometheus: app-sre
     name: observatorium-thanos-query-rule
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-query-template.yaml
@@ -91,7 +91,7 @@ objects:
       app.kubernetes.io/version: v0.32.4
       prometheus: app-sre
     name: observatorium-thanos-query
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-receive-router-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-metrics-receive-router-template.yaml
@@ -395,7 +395,7 @@ objects:
       app.kubernetes.io/version: v0.32.4
       prometheus: app-sre
     name: observatorium-thanos-receive-router
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-compact-rhel-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-compact-rhel-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-compact-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-receive-ingestor-rhel-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-receive-ingestor-rhel-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-ruler-rhel-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-ruler-rhel-template.yaml
@@ -100,7 +100,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-ruler-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -184,6 +184,7 @@ objects:
         - args:
           - rule
           - --alert.label-drop=rule_replica
+          - --alertmanagers.url=http://observatorium-alertmanager.rhobs.svc.cluster.local:9093
           - --data-dir=/var/thanos/ruler
           - --label=rule_replica="$(NAME)"
           - --log.format=logfmt
@@ -293,22 +294,6 @@ objects:
           volumeMounts:
           - mountPath: /etc/thanos-rule-syncer
             name: rule-syncer
-        - args:
-          - -volume-dir=/etc/thanos-rule-syncer
-          - -webhook-url=http://localhost:10902/-/reload
-          image: quay.io/openshift/origin-configmap-reloader:4.5.0
-          name: configmap-reloader
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-          - mountPath: /etc/thanos/rules/observatorium-rules
-            name: observatorium-rules
         - args:
           - -provider=openshift
           - -https-address=:8443

--- a/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/rhel/observatorium-metrics-store-rhel-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: rhel
       prometheus: app-sre
     name: observatorium-thanos-store-rhel
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-compact-telemeter-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-compact-telemeter-template.yaml
@@ -63,7 +63,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-compact-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-receive-ingestor-telemeter-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-receive-ingestor-telemeter-template.yaml
@@ -65,7 +65,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-receive-ingestor-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-ruler-telemeter-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-ruler-telemeter-template.yaml
@@ -100,7 +100,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-ruler-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http
@@ -184,6 +184,7 @@ objects:
         - args:
           - rule
           - --alert.label-drop=rule_replica
+          - --alertmanagers.url=http://observatorium-alertmanager.rhobs.svc.cluster.local:9093
           - --data-dir=/var/thanos/ruler
           - --label=rule_replica="$(NAME)"
           - --log.format=logfmt
@@ -293,22 +294,6 @@ objects:
           volumeMounts:
           - mountPath: /etc/thanos-rule-syncer
             name: rule-syncer
-        - args:
-          - -volume-dir=/etc/thanos-rule-syncer
-          - -webhook-url=http://localhost:10902/-/reload
-          image: quay.io/openshift/origin-configmap-reloader:4.5.0
-          name: configmap-reloader
-          resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
-          terminationMessagePolicy: FallbackToLogsOnError
-          volumeMounts:
-          - mountPath: /etc/thanos/rules/observatorium-rules
-            name: observatorium-rules
         - args:
           - -provider=openshift
           - -https-address=:8443

--- a/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/telemeter/observatorium-metrics-store-telemeter-template.yaml
@@ -195,7 +195,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-bucket-cache-memcached-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -367,7 +367,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-index-cache-memcached-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: metrics
@@ -513,7 +513,7 @@ objects:
       observatorium/tenant: telemeter
       prometheus: app-sre
     name: observatorium-thanos-store-telemeter
-    namespace: rhobs
+    namespace: openshift-customer-monitoring
   spec:
     endpoints:
     - port: http

--- a/services_go/observatorium/api.go
+++ b/services_go/observatorium/api.go
@@ -35,7 +35,7 @@ const (
 	gubernatorImage      = "quay.io/app-sre/gubernator"
 	gubernatorTag        = "v2.0.0-rc.36"
 	observatoriumUpImage = "quay.io/observatorium/up"
-	observatoriumUpTag   = "v0.0.0"
+	observatoriumUpTag   = "master-2022-03-24-098c31a"
 	avalancheImage       = "quay.io/prometheuscommunity/avalanche"
 	avalancheTag         = "main"
 	obsctlReloaderImage  = "quay.io/app-sre/obsctl-reloader"

--- a/services_go/observatorium/helpers.go
+++ b/services_go/observatorium/helpers.go
@@ -14,6 +14,7 @@ import (
 
 // postProcessServiceMonitor updates the service monitor to work with the app-sre prometheus.
 func postProcessServiceMonitor(serviceMonitor *monv1.ServiceMonitor, namespaceSelector string) {
+	serviceMonitor.ObjectMeta.Namespace = monitoringNamespace
 	serviceMonitor.Spec.NamespaceSelector.MatchNames = []string{namespaceSelector}
 	serviceMonitor.ObjectMeta.Labels["prometheus"] = "app-sre"
 }


### PR DESCRIPTION
- Service monitors must be deployed in the `openshift-customer-monitoring` namespace. Resetting it. Will fix deployment on app-interface side by adding a second target for each template with the preceding namespace.
- Fix ruler invalid volume mount.