### PR TITLE
Add  hypershift-cluster-cores to telemeter whitelist

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -86,6 +86,7 @@
   "{__name__=\"eo_es_misconfigured_memory_resources_info\"}",
   "{__name__=\"eo_es_redundancy_policy_info\"}",
   "{__name__=\"eo_es_storage_info\"}",
+  "{__name__=\"hypershift_cluster_cores\"}",
   "{__name__=\"imageregistry:imagestreamtags_count:sum\"}",
   "{__name__=\"imageregistry:operations_count:sum\"}",
   "{__name__=\"insightsclient_request_send_total\"}",

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -180,6 +180,7 @@ objects:
           - --whitelist={__name__="eo_es_misconfigured_memory_resources_info"}
           - --whitelist={__name__="eo_es_redundancy_policy_info"}
           - --whitelist={__name__="eo_es_storage_info"}
+          - --whitelist={__name__="hypershift_cluster_cores"}
           - --whitelist={__name__="imageregistry:imagestreamtags_count:sum"}
           - --whitelist={__name__="imageregistry:operations_count:sum"}
           - --whitelist={__name__="insightsclient_request_send_total"}
@@ -449,6 +450,7 @@ objects:
           - --whitelist={__name__="eo_es_misconfigured_memory_resources_info"}
           - --whitelist={__name__="eo_es_redundancy_policy_info"}
           - --whitelist={__name__="eo_es_storage_info"}
+          - --whitelist={__name__="hypershift_cluster_cores"}
           - --whitelist={__name__="imageregistry:imagestreamtags_count:sum"}
           - --whitelist={__name__="imageregistry:operations_count:sum"}
           - --whitelist={__name__="insightsclient_request_send_total"}


### PR DESCRIPTION
This PR adds the metric `hypershift-cluster-cores` used for billing to the telemeter whitelist.

Fixes: https://issues.redhat.com/browse/OSD-19886
