### PR TITLE
HOSTEDCP-1044: Add hypershift nodepool metrics to telemeter whitelist

### DIFF
--- a/configuration/telemeter/metrics.json
+++ b/configuration/telemeter/metrics.json
@@ -164,6 +164,8 @@
   "{__name__=\"os_image_url_override:sum\"}",
   "{__name__=\"platform:hypershift_hostedclusters:max\"}",
   "{__name__=\"platform:hypershift_nodepools:max\"}",
+  "{__name__=\"cluster_name:hypershift_nodepools_size:sum\"}",
+  "{__name__=\"cluster_name:hypershift_nodepools_available_replicas:sum\"}",
   "{__name__=\"pod:eo_es_shards_total:max\"}",
   "{__name__=\"profile:cluster_monitoring_operator_collection_profile:max\"}",
   "{__name__=\"rhacs:telemetry:rox_central_info\"}",

--- a/crds/loki.grafana.com_alertingrules.libsonnet
+++ b/crds/loki.grafana.com_alertingrules.libsonnet
@@ -7,11 +7,11 @@
     },
     creationTimestamp: null,
     labels: {
-      'app.kubernetes.io/instance': 'loki-operator-v0.6.1',
+      'app.kubernetes.io/instance': 'loki-operator-v0.6.2',
       'app.kubernetes.io/managed-by': 'operator-lifecycle-manager',
       'app.kubernetes.io/name': 'loki-operator',
       'app.kubernetes.io/part-of': 'loki-operator',
-      'app.kubernetes.io/version': '0.6.1',
+      'app.kubernetes.io/version': '0.6.2',
     },
     name: 'alertingrules.loki.grafana.com',
   },

--- a/crds/loki.grafana.com_recordingrules.libsonnet
+++ b/crds/loki.grafana.com_recordingrules.libsonnet
@@ -7,11 +7,11 @@
     },
     creationTimestamp: null,
     labels: {
-      'app.kubernetes.io/instance': 'loki-operator-v0.6.1',
+      'app.kubernetes.io/instance': 'loki-operator-v0.6.2',
       'app.kubernetes.io/managed-by': 'operator-lifecycle-manager',
       'app.kubernetes.io/name': 'loki-operator',
       'app.kubernetes.io/part-of': 'loki-operator',
-      'app.kubernetes.io/version': '0.6.1',
+      'app.kubernetes.io/version': '0.6.2',
     },
     name: 'recordingrules.loki.grafana.com',
   },

--- a/resources/crds/observatorium-logs-crds-template.yaml
+++ b/resources/crds/observatorium-logs-crds-template.yaml
@@ -10,11 +10,11 @@ objects:
       controller-gen.kubebuilder.io/version: v0.14.0
     creationTimestamp: null
     labels:
-      app.kubernetes.io/instance: loki-operator-v0.6.1
+      app.kubernetes.io/instance: loki-operator-v0.6.2
       app.kubernetes.io/managed-by: operator-lifecycle-manager
       app.kubernetes.io/name: loki-operator
       app.kubernetes.io/part-of: loki-operator
-      app.kubernetes.io/version: 0.6.1
+      app.kubernetes.io/version: 0.6.2
     name: alertingrules.loki.grafana.com
   spec:
     group: loki.grafana.com
@@ -356,11 +356,11 @@ objects:
       controller-gen.kubebuilder.io/version: v0.14.0
     creationTimestamp: null
     labels:
-      app.kubernetes.io/instance: loki-operator-v0.6.1
+      app.kubernetes.io/instance: loki-operator-v0.6.2
       app.kubernetes.io/managed-by: operator-lifecycle-manager
       app.kubernetes.io/name: loki-operator
       app.kubernetes.io/part-of: loki-operator
-      app.kubernetes.io/version: 0.6.1
+      app.kubernetes.io/version: 0.6.2
     name: recordingrules.loki.grafana.com
   spec:
     group: loki.grafana.com

--- a/resources/services/telemeter-template.yaml
+++ b/resources/services/telemeter-template.yaml
@@ -258,6 +258,8 @@ objects:
           - --whitelist={__name__="os_image_url_override:sum"}
           - --whitelist={__name__="platform:hypershift_hostedclusters:max"}
           - --whitelist={__name__="platform:hypershift_nodepools:max"}
+          - --whitelist={__name__="cluster_name:hypershift_nodepools_size:sum"}
+          - --whitelist={__name__="cluster_name:hypershift_nodepools_available_replicas:sum"}
           - --whitelist={__name__="pod:eo_es_shards_total:max"}
           - --whitelist={__name__="profile:cluster_monitoring_operator_collection_profile:max"}
           - --whitelist={__name__="rhacs:telemetry:rox_central_info"}
@@ -541,6 +543,8 @@ objects:
           - --whitelist={__name__="os_image_url_override:sum"}
           - --whitelist={__name__="platform:hypershift_hostedclusters:max"}
           - --whitelist={__name__="platform:hypershift_nodepools:max"}
+          - --whitelist={__name__="cluster_name:hypershift_nodepools_size:sum"}
+          - --whitelist={__name__="cluster_name:hypershift_nodepools_available_replicas:sum"}
           - --whitelist={__name__="pod:eo_es_shards_total:max"}
           - --whitelist={__name__="profile:cluster_monitoring_operator_collection_profile:max"}
           - --whitelist={__name__="rhacs:telemetry:rox_central_info"}


### PR DESCRIPTION
Adds 2 new metrics:
- `cluster_name:hypershift_nodepools_size:sum`
- `cluster_name:hypershift_nodepools_available_replicas:sum`