### PR TITLE
add a new metric of ACM managed cluster cpu cores on worker nodes

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -3,6 +3,7 @@
   "{__name__=\"ALERTS\",alertstate=\"firing\"}",
   "{__name__=\"acm_console_page_count:sum\", page=~\"overview-classic|overview-fleet|search|search-details|clusters|application|governance\"}",
   "{__name__=\"acm_managed_cluster_info\"}",
+  "{__name__=\"acm_managed_cluster_worker_cores:max\"}",
   "{__name__=\"apiserver_list_watch_request_success_total:rate:sum\", verb=~\"LIST|WATCH\"}",
   "{__name__=\"appsvcs:cores_by_product:sum\"}",
   "{__name__=\"cam_app_workload_migrations\"}",

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -97,6 +97,7 @@ objects:
           - --whitelist={__name__="alerts",alertstate="firing"}
           - --whitelist={__name__="acm_console_page_count:sum", page=~"overview-classic|overview-fleet|search|search-details|clusters|application|governance"}
           - --whitelist={__name__="acm_managed_cluster_info"}
+          - --whitelist={__name__="acm_managed_cluster_worker_cores:max"}
           - --whitelist={__name__="apiserver_list_watch_request_success_total:rate:sum", verb=~"LIST|WATCH"}
           - --whitelist={__name__="appsvcs:cores_by_product:sum"}
           - --whitelist={__name__="cam_app_workload_migrations"}
@@ -374,6 +375,7 @@ objects:
           - --whitelist={__name__="alerts",alertstate="firing"}
           - --whitelist={__name__="acm_console_page_count:sum", page=~"overview-classic|overview-fleet|search|search-details|clusters|application|governance"}
           - --whitelist={__name__="acm_managed_cluster_info"}
+          - --whitelist={__name__="acm_managed_cluster_worker_cores:max"}
           - --whitelist={__name__="apiserver_list_watch_request_success_total:rate:sum", verb=~"LIST|WATCH"}
           - --whitelist={__name__="appsvcs:cores_by_product:sum"}
           - --whitelist={__name__="cam_app_workload_migrations"}


### PR DESCRIPTION
The related issue: https://issues.redhat.com/browse/MON-3884