### PR TITLE
alertmanager: Extract service monitor from large template

### DIFF
--- a/magefiles/lib.go
+++ b/magefiles/lib.go
@@ -4,17 +4,23 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/bwplotka/mimic/encoding"
 	kghelpers "github.com/observatorium/observatorium/configuration_go/kubegen/helpers"
+	"github.com/observatorium/observatorium/configuration_go/kubegen/openshift"
 	"github.com/observatorium/observatorium/configuration_go/kubegen/workload"
 	templatev1 "github.com/openshift/api/template/v1"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
 	servingCertSecretNameAnnotation = "service.alpha.openshift.io/serving-cert-secret-name"
 	serviceRedirectAnnotation       = "serviceaccounts.openshift.io/oauth-redirectreference.application"
+
+	serviceMonitorTemplate = "service-monitor-template.yaml"
 )
 
 type resourceRequirements struct {
@@ -93,8 +99,44 @@ func makeOauthProxy(upstreamPort int32, namespace, serviceAccount, tlsSecret str
 	}
 }
 
+func getAndRemoveObject[T metav1.Object](objects []runtime.Object, name string) (T, []runtime.Object) {
+	var ret T
+	var atIndex int
+	found := false
+
+	for i, obj := range objects {
+		typedObject, ok := obj.(T)
+		if ok {
+			if name != "" && typedObject.GetName() != name {
+				continue
+			}
+
+			// Check if we already found an object of this type. If so, panic.
+			if found {
+				panic(fmt.Sprintf("found multiple objects of type %T", *new(T)))
+			}
+
+			ret = typedObject
+			found = true
+			atIndex = i
+			break
+		}
+	}
+
+	if !found {
+		panic(fmt.Sprintf("could not find object of type %T", *new(T)))
+	}
+	var modifiedObjs []runtime.Object
+	for i := range objects {
+		if i != atIndex {
+			modifiedObjs = append(modifiedObjs, objects[i])
+		}
+	}
+	return ret, modifiedObjs
+}
+
 // postProcessServiceMonitor updates the service monitor to work with the app-sre prometheus.
-func postProcessServiceMonitor(serviceMonitor *monv1.ServiceMonitor, namespaceSelector string) {
+func postProcessServiceMonitor(serviceMonitor *monv1.ServiceMonitor, namespaceSelector string) encoding.Encoder {
 	const (
 		openshiftCustomerMonitoringLabel     = "prometheus"
 		openShiftClusterMonitoringLabelValue = "app-sre"
@@ -103,6 +145,13 @@ func postProcessServiceMonitor(serviceMonitor *monv1.ServiceMonitor, namespaceSe
 	serviceMonitor.ObjectMeta.Namespace = "openshift-customer-monitoring"
 	serviceMonitor.Spec.NamespaceSelector.MatchNames = []string{namespaceSelector}
 	serviceMonitor.ObjectMeta.Labels[openshiftCustomerMonitoringLabel] = openShiftClusterMonitoringLabelValue
+
+	name := serviceMonitor.Name + "-service-monitor"
+
+	template := openshift.WrapInTemplate([]runtime.Object{serviceMonitor}, metav1.ObjectMeta{
+		Name: name,
+	}, nil)
+	return encoding.GhodssYAML(template)
 }
 
 func sortTemplateParams(params []templatev1.Parameter) []templatev1.Parameter {

--- a/resources/services/alertmanager/staging/alertmanager-template.yaml
+++ b/resources/services/alertmanager/staging/alertmanager-template.yaml
@@ -99,37 +99,6 @@ objects:
       app.kubernetes.io/part-of: observatorium
     name: alertmanager
     namespace: rhobs-stage
-- apiVersion: monitoring.coreos.com/v1
-  kind: ServiceMonitor
-  metadata:
-    creationTimestamp: null
-    labels:
-      app.kubernetes.io/component: alertmanager
-      app.kubernetes.io/instance: observatorium
-      app.kubernetes.io/name: alertmanager
-      app.kubernetes.io/part-of: observatorium
-      prometheus: app-sre
-    name: alertmanager
-    namespace: openshift-customer-monitoring
-  spec:
-    endpoints:
-    - port: http
-      relabelings:
-      - action: replace
-        separator: /
-        sourceLabels:
-        - namespace
-        - pod
-        targetLabel: instance
-    namespaceSelector:
-      matchNames:
-      - rhobs-stage
-    selector:
-      matchLabels:
-        app.kubernetes.io/component: alertmanager
-        app.kubernetes.io/instance: observatorium
-        app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/part-of: observatorium
 - apiVersion: apps/v1
   kind: StatefulSet
   metadata:

--- a/resources/services/alertmanager/staging/service-monitor-template.yaml
+++ b/resources/services/alertmanager/staging/service-monitor-template.yaml
@@ -1,0 +1,37 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: alertmanager-service-monitor
+objects:
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/component: alertmanager
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: observatorium
+      prometheus: app-sre
+    name: alertmanager
+    namespace: openshift-customer-monitoring
+  spec:
+    endpoints:
+    - port: http
+      relabelings:
+      - action: replace
+        separator: /
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: instance
+    namespaceSelector:
+      matchNames:
+      - rhobs-stage
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: alertmanager
+        app.kubernetes.io/part-of: observatorium


### PR DESCRIPTION
This change removes the ServiceMonitor from the workload template. I think this is better because of the way the templates are held in GitOps. We can specify both the workload and the monitor now in the same file.