### PR TITLE
Add MAX_AGE to rclone job, default to 4w. Will only replicate objects…

### DIFF
--- a/resources/operations/rclone-bucket-replicate/job-template.yaml
+++ b/resources/operations/rclone-bucket-replicate/job-template.yaml
@@ -30,6 +30,8 @@ parameters:
     value: '500Mi'
   - name: MEMORY_LIMIT
     value: '3Gi'
+  - name: MAX_AGE
+    value: '4w'
   - name: OBJ_STORE_CONFIG_SECRET_NAME
   - name: RCLONE_CONFIG_MAP_NAME
   - name: SOURCE_ENDPOINT
@@ -73,6 +75,7 @@ objects:
                 - 'copy'
                 - ${SOURCE_ENDPOINT}:${SOURCE_BUCKET}
                 - ${TARGET_ENDPOINT}:${TARGET_BUCKET}
+                - '--max-age=${MAX_AGE}'
                 - '--rc'
                 - '--rc-enable-metrics'
                 - '--rc-addr=:10902'


### PR DESCRIPTION
… younger than 4w.

https://rclone.org/commands/rclone_copy/

     ` --max-age Duration                    Only transfer files younger than this in s or suffix ms|s|m|h|d|w|M|y (default off)`
