### PR TITLE
Adding compactor concurrency flags

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -230,7 +230,7 @@
           "subdir": "configuration"
         }
       },
-      "version": "e743a6abc673774e60bf37b94e6454e542db46f0",
+      "version": "e59b139d57c7d5f60dbc43c061257d5139032e4b",
       "sum": "AuUPEXXfd/hxMbKWdURRKaCTBPcTJD4cs9XApBIZbiA="
     },
     {

--- a/resources/services/observatorium-metrics-template.yaml
+++ b/resources/services/observatorium-metrics-template.yaml
@@ -144,6 +144,8 @@ objects:
           - --downsample.concurrency=1
           - --deduplication.replica-label=replica
           - --debug.max-compaction-level=3
+          - --compact.concurrency=${THANOS_COMPACTOR_COMPACT_CONCURRENCY}
+          - --downsample.concurrency=${THANOS_COMPACTOR_DOWNSAMPLE_CONCURRENCY}
           - ${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}
           env:
           - name: OBJSTORE_CONFIG
@@ -4452,6 +4454,10 @@ parameters:
 - name: THANOS_COMPACTOR_PVC_REQUEST
   value: 50Gi
 - name: THANOS_COMPACTOR_REPLICAS
+  value: "1"
+- name: THANOS_COMPACTOR_COMPACT_CONCURRENCY
+  value: "1"
+- name: THANOS_COMPACTOR_DOWNSAMPLE_CONCURRENCY
   value: "1"
 - name: THANOS_CONFIG_SECRET
   value: thanos-objectstorage

--- a/services/observatorium-metrics-template-overwrites.libsonnet
+++ b/services/observatorium-metrics-template-overwrites.libsonnet
@@ -92,7 +92,11 @@ local thanosRuleSyncer = import './sidecars/thanos-rule-syncer.libsonnet';
                   // Temporary workaround on high cardinality blocks for 2w.
                   // Since we have only 2w retention, there is no point in having 2w blocks.
                   // See: https://issues.redhat.com/browse/OBS-437
-                  args+: ['--debug.max-compaction-level=3'] + disableDownsamplingFlag,
+                  args+: [
+                    '--debug.max-compaction-level=3',
+                    '--compact.concurrency=${THANOS_COMPACTOR_COMPACT_CONCURRENCY}',
+                    '--downsample.concurrency=${THANOS_COMPACTOR_DOWNSAMPLE_CONCURRENCY}',
+                  ] + disableDownsamplingFlag,
                 } else c
                 for c in super.containers
               ],

--- a/services/observatorium-metrics-template.jsonnet
+++ b/services/observatorium-metrics-template.jsonnet
@@ -76,6 +76,8 @@ local obs = import 'observatorium.libsonnet';
     { name: 'THANOS_COMPACTOR_MEMORY_REQUEST', value: '1Gi' },
     { name: 'THANOS_COMPACTOR_PVC_REQUEST', value: '50Gi' },
     { name: 'THANOS_COMPACTOR_REPLICAS', value: '1' },
+    { name: 'THANOS_COMPACTOR_COMPACT_CONCURRENCY', value: '1' },
+    { name: 'THANOS_COMPACTOR_DOWNSAMPLE_CONCURRENCY', value: '1' },
     { name: 'THANOS_CONFIG_SECRET', value: 'thanos-objectstorage' },
     { name: 'THANOS_IMAGE_TAG', value: 'v0.36.0' },
     { name: 'THANOS_IMAGE', value: 'quay.io/thanos/thanos' },


### PR DESCRIPTION
Couldn't use the params because kube-thanos does typechecks on those and doesn't like openshift template variables that aren't resolved at generation time. 