### PR TITLE
rhobs: fix missing env var in obsctl reloader

### DIFF
--- a/resources/services/app-sre-stage-01/rhobs/observatorium-api-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-api-template.yaml
@@ -900,6 +900,11 @@ objects:
           - --issuer-url=https://sso.redhat.com/auth/realms/redhat-external
           - --audience=observatorium
           - --log-rules-enabled=false
+          env:
+          - name: NAMESPACE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           image: quay.io/app-sre/obsctl-reloader:969b895
           imagePullPolicy: IfNotPresent
           name: obsctl-reloader

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-api-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-api-template.yaml
@@ -868,6 +868,11 @@ objects:
           - --issuer-url=https://sso.redhat.com/auth/realms/redhat-external
           - --audience=observatorium
           - --log-rules-enabled=false
+          env:
+          - name: NAMESPACE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           image: quay.io/app-sre/obsctl-reloader:969b895
           imagePullPolicy: IfNotPresent
           name: obsctl-reloader

--- a/services_go/observatorium/api.go
+++ b/services_go/observatorium/api.go
@@ -321,11 +321,21 @@ func (o *ObservatoriumAPI) makeAvalanche() k8sutil.ObjectMap {
 
 func (o *ObservatoriumAPI) makeObsCtlReloader(obsApiName string) k8sutil.ObjectMap {
 	depl := k8sutil.DeploymentGenericConfig{
-		Name:                 "observatorium-obsctl-reloader",
-		Namespace:            o.Namespace,
-		Image:                obsctlReloaderImage,
-		ImageTag:             obsctlReloaderTag,
-		ImagePullPolicy:      corev1.PullIfNotPresent,
+		Name:            "observatorium-obsctl-reloader",
+		Namespace:       o.Namespace,
+		Image:           obsctlReloaderImage,
+		ImageTag:        obsctlReloaderTag,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Env: []corev1.EnvVar{
+			{
+				Name: "NAMESPACE_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+		},
 		Replicas:             1,
 		EnableServiceMonitor: true,
 		CommonLabels: map[string]string{


### PR DESCRIPTION
Fixing this fairly explicit log from obsctl-reloader container:
`panic: Missing env var NAMESPACE_NAME`