### PR TITLE
Removing matcher param to get recording rule blocks and adding compaction level max to avoid copying non-compacted blocks (for-now).

### DIFF
--- a/resources/operations/bucket-replicate/cron-job-template.yaml
+++ b/resources/operations/bucket-replicate/cron-job-template.yaml
@@ -23,7 +23,7 @@ parameters:
   - name: DESTINATION_OBJ_STORE_K8S_SECRET_KEY
     value: 'config.yaml'
   - name: COMPACTION_MIN
-    value: '0'
+    value: '3'
   - name: COMPACTION_MAX
     value: '100'
   - name: MIN_TIME
@@ -91,7 +91,6 @@ objects:
                     - '--objstore.config-file=/var/lib/thanos/bucket-replicate-config/from/${SOURCE_OBJ_STORE_K8S_SECRET_KEY}'
                     - '--objstore-to.config-file=/var/lib/thanos/bucket-replicate-config/to/${DESTINATION_OBJ_STORE_K8S_SECRET_KEY}'
                     - '--single-run'
-                    - '--matcher=tenant_id="${TENANT_ID}"'
                     - '--min-time=${MIN_TIME}'
                     - '--max-time=${MAX_TIME}'
                     - '--compaction-min=${COMPACTION_MIN}'


### PR DESCRIPTION
* Removing matcher param to make sure we pick up the non-tenanted recording rule blocks
* Setting min-compaction to 3 to avoid copying blocks that later have to be re-compacted/duplicated over time (e.g. we copy the raw blocks from receivers, in two hours we also copy the compacted blocks by telemeter compaction and we have to double-compact)


After this - I'll raise a PR to repoint to the telemeter-lts bucket (>120Gi of DH metrics), then I will repoint the rhobs namespace thanos compactor to that bucket as well so we can monitor compaction. 