### PR TITLE
Fixing store lazy header parameterisation

### DIFF
--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -2912,7 +2912,7 @@ objects:
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
           - --max-time=${THANOS_STORE_MAX_TIME}
-          - --store.enable-index-header-lazy-reader=${THANOS_STORE_ENABLE_INDEX_HEADER_LAZY_READER}
+          - --store.enable-index-header-lazy-reader
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3170,7 +3170,7 @@ objects:
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
           - --max-time=${THANOS_STORE_MAX_TIME}
-          - --store.enable-index-header-lazy-reader=${THANOS_STORE_ENABLE_INDEX_HEADER_LAZY_READER}
+          - --store.enable-index-header-lazy-reader
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3428,7 +3428,7 @@ objects:
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
           - --max-time=${THANOS_STORE_MAX_TIME}
-          - --store.enable-index-header-lazy-reader=${THANOS_STORE_ENABLE_INDEX_HEADER_LAZY_READER}
+          - --store.enable-index-header-lazy-reader
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3686,7 +3686,7 @@ objects:
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
           - --max-time=${THANOS_STORE_MAX_TIME}
-          - --store.enable-index-header-lazy-reader=${THANOS_STORE_ENABLE_INDEX_HEADER_LAZY_READER}
+          - --store.enable-index-header-lazy-reader
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -3944,7 +3944,7 @@ objects:
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
           - --max-time=${THANOS_STORE_MAX_TIME}
-          - --store.enable-index-header-lazy-reader=${THANOS_STORE_ENABLE_INDEX_HEADER_LAZY_READER}
+          - --store.enable-index-header-lazy-reader
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -4202,7 +4202,7 @@ objects:
           - --store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}
           - --store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}
           - --max-time=${THANOS_STORE_MAX_TIME}
-          - --store.enable-index-header-lazy-reader=${THANOS_STORE_ENABLE_INDEX_HEADER_LAZY_READER}
+          - --store.enable-index-header-lazy-reader
           env:
           - name: OBJSTORE_CONFIG
             valueFrom:
@@ -4621,8 +4621,6 @@ parameters:
   value: "5"
 - name: THANOS_STORE_MAX_TIME
   value: "9999-12-31T23:59:59Z"
-- name: THANOS_STORE_ENABLE_INDEX_HEADER_LAZY_READER
-  value: "false"
 - name: CONFIGMAP_RELOADER_IMAGE
   value: quay.io/openshift/origin-configmap-reloader
 - name: CONFIGMAP_RELOADER_IMAGE_TAG

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -171,7 +171,7 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                         '--store.grpc.touched-series-limit=${THANOS_STORE_SERIES_TOUCHED_LIMIT}',
                         '--store.grpc.series-sample-limit=${THANOS_STORE_SERIES_SAMPLE_LIMIT}',
                         '--max-time=${THANOS_STORE_MAX_TIME}',
-                        '--store.enable-index-header-lazy-reader=${THANOS_STORE_ENABLE_INDEX_HEADER_LAZY_READER}',
+                        '--store.enable-index-header-lazy-reader',
                       ],
                     } else c
                     for c in super.containers

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -166,7 +166,6 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_STORE_MEMORY_REQUEST', value: '1Gi' },
     { name: 'THANOS_STORE_REPLICAS', value: '5' },
     { name: 'THANOS_STORE_MAX_TIME', value: '9999-12-31T23:59:59Z' },
-    { name: 'THANOS_STORE_ENABLE_INDEX_HEADER_LAZY_READER', value: 'false' },
     { name: 'CONFIGMAP_RELOADER_IMAGE', value: 'quay.io/openshift/origin-configmap-reloader' },
     { name: 'CONFIGMAP_RELOADER_IMAGE_TAG', value: '4.5.0' },
   ],


### PR DESCRIPTION
Flag is either available or not - parameterising is tricky as we can't manipulate the flag ahead of time unless the value is true/false at template generation. 

I'm setting it to enable by default first if it works as expected we can rollout to prod.