### PR TITLE
RHOBS-904: Standalone Store and Compactor for RH Resource Optimisation (ROS) Managed Service

### DIFF
--- a/magefiles/gateway.go
+++ b/magefiles/gateway.go
@@ -630,6 +630,14 @@ func stageGatewayTenants(m TemplateMaps, namespace string) *corev1.Secret {
           issuerURL: https://sso.redhat.com/auth/realms/redhat-external
           redirectURL: https://observatorium.api.stage.openshift.com/oidc/telemeter/callback
           usernameClaim: preferred_username
+      - id: B5B43A0A-3BC5-4D8D-BAAB-E424A835AA7D
+        name: ros
+        oidc:
+          clientID: ${CLIENT_ID}
+          clientSecret: ${CLIENT_SECRET}
+          issuerURL: https://sso.redhat.com/auth/realms/redhat-external
+          redirectURL: https://observatorium.api.stage.openshift.com/oidc/telemeter/callback
+          usernameClaim: preferred_username
 `,
 		},
 	}

--- a/magefiles/template.go
+++ b/magefiles/template.go
@@ -67,12 +67,14 @@ var StageImages = ParamMap[string]{
 	"STORE02W":                   thanosImage,
 	"STORE2W90D":                 thanosImage,
 	"STORE90D+":                  thanosImage,
+	"STORE_ROS":                  thanosImage,
 	"STORE_DEFAULT":              thanosImage,
 	"RECEIVE_ROUTER":             thanosImage,
 	"RECEIVE_INGESTOR_TELEMETER": thanosImage,
 	"RECEIVE_INGESTOR_DEFAULT":   thanosImage,
 	"RULER":                      thanosImage,
 	"COMPACT_DEFAULT":            thanosImage,
+	"COMPACT_ROS":                thanosImage,
 	"COMPACT_TELEMETER":          thanosImage,
 	"QUERY":                      thanosImage,
 	"QUERY_FRONTEND":             thanosImage,
@@ -90,12 +92,14 @@ var StageVersions = ParamMap[string]{
 	"STORE02W":                   thanosVersionStage,
 	"STORE2W90D":                 thanosVersionStage,
 	"STORE90D+":                  thanosVersionStage,
+	"STORE_ROS":                  thanosVersionStage,
 	"STORE_DEFAULT":              thanosVersionStage,
 	"RECEIVE_ROUTER":             thanosVersionStage,
 	"RECEIVE_INGESTOR_TELEMETER": thanosVersionStage,
 	"RECEIVE_INGESTOR_DEFAULT":   thanosVersionStage,
 	"RULER":                      thanosVersionStage,
 	"COMPACT_DEFAULT":            thanosVersionStage,
+	"COMPACT_ROS":                thanosVersionStage,
 	"COMPACT_TELEMETER":          thanosVersionStage,
 	"QUERY":                      thanosVersionStage,
 	"QUERY_FRONTEND":             thanosVersionStage,
@@ -108,12 +112,14 @@ var StageLogLevels = ParamMap[string]{
 	"STORE02W":                   logLevels[1],
 	"STORE2W90D":                 logLevels[1],
 	"STORE90D+":                  logLevels[1],
+	"STORE_ROS":                  logLevels[1],
 	"STORE_DEFAULT":              logLevels[1],
 	"RECEIVE_ROUTER":             logLevels[1],
 	"RECEIVE_INGESTOR_TELEMETER": logLevels[1],
 	"RECEIVE_INGESTOR_DEFAULT":   logLevels[1],
 	"RULER":                      logLevels[1],
 	"COMPACT_DEFAULT":            logLevels[1],
+	"COMPACT_ROS":                logLevels[1],
 	"COMPACT_TELEMETER":          logLevels[1],
 	"QUERY":                      logLevels[1],
 	"QUERY_FRONTEND":             logLevels[1],
@@ -125,11 +131,13 @@ var StageStorageSize = ParamMap[v1alpha1.StorageSize]{
 	"STORE02W":          "512Mi",
 	"STORE2W90D":        "512Mi",
 	"STORE90D+":         "512Mi",
+	"STORE_ROS":         "512Mi",
 	"STORE_DEFAULT":     "512Mi",
 	"RECEIVE_TELEMETER": "3Gi",
 	"RECEIVE_DEFAULT":   "3Gi",
 	"RULER":             "512Mi",
 	"COMPACT_DEFAULT":   "512Mi",
+	"COMPACT_ROS":       "512Mi",
 	"COMPACT_TELEMETER": "512Mi",
 }
 
@@ -138,6 +146,7 @@ var StageReplicas = ParamMap[int32]{
 	"STORE02W":                   3,
 	"STORE2W90D":                 3,
 	"STORE90D+":                  3,
+	"STORE_ROS":                  3,
 	"STORE_DEFAULT":              3,
 	"RECEIVE_ROUTER":             3,
 	"RECEIVE_INGESTOR_TELEMETER": 6,
@@ -172,6 +181,16 @@ var StageResourceRequirements = ParamMap[corev1.ResourceRequirements]{
 		},
 	},
 	"STORE90D+": corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+	},
+	"STORE_ROS": corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),
 			corev1.ResourceMemory: resource.MustParse("512Mi"),
@@ -232,6 +251,16 @@ var StageResourceRequirements = ParamMap[corev1.ResourceRequirements]{
 		},
 	},
 	"COMPACT_DEFAULT": corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("5Gi"),
+		},
+	},
+	"COMPACT_ROS": corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 			corev1.ResourceMemory: resource.MustParse("1Gi"),
@@ -339,6 +368,13 @@ var StageObjectStorageBucket = ParamMap[v1alpha1.ObjectStorageConfig]{
 		},
 		Optional: ptr.To(false),
 	},
+	"ROS": v1alpha1.ObjectStorageConfig{
+		Key: "thanos.yaml",
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: "observatorium-ros-objectstorage",
+		},
+		Optional: ptr.To(false),
+	},
 }
 
 // ProductionImages is a map of production images.
@@ -346,6 +382,7 @@ var ProductionImages = ParamMap[string]{
 	"STORE02W":        thanosImage,
 	"STORE2W90D":      thanosImage,
 	"STORE90D+":       thanosImage,
+	"STORE_ROS":       thanosImage,
 	"STORE_DEFAULT":   thanosImage,
 	"QUERY":           thanosImage,
 	"QUERY_FRONTEND":  thanosImage,
@@ -362,6 +399,7 @@ var ProductionVersions = ParamMap[string]{
 	"STORE02W":       thanosVersionProd,
 	"STORE2W90D":     thanosVersionProd,
 	"STORE90D+":      thanosVersionProd,
+	"STORE_ROS":      thanosVersionProd,
 	"STORE_DEFAULT":  thanosVersionProd,
 	"QUERY":          thanosVersionProd,
 	"QUERY_FRONTEND": thanosVersionProd,
@@ -374,6 +412,7 @@ var ProductionLogLevels = ParamMap[string]{
 	"STORE02W":       logLevels[0],
 	"STORE2W90D":     logLevels[0],
 	"STORE90D+":      logLevels[0],
+	"STORE_ROS":      logLevels[0],
 	"STORE_DEFAULT":  logLevels[0],
 	"QUERY":          logLevels[0],
 	"QUERY_FRONTEND": logLevels[0],
@@ -385,6 +424,7 @@ var ProductionStorageSize = ParamMap[v1alpha1.StorageSize]{
 	"STORE02W":      "300Gi",
 	"STORE2W90D":    "300Gi",
 	"STORE90D+":     "300Gi",
+	"STORE_ROS":     "300Gi",
 	"STORE_DEFAULT": "300Gi",
 }
 
@@ -393,6 +433,7 @@ var ProductionReplicas = ParamMap[int32]{
 	"STORE02W":       2,
 	"STORE2W90D":     2,
 	"STORE90D+":      1,
+	"STORE_ROS":      0, //TODO @moadz RHOBS-904: Temporary stage-only configuration for ROS disabled in Production.
 	"STORE_DEFAULT":  2,
 	"QUERY":          3,
 	"QUERY_FRONTEND": 3,
@@ -415,6 +456,12 @@ var ProductionResourceRequirements = ParamMap[corev1.ResourceRequirements]{
 		},
 	},
 	"STORE90D+": corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	},
+	"STORE_ROS": corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),
 			corev1.ResourceMemory: resource.MustParse("512Mi"),
@@ -506,6 +553,13 @@ var ProductionObjectStorageBucket = ParamMap[v1alpha1.ObjectStorageConfig]{
 		},
 		Optional: ptr.To(false),
 	},
+	"ROS": v1alpha1.ObjectStorageConfig{
+		Key: "thanos.yaml",
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: "observatorium-ros-objectstorage",
+		},
+		Optional: ptr.To(false),
+	},
 }
 
 var StageMaps = TemplateMaps{
@@ -562,12 +616,14 @@ var LocalImages = ParamMap[string]{
 	"STORE02W":                   localThanosImage,
 	"STORE2W90D":                 localThanosImage,
 	"STORE90D+":                  localThanosImage,
+	"STORE_ROS":                  localThanosImage,
 	"STORE_DEFAULT":              localThanosImage,
 	"RECEIVE_ROUTER":             localThanosImage,
 	"RECEIVE_INGESTOR_TELEMETER": localThanosImage,
 	"RECEIVE_INGESTOR_DEFAULT":   localThanosImage,
 	"RULER":                      localThanosImage,
 	"COMPACT_DEFAULT":            localThanosImage,
+	"COMPACT_ROS":                localThanosImage,
 	"COMPACT_TELEMETER":          localThanosImage,
 	"QUERY":                      localThanosImage,
 	"QUERY_FRONTEND":             localThanosImage,
@@ -580,13 +636,14 @@ var LocalImages = ParamMap[string]{
 var LocalVersions = ParamMap[string]{
 	"STORE02W":                   localThanosVersion,
 	"STORE2W90D":                 localThanosVersion,
-	"STORE90D+":                  localThanosVersion,
+	"STORE_ROS":                  localThanosVersion,
 	"STORE_DEFAULT":              localThanosVersion,
 	"RECEIVE_ROUTER":             localThanosVersion,
 	"RECEIVE_INGESTOR_TELEMETER": localThanosVersion,
 	"RECEIVE_INGESTOR_DEFAULT":   localThanosVersion,
 	"RULER":                      localThanosVersion,
 	"COMPACT_DEFAULT":            localThanosVersion,
+	"COMPACT_ROS":                localThanosVersion,
 	"COMPACT_TELEMETER":          localThanosVersion,
 	"QUERY":                      localThanosVersion,
 	"QUERY_FRONTEND":             localThanosVersion,
@@ -597,11 +654,13 @@ var LocalStorageSize = ParamMap[v1alpha1.StorageSize]{
 	"STORE02W":          "1Gi",
 	"STORE2W90D":        "1Gi",
 	"STORE90D+":         "1Gi",
+	"STORE_ROS":         "1Gi",
 	"STORE_DEFAULT":     "1Gi",
 	"RECEIVE_TELEMETER": "1Gi",
 	"RECEIVE_DEFAULT":   "1Gi",
 	"RULER":             "1Gi",
 	"COMPACT_DEFAULT":   "1Gi",
+	"COMPACT_ROS":       "1Gi",
 	"COMPACT_TELEMETER": "1Gi",
 }
 
@@ -610,12 +669,14 @@ var LocalResourceRequirements = ParamMap[corev1.ResourceRequirements]{
 	"STORE02W":                   getLocalResources(),
 	"STORE2W90D":                 getLocalResources(),
 	"STORE90D+":                  getLocalResources(),
+	"STORE_ROS":                  getLocalResources(),
 	"STORE_DEFAULT":              getLocalResources(),
 	"RECEIVE_ROUTER":             getLocalResources(),
 	"RECEIVE_INGESTOR_TELEMETER": getLocalResources(),
 	"RECEIVE_INGESTOR_DEFAULT":   getLocalResources(),
 	"RULER":                      getLocalResources(),
 	"COMPACT_DEFAULT":            getLocalResources(),
+	"COMPACT_ROS":                getLocalResources(),
 	"COMPACT_TELEMETER":          getLocalResources(),
 	"QUERY":                      getLocalResources(),
 	"QUERY_FRONTEND":             getLocalResources(),

--- a/resources/services/observatorium-api/staging/observatorium-api-template.yaml
+++ b/resources/services/observatorium-api/staging/observatorium-api-template.yaml
@@ -708,6 +708,14 @@ objects:
                 issuerURL: https://sso.redhat.com/auth/realms/redhat-external
                 redirectURL: https://observatorium.api.stage.openshift.com/oidc/telemeter/callback
                 usernameClaim: preferred_username
+            - id: B5B43A0A-3BC5-4D8D-BAAB-E424A835AA7D
+              name: ros
+              oidc:
+                clientID: ${CLIENT_ID}
+                clientSecret: ${CLIENT_SECRET}
+                issuerURL: https://sso.redhat.com/auth/realms/redhat-external
+                redirectURL: https://observatorium.api.stage.openshift.com/oidc/telemeter/callback
+                usernameClaim: preferred_username
 - apiVersion: v1
   kind: Service
   metadata:

--- a/resources/services/rhobs-thanos-operator/staging/rhobs.yaml
+++ b/resources/services/rhobs-thanos-operator/staging/rhobs.yaml
@@ -78,7 +78,6 @@ objects:
       lazyReaderIdleTimeout: 5m
     logFormat: logfmt
     logLevel: info
-    maxTime: -22h
     objectStorageConfig:
       key: thanos.yaml
       name: observatorium-mst-thanos-objectstorage
@@ -96,6 +95,193 @@ objects:
       type: block
     storageSize: 512Mi
     storeLimitsOptions: {}
+    timeRangeConfig:
+      maxTime: -22h
+    version: 03c9fefbda1b33830a950bd28484fa0a1e039555
+  status: {}
+- apiVersion: monitoring.thanos.io/v1alpha1
+  kind: ThanosStore
+  metadata:
+    creationTimestamp: null
+    name: default
+    namespace: rhobs-stage
+  spec:
+    additionalArgs:
+    - |-
+      --tracing.config="config":
+        "sampler_param": 2
+        "sampler_type": "ratelimiting"
+        "service_name": "thanos-store"
+      "type": "JAEGER"
+    additionalContainers:
+    - args:
+      - --reporter.grpc.host-port=dns:///otel-trace-writer-collector-headless.observatorium-tools.svc:14250
+      - --reporter.type=grpc
+      - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+      env:
+      - name: NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: POD
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      image: registry.redhat.io/rhosdt/jaeger-agent-rhel8:1.57.0-10
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 5
+        httpGet:
+          path: /
+          port: 14271
+          scheme: HTTP
+        initialDelaySeconds: 1
+      name: jaeger-agent
+      ports:
+      - containerPort: 5778
+        name: configs
+      - containerPort: 6831
+        name: jaeger-thrift
+      - containerPort: 14271
+        name: metrics
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 14271
+          scheme: HTTP
+        initialDelaySeconds: 1
+      resources:
+        limits:
+          cpu: 128m
+          memory: 128Mi
+        requests:
+          cpu: 32m
+          memory: 64Mi
+    baseImage: quay.io/redhat-user-workloads/rhobs-mco-tenant/rhobs-konflux-thanos
+    blockConfig:
+      blockDiscoveryStrategy: concurrent
+      blockFilesConcurrency: 1
+      blockMetaFetchConcurrency: 32
+    featureGates:
+      serviceMonitor:
+        enable: false
+    ignoreDeletionMarksDelay: 24h
+    imagePullPolicy: IfNotPresent
+    indexHeaderConfig:
+      enableLazyReader: true
+      lazyDownloadStrategy: lazy
+      lazyReaderIdleTimeout: 5m
+    logFormat: logfmt
+    logLevel: info
+    objectStorageConfig:
+      key: thanos.yaml
+      name: observatorium-ros-objectstorage
+      optional: false
+    replicas: 3
+    resourceRequirements:
+      limits:
+        cpu: 250m
+        memory: 2Gi
+      requests:
+        cpu: 50m
+        memory: 512Mi
+    shardingStrategy:
+      shards: 1
+      type: block
+    storageSize: 512Mi
+    storeLimitsOptions: {}
+    version: 03c9fefbda1b33830a950bd28484fa0a1e039555
+  status: {}
+- apiVersion: monitoring.thanos.io/v1alpha1
+  kind: ThanosCompact
+  metadata:
+    creationTimestamp: null
+    name: rhobs
+    namespace: rhobs-stage
+  spec:
+    additionalArgs:
+    - |-
+      --tracing.config="config":
+        "sampler_param": 2
+        "sampler_type": "ratelimiting"
+        "service_name": "thanos-compact"
+      "type": "JAEGER"
+    additionalContainers:
+    - args:
+      - --reporter.grpc.host-port=dns:///otel-trace-writer-collector-headless.observatorium-tools.svc:14250
+      - --reporter.type=grpc
+      - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+      env:
+      - name: NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: POD
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      image: registry.redhat.io/rhosdt/jaeger-agent-rhel8:1.57.0-10
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 5
+        httpGet:
+          path: /
+          port: 14271
+          scheme: HTTP
+        initialDelaySeconds: 1
+      name: jaeger-agent
+      ports:
+      - containerPort: 5778
+        name: configs
+      - containerPort: 6831
+        name: jaeger-thrift
+      - containerPort: 14271
+        name: metrics
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 14271
+          scheme: HTTP
+        initialDelaySeconds: 1
+      resources:
+        limits:
+          cpu: 128m
+          memory: 128Mi
+        requests:
+          cpu: 32m
+          memory: 64Mi
+    baseImage: quay.io/redhat-user-workloads/rhobs-mco-tenant/rhobs-konflux-thanos
+    compactConfig:
+      compactConcurrency: 1
+    debugConfig:
+      acceptMalformedIndex: true
+      haltOnError: true
+      maxCompactionLevel: 3
+    downsamplingConfig:
+      disable: false
+      downsamplingConcurrency: 1
+    featureGates:
+      serviceMonitor:
+        enable: false
+    imagePullPolicy: IfNotPresent
+    logFormat: logfmt
+    logLevel: info
+    objectStorageConfig:
+      key: thanos.yaml
+      name: observatorium-ros-objectstorage
+      optional: false
+    resourceRequirements:
+      limits:
+        cpu: "1"
+        memory: 5Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
+    retentionConfig:
+      fiveMinutes: 14d
+      oneHour: 14d
+      raw: 14d
+    storageSize: 512Mi
     version: 03c9fefbda1b33830a950bd28484fa0a1e039555
   status: {}
 - apiVersion: monitoring.thanos.io/v1alpha1
@@ -586,7 +772,6 @@ objects:
       lazyReaderIdleTimeout: 5m
     logFormat: logfmt
     logLevel: info
-    maxTime: -2w
     objectStorageConfig:
       key: thanos.yaml
       name: thanos-objectstorage
@@ -606,6 +791,8 @@ objects:
     storeLimitsOptions:
       storeLimitsRequestSamples: 627040000
       storeLimitsRequestSeries: 1000000
+    timeRangeConfig:
+      maxTime: -2w
     version: 03c9fefbda1b33830a950bd28484fa0a1e039555
   status: {}
 - apiVersion: monitoring.thanos.io/v1alpha1
@@ -684,8 +871,6 @@ objects:
       lazyReaderIdleTimeout: 5m
     logFormat: logfmt
     logLevel: info
-    maxTime: -2w
-    minTime: -90d
     objectStorageConfig:
       key: thanos.yaml
       name: thanos-objectstorage
@@ -705,6 +890,9 @@ objects:
     storeLimitsOptions:
       storeLimitsRequestSamples: 627040000
       storeLimitsRequestSeries: 1000000
+    timeRangeConfig:
+      maxTime: -2w
+      minTime: -90d
     version: 03c9fefbda1b33830a950bd28484fa0a1e039555
   status: {}
 - apiVersion: monitoring.thanos.io/v1alpha1
@@ -781,7 +969,6 @@ objects:
       lazyReaderIdleTimeout: 5m
     logFormat: logfmt
     logLevel: info
-    minTime: -90d
     objectStorageConfig:
       key: thanos.yaml
       name: thanos-objectstorage
@@ -801,6 +988,8 @@ objects:
     storeLimitsOptions:
       storeLimitsRequestSamples: 627040000
       storeLimitsRequestSeries: 1000000
+    timeRangeConfig:
+      minTime: -90d
     version: 03c9fefbda1b33830a950bd28484fa0a1e039555
   status: {}
 - apiVersion: route.openshift.io/v1


### PR DESCRIPTION
The reason we only need these two components is: 
* They will upload their blocks asynchronously via ROS managed service
* They will use RHOBS as a read-only tenant to access those blocks

Next: 
* Generate read only credentials
* Generate shared bucket credentials for the tenant