### PR TITLE
[receive]: allow configuration of too-far-in-the-future

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -1804,6 +1804,7 @@ objects:
           - --receive.hashrings-file-refresh-interval=5s
           - --store.limits.request-series=${THANOS_RECEIVE_REQUEST_SERIES_LIMIT}
           - --store.limits.request-samples=${THANOS_RECEIVE_REQUEST_SAMPLES_LIMIT}
+          - --tsdb.too-far-in-future.time-window=${THANOS_RECEIVE_TOO_FAR_IN_FUTURE_TIME_WINDOW}
           env:
           - name: NAME
             valueFrom:
@@ -4469,6 +4470,8 @@ parameters:
   value: observatorium-thanos-receive-default
 - name: THANOS_RECEIVE_HASHRINGS_ALGORITHM
   value: hashmod
+- name: THANOS_RECEIVE_TOO_FAR_IN_FUTURE_TIME_WINDOW
+  value: 0s
 - name: THANOS_RECEIVE_LIMIT_CONFIG
   value: '{"write":{"default":{"request":{"samples_limit":0,"series_limit":0,"size_bytes_limit":0}},"global":{"max_concurrency":0}}}'
 - name: THANOS_RECEIVE_REQUEST_SERIES_LIMIT

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -460,6 +460,7 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                         '--receive.hashrings-file-refresh-interval=5s',
                         '--store.limits.request-series=${THANOS_RECEIVE_REQUEST_SERIES_LIMIT}',
                         '--store.limits.request-samples=${THANOS_RECEIVE_REQUEST_SAMPLES_LIMIT}',
+                        '--tsdb.too-far-in-future.time-window=${THANOS_RECEIVE_TOO_FAR_IN_FUTURE_TIME_WINDOW}',
                       ],
                       env+: s3EnvVars + [{
                         name: 'DEBUG',

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -118,6 +118,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_RECEIVE_TSDB_RETENTION', value: '4d' },
     { name: 'THANOS_RECEIVE_HASHRING_SERVICE_NAME', value: 'observatorium-thanos-receive-default' },
     { name: 'THANOS_RECEIVE_HASHRINGS_ALGORITHM', value: 'hashmod' },
+    { name: 'THANOS_RECEIVE_TOO_FAR_IN_FUTURE_TIME_WINDOW', value: '0s' },
     { name: 'THANOS_RECEIVE_LIMIT_CONFIG', value: std.manifestJsonMinified(defaultReceiveLimits) },
     { name: 'THANOS_RECEIVE_REQUEST_SERIES_LIMIT', value: '0' },
     { name: 'THANOS_RECEIVE_REQUEST_SAMPLES_LIMIT', value: '0' },


### PR DESCRIPTION
The default value is `0s`, which leaves the feature disabled.