### PR TITLE
Remove version label from obsctl-reloader service monitor

### DIFF
--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -310,7 +310,6 @@ objects:
         app.kubernetes.io/instance: observatorium
         app.kubernetes.io/name: rules-obsctl-reloader
         app.kubernetes.io/part-of: observatorium
-        app.kubernetes.io/version: ${OBSCTL_RELOADER_IMAGE_TAG}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/services/observatorium.libsonnet
+++ b/services/observatorium.libsonnet
@@ -231,9 +231,15 @@ local obsctlReloader = (import 'github.com/rhobs/obsctl-reloader/jsonnet/lib/obs
       metadata+: {
         labels+: {
           prometheus: 'app-sre',
+          'app.kubernetes.io/version':: 'hidden',
         },
       },
       spec+: {
+        selector+: {
+          matchLabels+: {
+            'app.kubernetes.io/version':: 'hidden',
+          },
+        },
         namespaceSelector: {
           // NOTICE:
           // When using the ${{PARAMETER_NAME}} syntax only a single parameter reference is allowed and leading/trailing characters are not permitted.


### PR DESCRIPTION
The idea is to be able to deploy the service monitor independently from moving the version of obsctl-reloader.