### PR TITLE
MON-3707: Adding ipsec state metric into telemetry

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -146,6 +146,7 @@
   "{__name__=\"openshift:build_by_strategy:sum\"}",
   "{__name__=\"openshift:cpu_usage_cores:sum\"}",
   "{__name__=\"openshift:memory_usage_bytes:sum\"}",
+  "{__name__=\"openshift:openshift_network_operator_ipsec_state:info\"}",
   "{__name__=\"openshift:prometheus_tsdb_head_samples_appended_total:sum\"}",
   "{__name__=\"openshift:prometheus_tsdb_head_series:sum\"}",
   "{__name__=\"openshift_csi_share_configmap\"}",

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -240,6 +240,7 @@ objects:
           - --whitelist={__name__="openshift:build_by_strategy:sum"}
           - --whitelist={__name__="openshift:cpu_usage_cores:sum"}
           - --whitelist={__name__="openshift:memory_usage_bytes:sum"}
+          - --whitelist={__name__="openshift:openshift_network_operator_ipsec_state:info"}
           - --whitelist={__name__="openshift:prometheus_tsdb_head_samples_appended_total:sum"}
           - --whitelist={__name__="openshift:prometheus_tsdb_head_series:sum"}
           - --whitelist={__name__="openshift_csi_share_configmap"}
@@ -514,6 +515,7 @@ objects:
           - --whitelist={__name__="openshift:build_by_strategy:sum"}
           - --whitelist={__name__="openshift:cpu_usage_cores:sum"}
           - --whitelist={__name__="openshift:memory_usage_bytes:sum"}
+          - --whitelist={__name__="openshift:openshift_network_operator_ipsec_state:info"}
           - --whitelist={__name__="openshift:prometheus_tsdb_head_samples_appended_total:sum"}
           - --whitelist={__name__="openshift:prometheus_tsdb_head_series:sum"}
           - --whitelist={__name__="openshift_csi_share_configmap"}


### PR DESCRIPTION
Just the last part of adding this metric to Telemtery.
The metric was added to CNO in https://github.com/openshift/cluster-network-operator/pull/2346
and to the monitoring operator in https://github.com/openshift/cluster-monitoring-operator/pull/2326 