### PR TITLE
bump gubernator image to use new repo

### DIFF
--- a/resources/services/app-sre-stage-01/rhobs/observatorium-api-template.yaml
+++ b/resources/services/app-sre-stage-01/rhobs/observatorium-api-template.yaml
@@ -542,7 +542,7 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: gubernator
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: v2.0.0-rc.36
+      app.kubernetes.io/version: v2.6.0
     name: observatorium-gubernator
     namespace: rhobs
   spec:
@@ -562,7 +562,7 @@ objects:
           app.kubernetes.io/instance: observatorium
           app.kubernetes.io/name: gubernator
           app.kubernetes.io/part-of: observatorium
-          app.kubernetes.io/version: v2.0.0-rc.36
+          app.kubernetes.io/version: v2.6.0
         namespace: rhobs
       spec:
         affinity:
@@ -603,7 +603,7 @@ objects:
             value: k8s
           - name: GUBER_LOG_LEVEL
             value: info
-          image: quay.io/app-sre/gubernator:v2.0.0-rc.36
+          image: quay.io/app-sre/gubernator:v2.6.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
@@ -647,7 +647,7 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: gubernator
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: v2.0.0-rc.36
+      app.kubernetes.io/version: v2.6.0
     name: observatorium-gubernator
     namespace: rhobs
   rules:
@@ -668,7 +668,7 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: gubernator
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: v2.0.0-rc.36
+      app.kubernetes.io/version: v2.6.0
     name: observatorium-gubernator
     namespace: rhobs
   roleRef:

--- a/resources/services/observatorium-template.yaml
+++ b/resources/services/observatorium-template.yaml
@@ -1617,7 +1617,7 @@ parameters:
 - name: GUBERNATOR_CPU_REQUEST
   value: 300m
 - name: GUBERNATOR_IMAGE_TAG
-  value: v2.0.0-rc.36
+  value: v2.6.0
 - name: GUBERNATOR_IMAGE
   value: quay.io/app-sre/gubernator
 - name: GUBERNATOR_MEMORY_LIMIT

--- a/resources/services/telemeter-prod-01/rhobs/observatorium-api-template.yaml
+++ b/resources/services/telemeter-prod-01/rhobs/observatorium-api-template.yaml
@@ -716,7 +716,7 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: gubernator
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: v2.0.0-rc.36
+      app.kubernetes.io/version: v2.6.0
     name: observatorium-gubernator
   spec:
     replicas: 1
@@ -735,7 +735,7 @@ objects:
           app.kubernetes.io/instance: observatorium
           app.kubernetes.io/name: gubernator
           app.kubernetes.io/part-of: observatorium
-          app.kubernetes.io/version: v2.0.0-rc.36
+          app.kubernetes.io/version: v2.6.0
       spec:
         affinity:
           podAntiAffinity:
@@ -775,7 +775,7 @@ objects:
             value: k8s
           - name: GUBER_LOG_LEVEL
             value: info
-          image: quay.io/app-sre/gubernator:v2.0.0-rc.36
+          image: quay.io/app-sre/gubernator:v2.6.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 8
@@ -819,7 +819,7 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: gubernator
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: v2.0.0-rc.36
+      app.kubernetes.io/version: v2.6.0
     name: observatorium-gubernator
   rules:
   - apiGroups:
@@ -839,7 +839,7 @@ objects:
       app.kubernetes.io/instance: observatorium
       app.kubernetes.io/name: gubernator
       app.kubernetes.io/part-of: observatorium
-      app.kubernetes.io/version: v2.0.0-rc.36
+      app.kubernetes.io/version: v2.6.0
     name: observatorium-gubernator
   roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/services/observatorium-template.jsonnet
+++ b/services/observatorium-template.jsonnet
@@ -24,7 +24,7 @@ local obs = import 'observatorium.libsonnet';
     { name: 'AMS_URL', value: 'https://api.openshift.com' },
     { name: 'GUBERNATOR_CPU_LIMIT', value: '600m' },
     { name: 'GUBERNATOR_CPU_REQUEST', value: '300m' },
-    { name: 'GUBERNATOR_IMAGE_TAG', value: 'v2.0.0-rc.36' },
+    { name: 'GUBERNATOR_IMAGE_TAG', value: 'v2.6.0' },
     { name: 'GUBERNATOR_IMAGE', value: 'quay.io/app-sre/gubernator' },
     { name: 'GUBERNATOR_MEMORY_LIMIT', value: '200Mi' },
     { name: 'GUBERNATOR_MEMORY_REQUEST', value: '100Mi' },

--- a/services_go/observatorium/api.go
+++ b/services_go/observatorium/api.go
@@ -31,7 +31,7 @@ const (
 	obsApiImage          = "quay.io/observatorium/api"
 	obsApiTag            = "main-2023-12-06-62d7703"
 	gubernatorImage      = "quay.io/app-sre/gubernator"
-	gubernatorTag        = "v2.0.0-rc.36"
+	gubernatorTag        = "v2.6.0"
 	observatoriumUpImage = "quay.io/observatorium/up"
 	observatoriumUpTag   = "master-2022-03-24-098c31a"
 	avalancheImage       = "quay.io/prometheuscommunity/avalanche"


### PR DESCRIPTION
Repo moved to https://github.com/gubernator-io/gubernator and the new images are already mirrored to quay.io